### PR TITLE
Support nested index search

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -3756,8 +3756,13 @@ scan_info_build(grn_ctx *ctx, grn_obj *expr, int *n,
                 case GRN_ACCESSOR :
                 case GRN_ACCESSOR_VIEW :
                   if (grn_column_index(ctx, ec->value, c->op, &index, 1, &sid)) {
+                    int32_t weight = get_weight(ctx, ec);
                     si->flags |= SCAN_ACCESSOR;
-                    scan_info_put_index(ctx, si, index, sid, get_weight(ctx, ec));
+                    if (((grn_accessor *)ec->value)->next) {
+                      scan_info_put_index(ctx, si, ec->value, sid, weight);
+                    } else {
+                      scan_info_put_index(ctx, si, index, sid, weight);
+                    }
                   }
                   break;
                 case GRN_COLUMN_FIX_SIZE :

--- a/test/command/suite/select/index/nested/scalar.expected
+++ b/test/command/suite/select/index/nested/scalar.expected
@@ -1,0 +1,72 @@
+table_create Comments TABLE_HASH_KEY UInt32
+[[0,0.0,0.0],true]
+column_create Comments content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Articles TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Articles content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Articles comment COLUMN_SCALAR Comments
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText   --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION   Articles content
+[[0,0.0,0.0],true]
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION   Comments content
+[[0,0.0,0.0],true]
+column_create Comments article COLUMN_INDEX Articles comment
+[[0,0.0,0.0],true]
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+[[0,0.0,0.0],3]
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comments": 3}
+]
+[[0,0.0,0.0],3]
+#|e| invalid column('comments')
+select Articles --match_columns comment.content --query groonga   --output_columns "_id, _score, *"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_score",
+          "Int32"
+        ],
+        [
+          "comment",
+          "Comments"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        1,
+        1,
+        "Groonga is fast!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/nested/scalar.test
+++ b/test/command/suite/select/index/nested/scalar.test
@@ -1,0 +1,32 @@
+table_create Comments TABLE_HASH_KEY UInt32
+column_create Comments content COLUMN_SCALAR ShortText
+
+table_create Articles TABLE_NO_KEY
+column_create Articles content COLUMN_SCALAR Text
+column_create Articles comment COLUMN_SCALAR Comments
+
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText \
+  --default_tokenizer TokenBigram
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION \
+  Articles content
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION \
+  Comments content
+
+column_create Comments article COLUMN_INDEX Articles comment
+
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comments": 3}
+]
+
+select Articles --match_columns comment.content --query groonga \
+  --output_columns "_id, _score, *"

--- a/test/command/suite/select/index/nested/vector.expected
+++ b/test/command/suite/select/index/nested/vector.expected
@@ -1,0 +1,82 @@
+table_create Comments TABLE_HASH_KEY UInt32
+[[0,0.0,0.0],true]
+column_create Comments content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Articles TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Articles content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Articles comments COLUMN_VECTOR Comments
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText   --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION   Articles content
+[[0,0.0,0.0],true]
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION   Comments content
+[[0,0.0,0.0],true]
+column_create Comments article COLUMN_INDEX Articles comments
+[[0,0.0,0.0],true]
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+[[0,0.0,0.0],3]
+load --table Articles
+[
+{"content": "Groonga is fast!", "comments": [1, 3]},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comments": [2]}
+]
+[[0,0.0,0.0],3]
+select Articles --match_columns comments.content --query groonga   --output_columns "_id, _score, *"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_score",
+          "Int32"
+        ],
+        [
+          "comments",
+          "Comments"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        1,
+        [
+          1,
+          3
+        ],
+        "Groonga is fast!"
+      ],
+      [
+        3,
+        1,
+        [
+          2
+        ],
+        "Mroonga is fast!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/nested/vector.test
+++ b/test/command/suite/select/index/nested/vector.test
@@ -1,0 +1,32 @@
+table_create Comments TABLE_HASH_KEY UInt32
+column_create Comments content COLUMN_SCALAR ShortText
+
+table_create Articles TABLE_NO_KEY
+column_create Articles content COLUMN_SCALAR Text
+column_create Articles comments COLUMN_VECTOR Comments
+
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText \
+  --default_tokenizer TokenBigram
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION \
+  Articles content
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION \
+  Comments content
+
+column_create Comments article COLUMN_INDEX Articles comments
+
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+
+load --table Articles
+[
+{"content": "Groonga is fast!", "comments": [1, 3]},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comments": [2]}
+]
+
+select Articles --match_columns comments.content --query groonga \
+  --output_columns "_id, _score, *"

--- a/test/command/suite/select/index/nested/weight.expected
+++ b/test/command/suite/select/index/nested/weight.expected
@@ -1,0 +1,71 @@
+table_create Comments TABLE_HASH_KEY UInt32
+[[0,0.0,0.0],true]
+column_create Comments content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Articles TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Articles content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Articles comment COLUMN_SCALAR Comments
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText   --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION   Articles content
+[[0,0.0,0.0],true]
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION   Comments content
+[[0,0.0,0.0],true]
+column_create Comments article COLUMN_INDEX Articles comment
+[[0,0.0,0.0],true]
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+[[0,0.0,0.0],3]
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comment": 3}
+]
+[[0,0.0,0.0],3]
+select Articles   --match_columns 'comment.content * 10' --query groonga   --output_columns "_id, _score, *"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_score",
+          "Int32"
+        ],
+        [
+          "comment",
+          "Comments"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        10,
+        1,
+        "Groonga is fast!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/nested/weight.test
+++ b/test/command/suite/select/index/nested/weight.test
@@ -1,0 +1,33 @@
+table_create Comments TABLE_HASH_KEY UInt32
+column_create Comments content COLUMN_SCALAR ShortText
+
+table_create Articles TABLE_NO_KEY
+column_create Articles content COLUMN_SCALAR Text
+column_create Articles comment COLUMN_SCALAR Comments
+
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText \
+  --default_tokenizer TokenBigram
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION \
+  Articles content
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION \
+  Comments content
+
+column_create Comments article COLUMN_INDEX Articles comment
+
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comment": 3}
+]
+
+select Articles \
+  --match_columns 'comment.content * 10' --query groonga \
+  --output_columns "_id, _score, *"

--- a/test/command/suite/select/index/nested/with_top_level_index.expected
+++ b/test/command/suite/select/index/nested/with_top_level_index.expected
@@ -1,0 +1,77 @@
+table_create Comments TABLE_HASH_KEY UInt32
+[[0,0.0,0.0],true]
+column_create Comments content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Articles TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Articles content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Articles comment COLUMN_SCALAR Comments
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText   --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION   Articles content
+[[0,0.0,0.0],true]
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION   Comments content
+[[0,0.0,0.0],true]
+column_create Comments article COLUMN_INDEX Articles comment
+[[0,0.0,0.0],true]
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+[[0,0.0,0.0],3]
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comment": 3}
+]
+[[0,0.0,0.0],3]
+select Articles   --match_columns 'content || comment.content' --query groonga   --output_columns "_id, _score, *"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_score",
+          "Int32"
+        ],
+        [
+          "comment",
+          "Comments"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        2,
+        1,
+        "Groonga is fast!"
+      ],
+      [
+        2,
+        1,
+        0,
+        "Groonga is useful!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/nested/with_top_level_index.test
+++ b/test/command/suite/select/index/nested/with_top_level_index.test
@@ -1,0 +1,33 @@
+table_create Comments TABLE_HASH_KEY UInt32
+column_create Comments content COLUMN_SCALAR ShortText
+
+table_create Articles TABLE_NO_KEY
+column_create Articles content COLUMN_SCALAR Text
+column_create Articles comment COLUMN_SCALAR Comments
+
+table_create Lexicon TABLE_PAT_KEY|KEY_NORMALIZE ShortText \
+  --default_tokenizer TokenBigram
+column_create Lexicon articles_content COLUMN_INDEX|WITH_POSITION \
+  Articles content
+column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION \
+  Comments content
+
+column_create Comments article COLUMN_INDEX Articles comment
+
+load --table Comments
+[
+{"_key": 1, "content": "I'm using groonga too!"},
+{"_key": 2, "content": "I'm using groonga and mroonga!"},
+{"_key": 3, "content": "I'm using mroonga too!"}
+]
+
+load --table Articles
+[
+{"content": "Groonga is fast!", "comment": 1},
+{"content": "Groonga is useful!"},
+{"content": "Mroonga is fast!", "comment": 3}
+]
+
+select Articles \
+  --match_columns 'content || comment.content' --query groonga \
+  --output_columns "_id, _score, *"


### PR DESCRIPTION
This change supports the following query:

```
select Articles --match_columns comment.content --query KEYWORD
```

With the following schema:

```
table_create Comments TABLE_HASH_KEY UInt32
column_create Comments content COLUMN_SCALAR ShortText

table_create Articles TABLE_NO_KEY
column_create Articles comment COLUMN_SCALAR Comments

table_create Lexicon TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
column_create Lexicon comments_content COLUMN_INDEX|WITH_POSITION Comments content

column_create Comments article COLUMN_INDEX Articles comment
```

The select command searches with the following steps:
1. Searches Comments.content with KEYWORD by Lexicon.comments_content index
   and gets (a) record IDs of Comments.
2. Searches Articles with (a) by Comments.article index and gets record IDs
   of Articles.
