### PR TITLE
Add some API to handle scan_info from outside expr.c

### DIFF
--- a/lib/expr.h
+++ b/lib/expr.h
@@ -1,6 +1,8 @@
 #ifndef GRN_EXPR_H
 #define GRN_EXPR_H
 
+#include "db.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +21,29 @@ typedef enum {
 } scan_stat;
 
 typedef struct _grn_scan_info scan_info;
+typedef grn_bool (*grn_scan_info_each_arg_callback)(grn_ctx *ctx, grn_obj *obj, void *user_data);
+
+scan_info *grn_scan_info_alloc(grn_ctx *ctx, int start);
+void grn_scan_info_free(grn_ctx *ctx, scan_info *si);
+void grn_scan_info_put_index(grn_ctx *ctx, scan_info *si, grn_obj *index,
+                             uint32_t sid, int32_t weight);
+grn_bool grn_scan_info_check_flags(scan_info *si, int flags);
+void grn_scan_info_reset_flags(scan_info *si, int flags);
+int grn_scan_info_get_flags(scan_info *si);
+void grn_scan_info_set_flags(scan_info *si, int flags);
+void grn_scan_info_unset_flags(scan_info *si, int flags);
+grn_operator grn_scan_info_get_logical_op(scan_info *si);
+void grn_scan_info_set_logical_op(scan_info *si, grn_operator logical_op);
+grn_operator grn_scan_info_get_op(scan_info *si);
+void grn_scan_info_set_op(scan_info *si, grn_operator op);
+void grn_scan_info_set_end(scan_info *si, uint32_t end);
+void grn_scan_info_set_query(scan_info *si, grn_obj *query);
+grn_bool grn_scan_info_push_arg(scan_info *si, grn_obj *arg);
+void grn_scan_info_each_arg(grn_ctx *ctx, scan_info *si,
+                                grn_scan_info_each_arg_callback callback,
+                                void *user_data);
+
+int32_t grn_expr_code_get_weight(grn_ctx *ctx, grn_expr_code *ec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
To handle scan_info from outside expr.c - in example, mrb.c -, we have to get more public API.
