### PR TITLE
rpm centos: fix argument of killproc function

### DIFF
--- a/data/init.d/redhat/groonga-server-http
+++ b/data/init.d/redhat/groonga-server-http
@@ -124,7 +124,7 @@ start() {
 stop() {
 	echo -n "Shutting down $name: "
 	send_command shutdown
-	killproc -o $PIDFILE $prog
+	killproc -p $PIDFILE $prog
 	RETVAL=$?
 	echo
 	[ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/$name


### PR DESCRIPTION
The argument for pidfile is '-p'. But groonga-server-http script used
'-o' in stop().

これが原因でCentOSの「groonga-server-http stop」が異常終了します。
