### PR TITLE
Define grn_output_type

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -2146,6 +2146,7 @@ GRN_API void grn_output_obj(grn_ctx *ctx, grn_obj *outbuf, grn_content_type outp
 GRN_API void grn_output_envelope(grn_ctx *ctx, grn_rc rc,
                                  grn_obj *head, grn_obj *body, grn_obj *foot,
                                  const char *file, int line);
+GRN_API const char *grn_output_type(grn_ctx *ctx);
 
 /* obsolete */
 GRN_API grn_rc grn_text_otoj(grn_ctx *ctx, grn_obj *bulk, grn_obj *obj,

--- a/lib/output.c
+++ b/lib/output.c
@@ -1499,3 +1499,9 @@ grn_output_envelope(grn_ctx *ctx,
     break;
   }
 }
+
+const char *
+grn_output_type(grn_ctx *ctx)
+{
+  return ctx->impl->mime_type;
+}

--- a/src/groonga.c
+++ b/src/groonga.c
@@ -550,7 +550,6 @@ h_output(grn_ctx *ctx, int flags, void *arg)
   ht_context *hc = (ht_context *)arg;
   grn_sock fd = hc->msg->u.fd;
   grn_obj *body = &hc->body;
-  const char *mime_type = ctx->impl->mime_type;
   grn_obj head, foot, *outbuf = ctx->impl->outbuf;
   if (!(flags & GRN_CTX_TAIL)) { return; }
   GRN_TEXT_INIT(&head, 0);
@@ -573,7 +572,7 @@ h_output(grn_ctx *ctx, int flags, void *arg)
     GRN_TEXT_SETS(ctx, body, "HTTP/1.1 200 OK\r\n");
     GRN_TEXT_PUTS(ctx, body, "Connection: close\r\n");
     GRN_TEXT_PUTS(ctx, body, "Content-Type: ");
-    GRN_TEXT_PUTS(ctx, body, mime_type);
+    GRN_TEXT_PUTS(ctx, body, grn_output_type(ctx));
     GRN_TEXT_PUTS(ctx, body, "\r\nContent-Length: ");
     grn_text_lltoa(ctx, body,
                    GRN_TEXT_LEN(&head) + GRN_TEXT_LEN(outbuf) + GRN_TEXT_LEN(&foot));
@@ -587,7 +586,7 @@ h_output(grn_ctx *ctx, int flags, void *arg)
       GRN_TEXT_SETS(ctx, body, "HTTP/1.1 500 Internal Server Error\r\n");
     }
     GRN_TEXT_PUTS(ctx, body, "Content-Type: ");
-    GRN_TEXT_PUTS(ctx, body, mime_type);
+    GRN_TEXT_PUTS(ctx, body, grn_output_type(ctx));
     GRN_TEXT_PUTS(ctx, body, "\r\n\r\n");
   }
   {


### PR DESCRIPTION
これはlibgrongaにあったほうが嬉しいコードをsrc/groonga.cから移しています。それによりAPIから提供される関数が一つ増えています。

それだけがAPIの変更点なので互換性の問題は発生しません。また、機能的な違いは一切発生しません。

テストが通る事は確認しております。
