### PR TITLE
Support score respected merge by set operation

### DIFF
--- a/test/function/suite/select/score/need_temporary_table/and.expected
+++ b/test/function/suite/select/score/need_temporary_table/and.expected
@@ -1,0 +1,18 @@
+table_create Tags TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Movies TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Movies tags COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+column_create Tags index COLUMN_INDEX Movies tags
+[[0,0.0,0.0],true]
+load --table Movies
+[
+{"_key": "Seven Samurai", tags: ["Samurai", "Japanese", "Kurosawa Akira"]},
+{"_key": "The Last Samurai", tags: ["Samurai", "English", "Tom Cruise"]},
+{"_key": "The Matrix", tags: ["Keanu Reeves", "SF", "English"]},
+{"_key": "Star Wars", tags: ["George Lucas", "SF", "English"]}
+]
+[[0,0.0,0.0],4]
+select Movies   --output_columns "_key, _score"   --filter '(tags @ "English" || tags @ "Samurai") && (tags @ "SF" &! tags @ "Keanu Reeves")'
+[[0,0.0,0.0],[[[1],[["_key","ShortText"],["_score","Int32"]],["Star Wars",2]]]]

--- a/test/function/suite/select/score/need_temporary_table/and.test
+++ b/test/function/suite/select/score/need_temporary_table/and.test
@@ -1,0 +1,18 @@
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create Movies TABLE_HASH_KEY ShortText
+column_create Movies tags COLUMN_VECTOR Tags
+
+column_create Tags index COLUMN_INDEX Movies tags
+
+load --table Movies
+[
+{"_key": "Seven Samurai", tags: ["Samurai", "Japanese", "Kurosawa Akira"]},
+{"_key": "The Last Samurai", tags: ["Samurai", "English", "Tom Cruise"]},
+{"_key": "The Matrix", tags: ["Keanu Reeves", "SF", "English"]},
+{"_key": "Star Wars", tags: ["George Lucas", "SF", "English"]}
+]
+
+select Movies \
+  --output_columns "_key, _score" \
+  --filter '(tags @ "English" || tags @ "Samurai") && (tags @ "SF" &! tags @ "Keanu Reeves")'

--- a/test/function/suite/select/score/need_temporary_table/or.expected
+++ b/test/function/suite/select/score/need_temporary_table/or.expected
@@ -1,0 +1,53 @@
+table_create Tags TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Movies TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Movies tags COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+column_create Tags index COLUMN_INDEX Movies tags
+[[0,0.0,0.0],true]
+load --table Movies
+[
+{"_key": "Seven Samurai", tags: ["Samurai", "Japanese", "Japan", "Kurosawa Akira"]},
+{"_key": "The Last Samurai", tags: ["Samurai", "English", "Japanese", "US", "Japan", "Tom Cruise"]},
+{"_key": "The Matrix", tags: ["Keanu Reeves", "SF", "English", "US"]},
+{"_key": "Star Wars", tags: ["George Lucas", "SF", "English", "US"]}
+]
+[[0,0.0,0.0],4]
+select Movies   --output_columns "_key, _score"   --filter '(tags @ "English" && tags @ "SF") || (tags @ "US" &! tags @ "Keanu Reeves")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "The Last Samurai",
+        1
+      ],
+      [
+        "The Matrix",
+        2
+      ],
+      [
+        "Star Wars",
+        3
+      ]
+    ]
+  ]
+]

--- a/test/function/suite/select/score/need_temporary_table/or.test
+++ b/test/function/suite/select/score/need_temporary_table/or.test
@@ -1,0 +1,18 @@
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create Movies TABLE_HASH_KEY ShortText
+column_create Movies tags COLUMN_VECTOR Tags
+
+column_create Tags index COLUMN_INDEX Movies tags
+
+load --table Movies
+[
+{"_key": "Seven Samurai", tags: ["Samurai", "Japanese", "Japan", "Kurosawa Akira"]},
+{"_key": "The Last Samurai", tags: ["Samurai", "English", "Japanese", "US", "Japan", "Tom Cruise"]},
+{"_key": "The Matrix", tags: ["Keanu Reeves", "SF", "English", "US"]},
+{"_key": "Star Wars", tags: ["George Lucas", "SF", "English", "US"]}
+]
+
+select Movies \
+  --output_columns "_key, _score" \
+  --filter '(tags @ "English" && tags @ "SF") || (tags @ "US" &! tags @ "Keanu Reeves")'


### PR DESCRIPTION
--filter '(A || B) && C &! D' assign 3 (A + B + C) as score
when a record that matches A, B and C.
--filter '(A || B) && (C &! D)' assign 2 (A + B) as score
when a record that matches A, B and C.

Both of them should assign 3 as score. This change fixes the problem.
