### PR TITLE
rpm fedora: fix upgrade condition in %post server

### DIFF
--- a/packages/rpm/fedora/groonga.spec.in
+++ b/packages/rpm/fedora/groonga.spec.in
@@ -204,7 +204,7 @@ getent passwd groonga >/dev/null || \
 exit 0
 
 %post server
-if [ $1 = 0 ] ; then
+if [ $1 = 1 ] ; then
 	/bin/systemctl daemon-reload >/dev/null 2>&1 || :
 fi
 


### PR DESCRIPTION
Possible typo - $1 can never be 0 in %post action:
https://fedoraproject.org/wiki/Packaging/ScriptletSnippets#Syntax
