### PR TITLE
Wrap member 'next' of grn_accessor in ruby method

### DIFF
--- a/lib/mrb/mrb_obj.c
+++ b/lib/mrb/mrb_obj.c
@@ -21,8 +21,51 @@
 #ifdef GRN_WITH_MRUBY
 #include <mruby.h>
 #include <mruby/class.h>
+#include <mruby/variable.h>
+#include <mruby/data.h>
 
+#include "../db.h"
 #include "mrb_obj.h"
+
+static struct mrb_data_type mrb_grn_accessor_type = {
+  "Groonga::Accessor",
+  NULL
+};
+
+mrb_value
+mrb_grn_accessor_new(mrb_state *mrb, grn_accessor *accessor)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  struct RClass *module = ctx->impl->mrb.module;
+  struct RClass *klass;
+  mrb_value mrb_accessor_ptr;
+
+  mrb_accessor_ptr = mrb_cptr_value(mrb, accessor);
+  klass = mrb_class_ptr(mrb_const_get(mrb, mrb_obj_value(module),
+                                      mrb_intern(mrb, "Accessor")));
+  return mrb_obj_new(mrb, klass, 1, &mrb_accessor_ptr);
+}
+
+static mrb_value
+mrb_grn_accessor_initialize(mrb_state *mrb, mrb_value self)
+{
+  mrb_value mrb_accessor_ptr;
+
+  mrb_get_args(mrb, "o", &mrb_accessor_ptr);
+  DATA_TYPE(self) = &mrb_grn_accessor_type;
+  DATA_PTR(self) = mrb_cptr(mrb_accessor_ptr);
+  return self;
+}
+
+static mrb_value
+mrb_grn_accessor_next(mrb_state *mrb, mrb_value self)
+{
+  grn_accessor *accessor;
+
+  accessor = DATA_PTR(self);
+  if (!accessor->next) { return mrb_nil_value(); }
+  return mrb_cptr_value(mrb, accessor->next);
+}
 
 void
 grn_mrb_obj_init(grn_ctx *ctx)
@@ -33,5 +76,10 @@ grn_mrb_obj_init(grn_ctx *ctx)
 
   klass = mrb_define_class_under(mrb, module, "Object", mrb->object_class);
   MRB_SET_INSTANCE_TT(klass, MRB_TT_DATA);
+
+  klass = mrb_define_class_under(mrb, module, "Accessor", mrb->object_class);
+  MRB_SET_INSTANCE_TT(klass, MRB_TT_DATA);
+  mrb_define_method(mrb, klass, "initialize", mrb_grn_accessor_initialize, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, klass, "next", mrb_grn_accessor_next, MRB_ARGS_NONE());
 }
 #endif

--- a/lib/mrb/mrb_obj.h
+++ b/lib/mrb/mrb_obj.h
@@ -20,11 +20,13 @@
 #define GRN_MRB_OBJ_H
 
 #include "../ctx.h"
+#include "../db.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+mrb_value mrb_grn_accessor_new(mrb_state *mrb, grn_accessor *accessor);
 void grn_mrb_obj_init(grn_ctx *ctx);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I thought it is overkill to add expr_accessor.c, but I'm not sure.
If the file should be added, I'm ready to push another branch.
https://github.com/wanabe/groonga/tree/mruby-accessor2
