### PR TITLE
Add all_records()

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -4281,6 +4281,23 @@ grn_table_select(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
               /* todo : handle SCAN_PRE_CONST */
               break;
             }
+          } else {
+            switch (si->op) {
+            case GRN_OP_CALL :
+              if (selector_proc_p(si->args[0])) {
+                grn_rc rc;
+                grn_proc *proc = (grn_obj *)(si->args[0]);
+                rc = proc->selector(ctx, table, NULL, si->nargs, si->args,
+                                    res, si->logical_op);
+                if (rc) {
+                  /* TODO: report error */
+                } else {
+                  done++;
+                }
+              }
+            default :
+              break;
+            }
           }
           if (!done) {
             e->codes = codes + si->start;

--- a/test/function/suite/select/function/all_records/function.expected
+++ b/test/function/suite/select/function/all_records/function.expected
@@ -1,0 +1,47 @@
+table_create Softwares TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Softwares
+[
+["_key"],
+["groonga"],
+["mroonga"],
+["rroonga"]
+]
+[[0,0.0,0.0],3]
+select Softwares --filter 'all_records() == true'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "groonga"
+      ],
+      [
+        2,
+        "mroonga"
+      ],
+      [
+        3,
+        "rroonga"
+      ]
+    ]
+  ]
+]

--- a/test/function/suite/select/function/all_records/function.test
+++ b/test/function/suite/select/function/all_records/function.test
@@ -1,0 +1,11 @@
+table_create Softwares TABLE_HASH_KEY ShortText
+
+load --table Softwares
+[
+["_key"],
+["groonga"],
+["mroonga"],
+["rroonga"]
+]
+
+select Softwares --filter 'all_records() == true'

--- a/test/function/suite/select/function/all_records/selector.expected
+++ b/test/function/suite/select/function/all_records/selector.expected
@@ -1,0 +1,47 @@
+table_create Softwares TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Softwares
+[
+["_key"],
+["groonga"],
+["mroonga"],
+["rroonga"]
+]
+[[0,0.0,0.0],3]
+select Softwares --filter 'all_records()'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "groonga"
+      ],
+      [
+        2,
+        "mroonga"
+      ],
+      [
+        3,
+        "rroonga"
+      ]
+    ]
+  ]
+]

--- a/test/function/suite/select/function/all_records/selector.test
+++ b/test/function/suite/select/function/all_records/selector.test
@@ -1,0 +1,11 @@
+table_create Softwares TABLE_HASH_KEY ShortText
+
+load --table Softwares
+[
+["_key"],
+["groonga"],
+["mroonga"],
+["rroonga"]
+]
+
+select Softwares --filter 'all_records()'


### PR DESCRIPTION
It matches all records. It's fast rather than "true" literal because
all_records() doesn't evaluate on each record. It just copies all
record IDs to result set table.

Note that getting all records is heavy process. You should use it only
when you need it.
