### PR TITLE
Add grn_mrb_send(), grn_mrb_from_grn(), grn_mrb_obj_new()

### DIFF
--- a/lib/mrb.c
+++ b/lib/mrb.c
@@ -22,6 +22,9 @@
 #ifdef GRN_WITH_MRUBY
 # include <mruby/proc.h>
 # include <mruby/compile.h>
+# include <mruby/variable.h>
+# include <mruby/data.h>
+# include <mruby/string.h>
 #endif
 
 #ifdef GRN_WITH_MRUBY
@@ -71,6 +74,58 @@ grn_mrb_eval(grn_ctx *ctx, const char *script, int script_length)
   return result;
 }
 
+mrb_value
+grn_mrb_from_grn(grn_ctx *ctx, grn_obj **argv)
+{
+  grn_obj *obj = (*argv)++;
+  mrb_state *mrb = ctx->impl->mrb;
+  switch (obj->header.type) {
+  case GRN_EXPR:
+    return grn_mrb_obj_new(mrb, "Expr", obj);
+  case GRN_PTR:
+    {
+      const char *cname = GRN_TEXT_VALUE(*argv);
+      (*argv)++;
+      return grn_mrb_obj_new(mrb, cname, GRN_PTR_VALUE(obj));
+    }
+  default:
+    switch (obj->header.domain) {
+    case GRN_DB_INT32:
+      return mrb_fixnum_value(GRN_INT32_VALUE(obj));
+    }
+  }
+  return grn_mrb_obj_new(mrb, "Obj", obj);
+}
+
+grn_rc
+grn_mrb_send(grn_ctx *ctx, grn_obj *grn_recv, const char *name, int argc,
+             grn_obj *grn_argv, grn_obj *grn_object)
+{
+  int i, offset, ai;
+  grn_rc stat;
+  mrb_state *mrb = ctx->impl->mrb;
+  mrb_value ret, recv, *argv;
+  ai = mrb_gc_arena_save(mrb);
+  argv = GRN_MALLOCN(mrb_value, argc);
+  recv = grn_mrb_from_grn(ctx, &grn_recv);
+  for (i = offset = 0; i < argc; i++) {
+    argv[i] = grn_mrb_from_grn(ctx, &grn_argv);
+  }
+  ret = mrb_funcall_argv(mrb, recv, mrb_intern(mrb, name), argc, argv);
+  GRN_FREE(argv);
+  if (mrb->exc) {
+    mrb_value msg = mrb_inspect(mrb, mrb_obj_value(mrb->exc));
+    ERR(GRN_UNKNOWN_ERROR, "mruby error - %s", RSTRING_PTR(msg));
+    stat = GRN_UNKNOWN_ERROR;
+    mrb->exc = NULL;
+  } else {
+    GRN_VOID_INIT(grn_object);
+    stat = grn_mrb_to_grn(ctx, ret, grn_object);
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  return stat;
+}
+
 grn_rc
 grn_mrb_to_grn(grn_ctx *ctx, mrb_value mrb_object, grn_obj *grn_object)
 {
@@ -81,6 +136,8 @@ grn_mrb_to_grn(grn_ctx *ctx, mrb_value mrb_object, grn_obj *grn_object)
     grn_obj_reinit(ctx, grn_object, GRN_DB_INT32, 0);
     GRN_INT32_SET(ctx, grn_object, mrb_fixnum(mrb_object));
     break;
+  case MRB_TT_FALSE :
+    grn_obj_reinit(ctx, grn_object, GRN_DB_VOID, 0);
   default :
     rc = GRN_INVALID_ARGUMENT;
     break;
@@ -88,6 +145,19 @@ grn_mrb_to_grn(grn_ctx *ctx, mrb_value mrb_object, grn_obj *grn_object)
 
   return rc;
 }
+
+mrb_value
+grn_mrb_obj_new(mrb_state *mrb, const char *cname, void *ptr)
+{
+  mrb_value obj, type;
+  struct RClass *klass;
+  if (!ptr) { return mrb_nil_value(); }
+  klass = mrb_class_get(mrb, cname);
+  type  = mrb_iv_get(mrb, mrb_obj_value(klass), mrb_intern(mrb, "type"));
+  obj = mrb_obj_value(Data_Wrap_Struct(mrb, klass, mrb_voidp(type), ptr));
+  return obj;
+}
+
 #else
 void
 grn_ctx_impl_mrb_init(grn_ctx *ctx)

--- a/lib/mrb.h
+++ b/lib/mrb.h
@@ -35,7 +35,11 @@ void grn_ctx_impl_mrb_fin(grn_ctx *ctx);
 
 #ifdef GRN_WITH_MRUBY
 mrb_value grn_mrb_eval(grn_ctx *ctx, const char *script, int script_length);
+grn_rc grn_mrb_send(grn_ctx *ctx, grn_obj *grn_recv, const char *name, int argc,
+                    grn_obj *grn_argv, grn_obj *grn_object);
 grn_rc grn_mrb_to_grn(grn_ctx *ctx, mrb_value mrb_object, grn_obj *grn_object);
+mrb_value grn_mrb_from_grn(grn_ctx *ctx, grn_obj **argv);
+mrb_value grn_mrb_obj_new(mrb_state *mrb, const char *cname, void *ptr);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
This patch introduces grn_mrb_send() to call ruby method from groonga.
grn_mrb_from_grn() is used by grn_mrb_send().
grn_mrb_obj_new() is helper function to create mruby data-object from pointer.
