### PR TITLE
Fix ENV to fit current name of scripts directory: "lib/mrb/scripts"

### DIFF
--- a/test/unit/run-test.sh
+++ b/test/unit/run-test.sh
@@ -58,7 +58,7 @@ CUTTER_ARGS="$CUTTER_ARGS --exclude-file test-performance.so"
 GRN_PLUGINS_DIR="$top_dir/plugins"
 export GRN_PLUGINS_DIR
 
-GRN_RUBY_SCRIPTS_DIR="$top_dir/lib/mrb/ruby_scripts"
+GRN_RUBY_SCRIPTS_DIR="$top_dir/lib/mrb/scripts"
 export GRN_RUBY_SCRIPTS_DIR
 
 case `uname` in


### PR DESCRIPTION
I guess it's caused by my bad naming sense...sorry.
