### PR TITLE
Support changing default logger's max level before grn_init()

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -2039,6 +2039,9 @@ GRN_API int grn_logger_pass(grn_ctx *ctx, grn_log_level level);
 #define GRN_LOG_DEFAULT_LEVEL GRN_LOG_NOTICE
 #endif /* GRN_LOG_DEFAULT_LEVEL */
 
+GRN_API void grn_default_logger_set_max_level(grn_log_level level);
+GRN_API grn_log_level grn_default_logger_get_max_level();
+
 #define GRN_LOG(ctx,level,...) do {\
   if (grn_logger_pass(ctx, level)) {\
     grn_logger_put(ctx, (level), __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__); \

--- a/lib/ctx.c
+++ b/lib/ctx.c
@@ -732,6 +732,18 @@ static grn_logger_info default_logger = {
 static const grn_logger_info *grn_logger = &default_logger;
 
 void
+grn_default_logger_set_max_level(grn_log_level level)
+{
+  default_logger.max_level = level;
+}
+
+grn_log_level
+grn_default_logger_get_max_level(void)
+{
+  return default_logger.max_level;
+}
+
+void
 grn_log_reopen(grn_ctx *ctx)
 {
   if (grn_logger != &default_logger) {

--- a/src/groonga.c
+++ b/src/groonga.c
@@ -2234,6 +2234,20 @@ main(int argc, char **argv)
     grn_qlog_path = query_log_path_arg;
   }
 
+  if (log_level_arg) {
+    const char * const end = log_level_arg + strlen(log_level_arg);
+    const char *rest = NULL;
+    const int value = grn_atoi(log_level_arg, end, &rest);
+    if (end != rest || value < 0 || value > 9) {
+      fprintf(stderr, "invalid log level: <%s>\n", log_level_arg);
+      return EXIT_FAILURE;
+    }
+    log_level = value;
+  } else {
+    log_level = default_log_level;
+  }
+  grn_default_logger_set_max_level(log_level);
+
   if (max_num_threads_arg) {
     const char * const end = max_num_threads_arg + strlen(max_num_threads_arg);
     const char *rest = NULL;
@@ -2366,19 +2380,6 @@ main(int argc, char **argv)
     default_match_escalation_threshold = value;
   } else {
     default_match_escalation_threshold = default_default_match_escalation_threshold;
-  }
-
-  if (log_level_arg) {
-    const char * const end = log_level_arg + strlen(log_level_arg);
-    const char *rest = NULL;
-    const int value = grn_atoi(log_level_arg, end, &rest);
-    if (end != rest || value < 0 || value > 9) {
-      fprintf(stderr, "invalid log level: <%s>\n", log_level_arg);
-      return EXIT_FAILURE;
-    }
-    log_level = value;
-  } else {
-    log_level = default_log_level;
   }
 
   if (cache_limit_arg) {


### PR DESCRIPTION
grn_init() logs some messages such as vm.overcommit_memory related
messages. vm.overcommit_memory related messages uses INFO log level.
The messages never be logged because the default max log level is
NOTICE and the default max log level can't be changed before grn_init().
