### PR TITLE
initialize ps before wcrtomb call

### DIFF
--- a/src/groonga.c
+++ b/src/groonga.c
@@ -192,6 +192,7 @@ prompt(grn_ctx *ctx, grn_obj *buf)
       size_t multibyte_len;
       mbstate_t ps;
       history_w(command_history, &command_history_event, H_ENTER, line);
+      memset(&ps, 0, sizeof(ps));
       wcrtomb(NULL, L'\0', &ps);
       for (i = 0; i < nchar; i++) {
         multibyte_len = wcrtomb(multibyte_buf, line[i], &ps);


### PR DESCRIPTION
This will fix problem of prompt built with libedit on OS X Lion.
