### PR TITLE
Add --query_flags option to select command

### DIFF
--- a/doc/source/reference/commands/select.txt
+++ b/doc/source/reference/commands/select.txt
@@ -40,6 +40,7 @@ Syntax
          [cache=yes]
          [match_escalation_threshold=0]
          [query_expansion=null]
+         [query_flags=ALLOW_PRAGMA|ALLOW_COLUMN]
 
 Usage
 -----
@@ -533,6 +534,41 @@ more liked entries.
 
 The ``select`` command outputs records that ``n_likes`` column value
 is equal to or more than ``10`` from ``Entries`` table.
+
+.. _query-flags:
+
+``query_flags``
+"""""""""""""""
+
+It customs ``query`` parameter syntax. You cannot update column value
+by ``query`` parameter by default. But if you specify
+``ALLOW_COLUMN|ALLOW_UPDATE`` as ``query_flags``, you can update
+column value ``query``.
+
+Here are available values:
+
+* ``ALLOW_PRAGMA``
+* ``ALLOW_COLUMN``
+* ``ALLOW_UPDATE``
+
+``ALLOW_PRAGMA`` enables pragma at the head of ``query``.
+
+``ALLOW_COLUMN`` enables search againt columns that are not included
+in ``match_columns``. To specify column, there are ``COLUMN:...``
+syntaxes.
+
+``ALLOW_UPDATE`` enables column update by ``query`` with
+``COLUMN:=NEW_VALUE`` syntax. ``ALLOW_COLUMN`` is also required to
+update column because the column update syntax specifies column.
+
+They can be combined by separated ``|`` such as
+``ALLOW_COLUMN|ALLOW_UPDATE``.
+
+The default value is ``ALLOW_PRAGMA|ALLOW_COLUMN``.
+
+TODO: example
+
+See also :doc:`/reference/grn_expr/query_syntax`.
 
 Output related parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/reference/grn_expr/query_syntax.txt
+++ b/doc/source/reference/grn_expr/query_syntax.txt
@@ -564,9 +564,9 @@ Assignment expression
 ---------------------
 
 This section is for advanced users. Because assignment expression is
-disabled in ``--query`` option of :doc:`/reference/commands/select`. You need to
-use groonga as a library instead of server or command line tool for
-assignment expression.
+disabled in ``--query`` option of :doc:`/reference/commands/select` by
+default. You need to specify ``ALLOW_COLUMN|ALLOW_UPDATE`` as
+``--query_flags`` option value to enable assignment expression.
 
 Assignment expression in query syntax has some limitations. So you
 should use :doc:`/reference/grn_expr/script_syntax` instead of query syntax for

--- a/test/function/suite/select/query_flags/allow_update.expected
+++ b/test/function/suite/select/query_flags/allow_update.expected
@@ -1,0 +1,88 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice", "age": 18},
+{"_key": "bob",   "age": 20}
+]
+[[0,0.0,0.0],2]
+select Users   --query "age:=19"   --query_flags "ALLOW_COLUMN|ALLOW_UPDATE"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "UInt32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        19
+      ],
+      [
+        2,
+        "bob",
+        19
+      ]
+    ]
+  ]
+]
+select Users
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "UInt32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        19
+      ],
+      [
+        2,
+        "bob",
+        19
+      ]
+    ]
+  ]
+]

--- a/test/function/suite/select/query_flags/allow_update.test
+++ b/test/function/suite/select/query_flags/allow_update.test
@@ -1,0 +1,14 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR UInt32
+
+load --table Users
+[
+{"_key": "alice", "age": 18},
+{"_key": "bob",   "age": 20}
+]
+
+select Users \
+  --query "age:=19" \
+  --query_flags "ALLOW_COLUMN|ALLOW_UPDATE"
+
+select Users


### PR DESCRIPTION
By this change, GRN_EXPR_ALLOW_UPDATE can be enabled in query syntax
by `select --query_flags ALLOW_COLUMN|ALLOW_UPDATE ...`.
