### PR TITLE
groonga-serverの依存関係の欠落: curl(1)

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -39,6 +39,7 @@ Depends:
   ${misc:Depends},
   ${shlibs:Depends},
   adduser,
+  curl,
   groonga (= ${binary:Version})
 Description: Fulltext search engine. (meta-package for server use)
  Groonga is an open-source fulltext search engine and column store.

--- a/packages/rpm/centos/groonga.spec.in
+++ b/packages/rpm/centos/groonga.spec.in
@@ -51,6 +51,7 @@ Summary:	Groonga server
 Group:		Applications/Text
 License:	LGPLv2 and (MIT or GPLv2)
 Requires:	%{name} = %{version}-%{release}
+Requires:	curl
 Requires(pre):	shadow-utils
 Requires(post):	/sbin/chkconfig
 Requires(preun):	/sbin/chkconfig

--- a/packages/rpm/fedora/groonga.spec.in
+++ b/packages/rpm/fedora/groonga.spec.in
@@ -50,6 +50,7 @@ Summary:	Groonga server
 Group:		Applications/Text
 License:	LGPLv2 and (MIT or GPLv2)
 Requires:	%{name} = %{version}-%{release}
+Requires:	curl
 Requires(pre):	shadow-utils
 Requires(post):	/sbin/chkconfig
 Requires(preun):	/sbin/chkconfig


### PR DESCRIPTION
Current init scripts execute curl(1). rpm and deb packages should
require 'curl' package.

http://redmine.groonga.org/issues/1332

debは試してないけどこれでいいはず！
