### PR TITLE
Debian/Ubuntu init script: exit code of status action should be non-zero when services are not running.

### DIFF
--- a/packages/debian/groonga-httpd.init
+++ b/packages/debian/groonga-httpd.init
@@ -174,6 +174,7 @@ case "$1" in
 	;;
     status)
 	do_status
+	exit $?
 	;;
     *)
 	echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload|status}" >&2

--- a/packages/debian/groonga-server-gqtp.init
+++ b/packages/debian/groonga-server-gqtp.init
@@ -219,6 +219,7 @@ case "$1" in
 	;;
     status)
 	do_status
+	exit $?
 	;;
     *)
 	echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload|status}" >&2

--- a/packages/debian/groonga-server-http.init
+++ b/packages/debian/groonga-server-http.init
@@ -225,6 +225,7 @@ case "$1" in
 	;;
     status)
 	do_status
+	exit $?
 	;;
     *)
 	echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload|status}" >&2


### PR DESCRIPTION
Currently, under Ubuntu 12.04, `sudo /etc/init.d/groonga-* status` commands always exit with exit code 0.

According to [LSB](http://refspecs.linuxbase.org/LSB_3.1.1/LSB-Core-generic/LSB-Core-generic/iniscrptact.html), exit code should be non-zero when the services are not running.

This fix is useful for automated monitoring or testing like serverspec.

---

Current behavior under Ubuntu 12.04:

``` sh
$ sudo service groonga-httpd start
$ sudo service groonga-httpd status
[[0,1371380737.64486,7.22408294677734e-05],{"alloc_count":143,"starttime":1371380734,"uptime":3,"version":"3.0.4","n_queries":0,"cache_hit_rate":0.0,"command_version":1,"default_command_version":1,"max_command_version":2}]
$ echo $?
0
$ sudo service groonga-httpd stop
$ sudo service groonga-httpd status
curl: (7) couldn't connect to host
$ echo $?
0 # Should be non-zero
```

Under CentOS 6.4, the status action returns non-zero as expected:

``` sh
$ sudo service groonga-httpd start
Starting groonga-httpd:                                    [  OK  ]
$ sudo service groonga-httpd status
[[0,1371392567.48521,0.0018610954284668],{"alloc_count":138,"starttime":1371392559,"uptime":8,"version":"3.0.4","n_queries":0,"cache_hit_rate":0.0,"command_version":1,"default_command_version":1,"max_command_version":2}]
$ echo $?
0
$ sudo service groonga-httpd stop
Shutting down groonga-httpd: [[-2,1371392580.97317,0.000585079193115234,"",[["","",0]]],false]
$ sudo service groonga-httpd status
curl: (7) couldn't connect to host
$ echo $?
7 # Non-zero as expected.
  # Strictly speaking, 7 is not LSB compatible, but it does not matter.
```
