### PR TITLE
 rpm: groonga package does not require groonga-tokenizer-mecab package

### DIFF
--- a/packages/rpm/centos/groonga.spec.in
+++ b/packages/rpm/centos/groonga.spec.in
@@ -20,7 +20,6 @@ BuildRequires:	lzo-devel
 %endif
 Requires:	%{name}-libs = %{version}-%{release}
 Requires:	%{name}-plugin-suggest = %{version}-%{release}
-Requires:	%{name}-tokenizer-mecab = %{version}-%{release}
 #BuildRequires:	messagepack-devel
 #BuildRequires:	zeromq-devel
 #BuildRequires:	libevent-devel
@@ -254,6 +253,7 @@ fi
 %changelog
 * Fri Jun 29 2012 Kouhei Sutou <kou@clear-code.com> - 2.0.4-0
 - new upstream release.
+- groonga package does not require groonga-tokenizer-mecab package.
 
 * Tue May 29 2012 Kouhei Sutou <kou@clear-code.com> - 2.0.3-0
 - new upstream release.

--- a/packages/rpm/fedora/groonga.spec.in
+++ b/packages/rpm/fedora/groonga.spec.in
@@ -21,7 +21,6 @@ BuildRequires:	php-devel
 BuildRequires:	libedit-devel
 Requires:	%{name}-libs = %{version}-%{release}
 Requires:	%{name}-plugin-suggest = %{version}-%{release}
-Requires:	%{name}-tokenizer-mecab = %{version}-%{release}
 Requires(post):	systemd-units
 Requires(preun):	systemd-units
 Requires(postun):	systemd-units
@@ -311,6 +310,7 @@ fi
 %changelog
 * Fri Jun 29 2012 Kouhei Sutou <kou@clear-code.com> - 2.0.4-0
 - new upstream release.
+- groonga package does not require groonga-tokenizer-mecab package.
 
 * Tue May 29 2012 Kouhei Sutou <kou@clear-code.com> - 2.0.3-0
 - new upstream release.


### PR DESCRIPTION
groonga package does not require groonga-tokenizer-mecab package.
Because groonga-tokenizer-mecab package requires mecab package.
But mecab package may conflict in some system.

groonga自体に必須じゃないのでRequiresはしなくていいかな、と。
