### PR TITLE
Fix function detection with a completed argument

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -841,9 +841,26 @@ grn_expr_append_obj(grn_ctx *ctx, grn_obj *expr, grn_obj *obj, grn_operator op, 
       {
         grn_obj *proc = NULL;
         if (e->codes_curr - nargs > 0) {
-          proc = e->codes[e->codes_curr - nargs - 1].value;
+          int i;
+          grn_expr_code *code;
+          code = &(e->codes[e->codes_curr - 1]);
+          for (i = 0; i < nargs; i++) {
+            int rest_n_codes = 1;
+            while (rest_n_codes > 0) {
+              if (!code->value) {
+                rest_n_codes += code->nargs;
+              }
+              rest_n_codes--;
+              code--;
+            }
+          }
+          proc = code->value;
         }
-        if (proc && !function_proc_p(proc)) {
+        if (!proc) {
+          ERR(GRN_INVALID_ARGUMENT, "invalid function call expression");
+          goto exit;
+        }
+        if (!function_proc_p(proc)) {
           grn_obj buffer;
 
           GRN_TEXT_INIT(&buffer, 0);

--- a/test/function/suite/select/filter/invalid/function_call_with_argument.expected
+++ b/test/function/suite/select/filter/invalid/function_call_with_argument.expected
@@ -1,0 +1,5 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+select Users --filter '"invalid function"("alice")'
+[[[-22,0.0,0.0],"invalid function: <\"invalid function\">"],[]]
+#|e| invalid function: <"invalid function">

--- a/test/function/suite/select/filter/invalid/function_call_with_argument.test
+++ b/test/function/suite/select/filter/invalid/function_call_with_argument.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+select Users --filter '"invalid function"("alice")'

--- a/test/function/suite/select/filter/invalid/function_call_with_complex_argument.expected
+++ b/test/function/suite/select/filter/invalid/function_call_with_complex_argument.expected
@@ -1,0 +1,5 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+select Users --filter '"invalid function"(_key == "alice" || _key == "bob")'
+[[[-22,0.0,0.0],"invalid function: <\"invalid function\">"],[]]
+#|e| invalid function: <"invalid function">

--- a/test/function/suite/select/filter/invalid/function_call_with_complex_argument.test
+++ b/test/function/suite/select/filter/invalid/function_call_with_complex_argument.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+select Users --filter '"invalid function"(_key == "alice" || _key == "bob")'

--- a/test/function/suite/select/filter/invalid/function_call_with_complex_arguments.expected
+++ b/test/function/suite/select/filter/invalid/function_call_with_complex_arguments.expected
@@ -1,0 +1,5 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+select Users --filter '"invalid function"(_key == "alice" || _key == "bob", _key == "chris" && _id == 1)'
+[[[-22,0.0,0.0],"invalid function: <\"invalid function\">"],[]]
+#|e| invalid function: <"invalid function">

--- a/test/function/suite/select/filter/invalid/function_call_with_complex_arguments.test
+++ b/test/function/suite/select/filter/invalid/function_call_with_complex_arguments.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+select Users --filter '"invalid function"(_key == "alice" || _key == "bob", _key == "chris" && _id == 1)'

--- a/test/function/suite/select/filter/invalid/function_call_without_argument.expected
+++ b/test/function/suite/select/filter/invalid/function_call_without_argument.expected
@@ -1,0 +1,5 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+select Users --filter '"invalid function"()'
+[[[-22,0.0,0.0],"invalid function: <\"invalid function\">"],[]]
+#|e| invalid function: <"invalid function">

--- a/test/function/suite/select/filter/invalid/function_call_without_argument.test
+++ b/test/function/suite/select/filter/invalid/function_call_without_argument.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+select Users --filter '"invalid function"()'


### PR DESCRIPTION
The current function object detection is very naive. It just looks the
Nth prior code. N is the number of arguments.

It works well for simple function call such as 'function(arg1, arg2)'
but doesn't work well for complex function call such as
'function(column == "value1" || column == "value2")'. The simple
function call has 2 codes for arguments. It's the same number as the
number of arguments. The comlex function call has 5 codes for
arguments. It's not the same number as the number of arguments.

This change computes the correct number of codes for arguments.
