### PR TITLE
Support index section in match_columns

### DIFF
--- a/test/command/suite/select/match_columns/section.test
+++ b/test/command/suite/select/match_columns/section.test
@@ -1,0 +1,22 @@
+table_create Memos TABLE_NO_KEY
+column_create Memos title COLUMN_SCALAR ShortText
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Lexicon TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
+column_create Lexicon memo_index COLUMN_INDEX|WITH_POSITION|WITH_SECTION \
+  Memos title,content
+
+load --table Memos
+[
+["title", "content"],
+["groonga", "Start groonga!"],
+["mroonga", "Start mroonga!"],
+["rroonga", "Start rroonga!"],
+["Ruby", "Start Ruby!"],
+["learn", "Learning Ruby and groonga..."]
+]
+
+select Memos \
+  --match_columns "Lexicon.memo_index.title * 10 || Lexicon.memo_index.content" \
+  --query rroonga \
+  --output_columns "title, content, _score"


### PR DESCRIPTION
It supports:

```
select Documents \
  --match_columns "Lexicon.index.section1 * 10 || Lexicon.index.section2" \
  --query "QUERY" \
  --output_columns "content, _score"
# -> _score = (# of matches against section1) * 10 + (# of matches against section2)
```
