### PR TITLE
Split query logger from logger

### DIFF
--- a/lib/ctx.h
+++ b/lib/ctx.h
@@ -404,16 +404,6 @@ extern grn_timeval grn_starttime;
 #define GRN_TIME_NSEC_TO_USEC(nsec) ((nsec) / GRN_TIME_NSEC_PER_USEC)
 #define GRN_TIME_USEC_TO_NSEC(usec) ((usec) * GRN_TIME_NSEC_PER_USEC)
 
-#define LAP(prefix,format,...) do {\
-  uint64_t et;\
-  grn_timeval tv;\
-  grn_timeval_now(ctx, &tv);\
-  et = (uint64_t)(tv.tv_sec - ctx->impl->tv.tv_sec) * GRN_TIME_NSEC_PER_SEC\
-    + (tv.tv_nsec - ctx->impl->tv.tv_nsec);\
-  GRN_LOG(ctx, GRN_LOG_NONE, "%p|" prefix "%015" GRN_FMT_INT64U " " format,\
-          ctx, et, __VA_ARGS__);\
-} while (0)
-
 GRN_API grn_rc grn_timeval_now(grn_ctx *ctx, grn_timeval *tv);
 GRN_API grn_rc grn_timeval2str(grn_ctx *ctx, grn_timeval *tv, char *buf);
 grn_rc grn_str2timeval(const char *str, uint32_t str_len, grn_timeval *tv);
@@ -422,6 +412,9 @@ GRN_API void grn_ctx_log(grn_ctx *ctx, const char *fmt, ...) GRN_ATTRIBUTE_PRINT
 void grn_ctx_qe_fin(grn_ctx *ctx);
 void grn_ctx_loader_clear(grn_ctx *ctx);
 void grn_log_reopen(grn_ctx *ctx);
+
+void grn_logger_fin(void);
+void grn_query_logger_fin(grn_ctx *ctx);
 
 GRN_API grn_rc grn_ctx_sendv(grn_ctx *ctx, int argc, char **argv, int flags);
 GRN_API void grn_ctx_set_next_expr(grn_ctx *ctx, grn_obj *expr);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -4328,7 +4328,8 @@ grn_table_select(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
             grn_table_select_(ctx, table, expr, v, res, si->logical_op);
           }
         }
-        LAP(":", "filter(%d)", grn_table_size(ctx, res));
+        GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                      ":", "filter(%d)", grn_table_size(ctx, res));
       }
       for (i = 0; i < n; i++) {
         scan_info *si = sis[i];

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -506,7 +506,9 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
     if ((cache = grn_cache_fetch(ctx, cache_key, cache_key_size))) {
       GRN_TEXT_PUT(ctx, outbuf, GRN_TEXT_VALUE(cache), GRN_TEXT_LEN(cache));
       grn_cache_unref(cache_key, cache_key_size);
-      LAP(":", "cache(%" GRN_FMT_LLD ")", (long long int)GRN_TEXT_LEN(cache));
+      GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_CACHE,
+                    ":", "cache(%" GRN_FMT_LLD ")",
+                    (long long int)GRN_TEXT_LEN(cache));
       return ctx->rc;
     }
   }
@@ -596,7 +598,8 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
       res = table_;
     }
     nhits = res ? grn_table_size(ctx, res) : 0;
-    LAP(":", "select(%d)", nhits);
+    GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                  ":", "select(%d)", nhits);
 
     if (res) {
       uint32_t ngkeys;
@@ -629,7 +632,8 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
           }
           grn_obj_unlink(ctx, scorer_);
         }
-        LAP(":", "score(%d)", nhits);
+        GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                      ":", "score(%d)", nhits);
       }
 
       grn_normalize_offset_and_limit(ctx, nhits, &offset, &limit);
@@ -639,7 +643,8 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
         if ((sorted = grn_table_create(ctx, NULL, 0, NULL,
                                        GRN_OBJ_TABLE_NO_KEY, NULL, res))) {
           grn_table_sort(ctx, res, offset, limit, sorted, keys, nkeys);
-          LAP(":", "sort(%d)", limit);
+          GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                        ":", "sort(%d)", limit);
           GRN_OBJ_FORMAT_INIT(&format, nhits, 0, limit, offset);
           format.flags =
             GRN_OBJ_FORMAT_WITH_COLUMN_NAMES|
@@ -681,7 +686,8 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
           GRN_OBJ_FORMAT_FIN(ctx, &format);
         }
       }
-      LAP(":", "output(%d)", limit);
+      GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                    ":", "output(%d)", limit);
       if (!ctx->rc && drilldown_len) {
         uint32_t i;
         grn_table_group_result g = {NULL, 0, 0, 1, GRN_TABLE_GROUP_CALC_COUNT, 0};
@@ -734,7 +740,8 @@ grn_select(grn_ctx *ctx, const char *table, unsigned int table_len,
               }
               grn_obj_unlink(ctx, g.table);
             }
-            LAP(":", "drilldown(%d)", nhits);
+            GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                          ":", "drilldown(%d)", nhits);
           }
           grn_table_sort_key_close(ctx, gkeys, ngkeys);
         }

--- a/lib/str.h
+++ b/lib/str.h
@@ -77,8 +77,6 @@ grn_id grn_btoi(char *b);
 
 grn_rc grn_substring(grn_ctx *ctx, char **str, char **str_end, int start, int end, grn_encoding encoding);
 
-void grn_logger_fin(void);
-
 GRN_API int grn_charlen_(grn_ctx *ctx, const char *str, const char *end, grn_encoding encoding);
 GRN_API grn_str *grn_str_open_(grn_ctx *ctx, const char *str, unsigned int str_len, int flags, grn_encoding encoding);
 

--- a/plugins/suggest/suggest.c
+++ b/plugins/suggest/suggest.c
@@ -246,7 +246,8 @@ output(grn_ctx *ctx, grn_obj *table, grn_obj *res, grn_id tid,
     }
     if ((keys = grn_table_sort_key_from_str(ctx, sortby_val, sortby_len, res, &nkeys))) {
       grn_table_sort(ctx, res, offset, limit, sorted, keys, nkeys);
-      LAP(":", "sort(%d)", limit);
+      GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                    ":", "sort(%d)", limit);
       GRN_OBJ_FORMAT_INIT(&format, grn_table_size(ctx, res), 0, limit, offset);
       format.flags =
         GRN_OBJ_FORMAT_WITH_COLUMN_NAMES|
@@ -380,7 +381,8 @@ correct(grn_ctx *ctx, grn_obj *items, grn_obj *items_boost,
     max_score = cooccurrence_search(ctx, items, items_boost, tid, res, CORRECT,
                                     frequency_threshold,
                                     conditional_probability_threshold);
-    LAP(":", "cooccur(%d)", max_score);
+    GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SCORE,
+                  ":", "cooccur(%d)", max_score);
     if (GRN_TEXT_LEN(query) &&
         ((similar_search_mode == GRN_SUGGEST_SEARCH_YES) ||
          (similar_search_mode == GRN_SUGGEST_SEARCH_AUTO &&
@@ -396,7 +398,8 @@ correct(grn_ctx *ctx, grn_obj *items, grn_obj *items_boost,
           grn_ii_select(ctx, (grn_ii *)index, TEXT_VALUE_LEN(query),
                         (grn_hash *)res, GRN_OP_OR, &optarg);
           grn_obj_unlink(ctx, index);
-          LAP(":", "similar(%d)", grn_table_size(ctx, res));
+          GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                        ":", "similar(%d)", grn_table_size(ctx, res));
           {
             grn_hash_cursor *hc = grn_hash_cursor_open(ctx, (grn_hash *)res, NULL,
                                                        0, NULL, 0, 0, -1, 0);
@@ -427,7 +430,8 @@ correct(grn_ctx *ctx, grn_obj *items, grn_obj *items_boost,
               grn_hash_cursor_close(ctx, hc);
             }
           }
-          LAP(":", "filter(%d)", grn_table_size(ctx, res));
+          GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,
+                        ":", "filter(%d)", grn_table_size(ctx, res));
           {
             /* exec _score -= edit_distance(_key, "query string") for all records */
             grn_obj *var;

--- a/test/unit/core/test-log.c
+++ b/test/unit/core/test-log.c
@@ -92,10 +92,13 @@ test_invalid_char(void)
   assert_send_command("load --table Users --input_type json\n"
                       "{\"name\": \"groonga\" @ \"desc\" \"search engine\"}\n"
                       "");
-  log = g_list_next(grn_collect_logger_get_messages(logger));
-  cut_assert_equal_string("ignored invalid char('@') at", g_list_nth_data(log, 0));
-  cut_assert_equal_string("{\"name\": \"groonga\" @", g_list_nth_data(log, 1));
-  cut_assert_equal_string("                   ^", g_list_nth_data(log, 2));
+  log = (GList *)grn_collect_logger_get_messages(logger);
+  cut_assert_equal_string("ignored invalid char('@') at",
+                          g_list_nth_data(log, 0));
+  cut_assert_equal_string("{\"name\": \"groonga\" @",
+                          g_list_nth_data(log, 1));
+  cut_assert_equal_string("                   ^",
+                          g_list_nth_data(log, 2));
 }
 
 void
@@ -109,8 +112,9 @@ test_no_key(void)
   assert_send_command("load --table Users --input_type json\n"
                       "{\"info\" \"search engine\"}\n"
                       "");
-  log = g_list_next(grn_collect_logger_get_messages(logger));
-  cut_assert_equal_string("neither _key nor _id is assigned", g_list_nth_data(log, 0));
+  log = (GList *)grn_collect_logger_get_messages(logger);
+  cut_assert_equal_string("neither _key nor _id is assigned",
+                          g_list_nth_data(log, 0));
 }
 
 void
@@ -124,8 +128,9 @@ test_duplicated_key(void)
   assert_send_command("load --table Users --input_type json\n"
                       "{\"_key\": \"groonga\", \"_id\": 1}\n"
                       "");
-  log = g_list_next(grn_collect_logger_get_messages(logger));
-  cut_assert_equal_string("duplicated key columns: _key and _id", g_list_nth_data(log, 0));
+  log = (GList *)grn_collect_logger_get_messages(logger);
+  cut_assert_equal_string("duplicated key columns: _key and _id",
+                          g_list_nth_data(log, 0));
 }
 
 void
@@ -139,6 +144,6 @@ test_invalid_column(void)
   assert_send_command("load --table Users --input_type json\n"
                       "{\"_key\": \"groonga\", \"info\" \"search engine\"}\n"
                       "");
-  log = g_list_next(grn_collect_logger_get_messages(logger));
+  log = (GList *)grn_collect_logger_get_messages(logger);
   cut_assert_equal_string("invalid column('info')", g_list_nth_data(log, 0));
 }


### PR DESCRIPTION
Now, logger supports both normal log and query log. GRN_LOG_NONE level is used for query log but it is confused.

This change split query logger from logger.

Before:

```
LAP(":", "select(%d)", nhits)
```

After:

```
GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE, ":", "select(%d)", nhits)
```
