### PR TITLE
GRN_OP_GET_VALUE supports vector

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -7358,6 +7358,27 @@ grn_obj_reinit(grn_ctx *ctx, grn_obj *obj, grn_id domain, unsigned char flags)
   return ctx->rc;
 }
 
+grn_rc
+grn_obj_reinit_for(grn_ctx *ctx, grn_obj *obj, grn_obj *domain_obj)
+{
+  grn_id domain = GRN_ID_NIL;
+  grn_obj_flags flags = 0;
+
+  if (!GRN_DB_OBJP(domain_obj) && domain_obj->header.type != GRN_ACCESSOR) {
+    grn_obj inspected;
+    GRN_TEXT_INIT(&inspected, 0);
+    limited_size_inspect(ctx, &inspected, domain_obj);
+    ERR(GRN_INVALID_ARGUMENT,
+        "[reinit] invalid domain object: <%.*s>",
+        (int)GRN_TEXT_LEN(&inspected), GRN_TEXT_VALUE(&inspected));
+    GRN_OBJ_FIN(ctx, &inspected);
+    return ctx->rc;
+  }
+
+  grn_obj_get_range_info(ctx, domain_obj, &domain, &flags);
+  return grn_obj_reinit(ctx, obj, domain, flags);
+}
+
 const char *
 grn_obj_path(grn_ctx *ctx, grn_obj *obj)
 {

--- a/lib/db.h
+++ b/lib/db.h
@@ -422,6 +422,8 @@ grn_id grn_obj_register(grn_ctx *ctx, grn_obj *db, const char *name, unsigned in
 int grn_obj_is_persistent(grn_ctx *ctx, grn_obj *obj);
 void grn_obj_spec_save(grn_ctx *ctx, grn_db_obj *obj);
 
+grn_rc grn_obj_reinit_for(grn_ctx *ctx, grn_obj *obj, grn_obj *domain_obj);
+
 #define GRN_UINT32_POP(obj,value) do {\
   if (GRN_BULK_VSIZE(obj) >= sizeof(uint32_t)) {\
     GRN_BULK_INCR_LEN((obj), -(sizeof(uint32_t)));\

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -2687,6 +2687,7 @@ grn_expr_exec(grn_ctx *ctx, grn_obj *expr, int nargs)
               col = grn_obj_column(ctx, table, GRN_BULK_HEAD(col), GRN_BULK_VSIZE(col));
               if (col) { GRN_PTR_PUT(ctx, &e->objs, col); }
             }
+            grn_obj_reinit_for(ctx, res, col);
             if (col) {
               value = grn_obj_get_value_(ctx, col, GRN_RECORD_VALUE(rec), &size);
             } else {
@@ -2696,9 +2697,12 @@ grn_expr_exec(grn_ctx *ctx, grn_obj *expr, int nargs)
             if (size == GRN_OBJ_GET_VALUE_IMD) {
               GRN_RECORD_SET(ctx, res, (uintptr_t)value);
             } else {
-              grn_bulk_write_from(ctx, res, value, 0, size);
+              if (res->header.type == GRN_VECTOR) {
+                grn_vector_decode(ctx, res, value, size);
+              } else {
+                grn_bulk_write_from(ctx, res, value, 0, size);
+              }
             }
-            res->header.domain = grn_obj_get_range(ctx, col);
             code++;
           } while (code < ce && code->op == GRN_OP_GET_VALUE);
         }


### PR DESCRIPTION
With grn_expr based output_columns causes a test failure: https://travis-ci.org/#!/groonga/groonga/jobs/2822514

```
Failure: test_vector_text
<"[[[2]," "[[\"_key\",\"ShortText\"]," "[\"articles\",\"Text\"]]," "[\"gunya-gunya\"," "[\"hello all!\"," "\"hello groonga!\"," "\"hello Senna!\"]]," "[\"groonga\"," "[\"Release!\"," "\"My name is groonga!\"]]]]" == send_command("select Blogs " "--output_columns _key,articles " "--match_columns articles " "--query groonga")>
expected: <"[[[2],[[\"_key\",\"ShortText\"],[\"articles\",\"Text\"]],[\"gunya-gunya\",[\"hello all!\",\"hello groonga!\",\"hello Senna!\"]],[\"groonga\",[\"Release!\",\"My name is groonga!\"]]]]">
actual: <"[[[2],[[\"_key\",\"ShortText\"],[\"articles\",\"Text\"]],[\"gunya-gunya\",\"\\u0003\\n\\u000E\\fhello all!hello groonga!hello Senna!\"],[\"groonga\",\"\\u0002\\b\\u0013Release!My name is groonga!\"]]]">

diff:
"[[[2],[[\"_key\",\"ShortText\"],[\"articles\",\"Text\"]],[\"gunya-gunya\",[\"\\u0003\\n\\u000E\\fhello all!\",\"hello groonga!\",\"hello Senna!\"]],[\"groonga\",[\"\\u0002\\b\\u0013Release!\",\"My name is groonga!\"]]]]"
```

It is the reason of this problem that GRN_OP_GET_VALUE doesn't support vector. GRN_OP_GET_VALUE sets domain but it doesn't set flags that has vector information.

This pull request sets not only domain but also flags.
