### PR TITLE
Support two or more indexes for a table key

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1108,11 +1108,11 @@ grn_table_add(grn_ctx *ctx, grn_obj *table, const void *key, unsigned int key_si
         GRN_TEXT_SET_REF(&value_, key, key_size);
         GRN_UINT32_SET(ctx, &id_, id);
         GRN_UINT32_SET(ctx, &flags_, GRN_OBJ_SET);
-        grn_ctx_push(ctx, &id_);
-        grn_ctx_push(ctx, &oldvalue_);
-        grn_ctx_push(ctx, &value_);
-        grn_ctx_push(ctx, &flags_);
         while (hooks) {
+          grn_ctx_push(ctx, &id_);
+          grn_ctx_push(ctx, &oldvalue_);
+          grn_ctx_push(ctx, &value_);
+          grn_ctx_push(ctx, &flags_);
           pctx.caller = NULL;
           pctx.currh = hooks;
           if (hooks->proc) {

--- a/test/command/suite/load/index/online/key_twice.expected
+++ b/test/command/suite/load/index/online/key_twice.expected
@@ -1,0 +1,19 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Index1 TABLE_PAT_KEY --key_type ShortText   --default_tokenizer TokenBigramSplitSymbolAlpha
+[[0,0.0,0.0],true]
+column_create Index1 users_key COLUMN_INDEX Users _key
+[[0,0.0,0.0],true]
+table_create Index2 TABLE_PAT_KEY --key_type ShortText   --default_tokenizer TokenBigramSplitSymbolAlpha
+[[0,0.0,0.0],true]
+column_create Index2 users_key COLUMN_INDEX Users _key
+[[0,0.0,0.0],true]
+load --table Users
+[
+["_key"],
+["Alice"],
+["Bob"]
+]
+[[0,0.0,0.0],2]
+select Users   --match_columns "Index1.users_key * 10 || Index2.users_key * 5"   --query "li"   --output_columns _key,_score
+[[0,0.0,0.0],[[[1],[["_key","ShortText"],["_score","Int32"]],["Alice",15]]]]

--- a/test/command/suite/load/index/online/key_twice.test
+++ b/test/command/suite/load/index/online/key_twice.test
@@ -1,0 +1,21 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+table_create Index1 TABLE_PAT_KEY --key_type ShortText \
+  --default_tokenizer TokenBigramSplitSymbolAlpha
+column_create Index1 users_key COLUMN_INDEX Users _key
+
+table_create Index2 TABLE_PAT_KEY --key_type ShortText \
+  --default_tokenizer TokenBigramSplitSymbolAlpha
+column_create Index2 users_key COLUMN_INDEX Users _key
+
+load --table Users
+[
+["_key"],
+["Alice"],
+["Bob"]
+]
+
+select Users \
+  --match_columns "Index1.users_key * 10 || Index2.users_key * 5" \
+  --query "li" \
+  --output_columns _key,_score


### PR DESCRIPTION
If there are two or more indexes for a table key, loading a new key to
the talbe may crash.
