### PR TITLE
Support '-WORD' in --query of the select command

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -2579,6 +2579,7 @@ typedef unsigned int grn_expr_flags;
 #define GRN_EXPR_ALLOW_PRAGMA          (0x02)
 #define GRN_EXPR_ALLOW_COLUMN          (0x04)
 #define GRN_EXPR_ALLOW_UPDATE          (0x08)
+#define GRN_EXPR_ALLOW_LEADING_NOT     (0x10)
 
 GRN_API grn_rc grn_expr_parse(grn_ctx *ctx, grn_obj *expr,
                               const char *str, unsigned int str_size,

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -5083,6 +5083,15 @@ parse_query(grn_ctx *ctx, efs_info *q)
       break;
     case GRN_QUERY_AND_NOT :
       q->cur++;
+      if (first_token && (q->flags & GRN_EXPR_ALLOW_LEADING_NOT)) {
+        grn_obj *all_records = grn_ctx_get(ctx, "all_records", 11);
+        if (all_records) {
+          /* dummy token */
+          PARSE(GRN_EXPR_TOKEN_QSTRING);
+          grn_expr_append_obj(ctx, q->e, all_records, GRN_OP_PUSH, 1);
+          grn_expr_append_op(ctx, q->e, GRN_OP_CALL, 0);
+        }
+      }
       op->op = GRN_OP_AND_NOT;
       PARSE(GRN_EXPR_TOKEN_LOGICAL_AND_NOT);
       break;

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -270,6 +270,7 @@ grn_parse_query_flags(grn_ctx *ctx, const char *query_flags,
     CHECK_EXPR_FLAG(ALLOW_PRAGMA);
     CHECK_EXPR_FLAG(ALLOW_COLUMN);
     CHECK_EXPR_FLAG(ALLOW_UPDATE);
+    CHECK_EXPR_FLAG(ALLOW_LEADING_NOT);
 
 #define GRN_EXPR_NONE 0
     CHECK_EXPR_FLAG(NONE);

--- a/test/function/suite/select/query/invalid/leading_not.expected
+++ b/test/function/suite/select/query/invalid/leading_not.expected
@@ -1,0 +1,25 @@
+table_create Entries TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Terms entries_content_index COLUMN_INDEX|WITH_POSITION Entries content
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"_key":    "The first post!",
+ "content": "Welcome! This is my first post!"},
+{"_key":    "Groonga",
+ "content": "I started to use groonga. It's very fast!"},
+{"_key":    "Mroonga",
+ "content": "I also started to use mroonga. It's also very fast! Really fast!"},
+{"_key":    "Good-bye Senna",
+ "content": "I migrated all Senna system!"},
+{"_key":    "Good-bye Tritonn",
+ "content": "I also migrated all Tritonn system!"}
+]
+[[0,0.0,0.0],5]
+select Entries --match_columns content --query '-fast'
+[[[-63,0.0,0.0],"Syntax error! (-fast)"],[]]
+#|e| Syntax error! (-fast)

--- a/test/function/suite/select/query/invalid/leading_not.test
+++ b/test/function/suite/select/query/invalid/leading_not.test
@@ -1,0 +1,21 @@
+table_create Entries TABLE_PAT_KEY ShortText
+column_create Entries content COLUMN_SCALAR Text
+
+table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+column_create Terms entries_content_index COLUMN_INDEX|WITH_POSITION Entries content
+
+load --table Entries
+[
+{"_key":    "The first post!",
+ "content": "Welcome! This is my first post!"},
+{"_key":    "Groonga",
+ "content": "I started to use groonga. It's very fast!"},
+{"_key":    "Mroonga",
+ "content": "I also started to use mroonga. It's also very fast! Really fast!"},
+{"_key":    "Good-bye Senna",
+ "content": "I migrated all Senna system!"},
+{"_key":    "Good-bye Tritonn",
+ "content": "I also migrated all Tritonn system!"}
+]
+
+select Entries --match_columns content --query '-fast'

--- a/test/function/suite/select/query_flags/allow_leading_not.expected
+++ b/test/function/suite/select/query_flags/allow_leading_not.expected
@@ -1,0 +1,66 @@
+table_create Entries TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Terms entries_content_index COLUMN_INDEX|WITH_POSITION Entries content
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"_key":    "The first post!",
+ "content": "Welcome! This is my first post!"},
+{"_key":    "Groonga",
+ "content": "I started to use groonga. It's very fast!"},
+{"_key":    "Mroonga",
+ "content": "I also started to use mroonga. It's also very fast! Really fast!"},
+{"_key":    "Good-bye Senna",
+ "content": "I migrated all Senna system!"},
+{"_key":    "Good-bye Tritonn",
+ "content": "I also migrated all Tritonn system!"}
+]
+[[0,0.0,0.0],5]
+select Entries --match_columns content --query '-fast'   --query_flags ALLOW_LEADING_NOT
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        4,
+        "Good-bye Senna",
+        "I migrated all Senna system!"
+      ],
+      [
+        5,
+        "Good-bye Tritonn",
+        "I also migrated all Tritonn system!"
+      ],
+      [
+        1,
+        "The first post!",
+        "Welcome! This is my first post!"
+      ]
+    ]
+  ]
+]

--- a/test/function/suite/select/query_flags/allow_leading_not.test
+++ b/test/function/suite/select/query_flags/allow_leading_not.test
@@ -1,0 +1,22 @@
+table_create Entries TABLE_PAT_KEY ShortText
+column_create Entries content COLUMN_SCALAR Text
+
+table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+column_create Terms entries_content_index COLUMN_INDEX|WITH_POSITION Entries content
+
+load --table Entries
+[
+{"_key":    "The first post!",
+ "content": "Welcome! This is my first post!"},
+{"_key":    "Groonga",
+ "content": "I started to use groonga. It's very fast!"},
+{"_key":    "Mroonga",
+ "content": "I also started to use mroonga. It's also very fast! Really fast!"},
+{"_key":    "Good-bye Senna",
+ "content": "I migrated all Senna system!"},
+{"_key":    "Good-bye Tritonn",
+ "content": "I also migrated all Tritonn system!"}
+]
+
+select Entries --match_columns content --query '-fast' \
+  --query_flags ALLOW_LEADING_NOT


### PR DESCRIPTION
'-WORD' is disabled by default. --query_flags ALLOW_LEADING_NOT is
required for the feature.
