### PR TITLE
mruby: Define Groonga::Object for wrapper of grn_obj

### DIFF
--- a/lib/mrb/mrb_obj.c
+++ b/lib/mrb/mrb_obj.c
@@ -31,7 +31,7 @@ grn_mrb_obj_init(grn_ctx *ctx)
   struct RClass *module = ctx->impl->mrb.module;
   struct RClass *klass;
 
-  klass = mrb_define_class_under(mrb, module, "Groonga", mrb->object_class);
-  MRB_SET_INSTANCE_TT(klass, MRB_TT_STRING);
+  klass = mrb_define_class_under(mrb, module, "Object", mrb->object_class);
+  MRB_SET_INSTANCE_TT(klass, MRB_TT_DATA);
 }
 #endif

--- a/test/command/suite/ruby/eval/built_in_class.expected
+++ b/test/command/suite/ruby/eval/built_in_class.expected
@@ -1,4 +1,4 @@
 register ruby/eval
 [[0,0.0,0.0],true]
 ruby_eval "Groonga::Object.to_s"
-[[0,0.0,0.0],{"value":"Object"}]
+[[0,0.0,0.0],{"value":"Groonga::Object"}]


### PR DESCRIPTION
I guess lib/mrb/mrb_obj.c is for Groonga::Object, wrapper of grn_obj, isn't it?
If so, this request might be help it.
