### PR TITLE
Add query() function

### DIFF
--- a/test/command/suite/select/filter/query/function.expected
+++ b/test/command/suite/select/filter/query/function.expected
@@ -1,0 +1,48 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_HASH_KEY ShortText   --default_tokenizer TokenBigramSplitSymbolAlphaDigit   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Lexicon users_name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Alice"},
+{"name": "Alisa"},
+{"name": "Bob"}
+]
+[[0,0.0,0.0],3]
+select Users   --output_columns name,_score   --filter 'query("name * 10", "ali") == true'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "name",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Alice",
+        1
+      ],
+      [
+        "Alisa",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/query/function.test
+++ b/test/command/suite/select/filter/query/function.test
@@ -1,0 +1,18 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Lexicon TABLE_HASH_KEY ShortText \
+  --default_tokenizer TokenBigramSplitSymbolAlphaDigit \
+  --normalizer NormalizerAuto
+column_create Lexicon users_name COLUMN_INDEX|WITH_POSITION Users name
+
+load --table Users
+[
+{"name": "Alice"},
+{"name": "Alisa"},
+{"name": "Bob"}
+]
+
+select Users \
+  --output_columns name,_score \
+  --filter 'query("name * 10", "ali") == true'

--- a/test/command/suite/select/filter/query/selector.expected
+++ b/test/command/suite/select/filter/query/selector.expected
@@ -1,0 +1,48 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_HASH_KEY ShortText   --default_tokenizer TokenBigramSplitSymbolAlphaDigit   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Lexicon users_name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Alice"},
+{"name": "Alisa"},
+{"name": "Bob"}
+]
+[[0,0.0,0.0],3]
+select Users   --output_columns name,_score   --filter 'query("name * 10", "ali")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "name",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Alice",
+        10
+      ],
+      [
+        "Alisa",
+        10
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/query/selector.test
+++ b/test/command/suite/select/filter/query/selector.test
@@ -1,0 +1,18 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Lexicon TABLE_HASH_KEY ShortText \
+  --default_tokenizer TokenBigramSplitSymbolAlphaDigit \
+  --normalizer NormalizerAuto
+column_create Lexicon users_name COLUMN_INDEX|WITH_POSITION Users name
+
+load --table Users
+[
+{"name": "Alice"},
+{"name": "Alisa"},
+{"name": "Bob"}
+]
+
+select Users \
+  --output_columns name,_score \
+  --filter 'query("name * 10", "ali")'


### PR DESCRIPTION
We can use --match_columns and --query feature in --filter. Both of
the following commands return the same result:

--query version:

```
select Users \
  --output_columns name,_score \
  --match_columns "name * 10" \
  --query alice
```

--filter version:

```
select Users \
  --output_columns name,_score \
  --filter 'query("name * 10", "alice")'
```

With query() function, we can specify multiple query()s in a select
command.

TODO:
- Support query_expansion
- Support query_flags
- Document it
