### PR TITLE
[deb] Remove Depends: lib* that are auto-generated by ${shlibs:Depends} 

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -84,7 +84,6 @@ Depends:
   ${misc:Depends},
   ${shlibs:Depends},
   libgroonga0 (= ${binary:Version}),
-  libmecab1
 Description: MeCab tokenizer for groonga.
  Groonga is an open-source fulltext search engine and column store.
  It lets you write high-performance applications that requires fulltext search.
@@ -99,9 +98,6 @@ Breaks: libgroonga-plugin-suggest (<< 1.2.0-1)
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-  libmsgpack3,
-  libzmq0,
-  libevent-1.4-2,
   libgroonga0 (= ${binary:Version})
 Description: Suggest plugin for groonga.
  Groonga is an open-source fulltext search engine and column store.


### PR DESCRIPTION
I cannot install groonga-plugin-suggest to my Debian sid (unstable) box because
the current Debian sid provides libzmq1, not libzmq0.

To fix this problem, you should pull a patch from my Groonga git repository on GitHub.

With this patch on my Debian sid box, groonga-*.deb have the following Depends: lines:

$ dpkg-deb -I groonga-tokenizer-mecab_1.2.5-1_amd64.deb|grep Depends
 Depends: libc6 (>= 2.3), libgroonga0 (= 1.2.5-1), libmecab1 (>= 0.98-1)
$ dpkg-deb -I groonga-plugin-suggest_1.2.5-1_amd64.deb |grep Depends
 Depends: libc6 (>= 2.2.5), libevent-1.4-2 (>= 1.4.14b-stable), libgroonga0 (= 1.2.5-1), libmsgpack3 (>= 0.5.1), libzmq1
