### PR TITLE
doc: update Travis CI environment information

### DIFF
--- a/doc/locale/en/LC_MESSAGES/development.po
+++ b/doc/locale/en/LC_MESSAGES/development.po
@@ -65,14 +65,14 @@ msgstr "Configuration"
 # 3c2876acdfa94e50846d681d3c6cc5d0
 #: ../../../source/development/travis-ci.txt:20
 msgid ""
-"Travis CI is running on 32-bit Ubuntu 11.10. (See `Travis CI: About Travis "
+"Travis CI is running on 64-bit Ubuntu 12.04 LTS Server Edition. (See `Travis CI: About Travis "
 "CI Environment <http://about.travis-ci.org/docs/user/ci-environment/>`_.)  "
-"You can use apt-line for Ubuntu 11.10 provided by groonga project to install "
+"You can use apt-line for Ubuntu 12.04 LTS provided by groonga project to install "
 "groonga on Travis CI."
 msgstr ""
-"Travis CI is running on 32-bit Ubuntu 11.10. (See `Travis CI: About Travis "
+"Travis CI is running on 64-bit Ubuntu 12.04 LTS Server Edition. (See `Travis CI: About Travis "
 "CI Environment <http://about.travis-ci.org/docs/user/ci-environment/>`_.)  "
-"You can use apt-line for Ubuntu 11.10 provided by groonga project to install "
+"You can use apt-line for Ubuntu 12.04 LTS provided by groonga project to install "
 "groonga on Travis CI."
 
 # 8bbd47f3a4b14f4f88fd06001615f178

--- a/doc/locale/ja/LC_MESSAGES/development.po
+++ b/doc/locale/ja/LC_MESSAGES/development.po
@@ -68,15 +68,15 @@ msgstr "設定"
 # 514db429bebf4729abf0a273db593924
 #: ../../../source/development/travis-ci.txt:20
 msgid ""
-"Travis CI is running on 32-bit Ubuntu 11.10. (See `Travis CI: About Travis "
+"Travis CI is running on 64-bit Ubuntu 12.04 LTS Server Edition. (See `Travis CI: About Travis "
 "CI Environment <http://about.travis-ci.org/docs/user/ci-environment/>`_.)  "
-"You can use apt-line for Ubuntu 11.10 provided by groonga project to install "
+"You can use apt-line for Ubuntu 12.04 LTS provided by groonga project to install "
 "groonga on Travis CI."
 msgstr ""
-"Travis CIは32-bit版のUbuntu 11.10を使っています。（ `Travis CI: About Travis "
+"Travis CIは64-bit版のUbuntu 12.04 LTS サーバ版を使っています。（ `Travis CI: About Travis "
 "CI Environment <http://about.travis-ci.org/docs/user/ci-environment/>`_ 参"
 "照。）Travis CIにgroongaをインストールするために、groongaプロジェクトが提供し"
-"ているUbuntu 11.10用のapt-lineを使えます。"
+"ているUbuntu 12.04 LTS用のapt-lineを使えます。"
 
 # ccf892ca5eb740ae8467f66720b0248d
 #: ../../../source/development/travis-ci.txt:26

--- a/doc/source/development/travis-ci.txt
+++ b/doc/source/development/travis-ci.txt
@@ -17,10 +17,10 @@ Travis CI.
 Configuration
 -------------
 
-Travis CI is running on 32-bit Ubuntu 11.10. (See `Travis CI: About
+Travis CI is running on 64-bit Ubuntu 12.04 LTS Server Edition. (See `Travis CI: About
 Travis CI Environment
 <http://about.travis-ci.org/docs/user/ci-environment/>`_.)  You can
-use apt-line for Ubuntu 11.10 provided by groonga project to install
+use apt-line for Ubuntu 12.04 LTS provided by groonga project to install
 groonga on Travis CI.
 
 You can custom build lifecycle by ``.travis.yml``. (See `Travis CI:


### PR DESCRIPTION
Travis CI uses Ubuntu 12.04 LTS Server Edition now, but groonga document says that Travis CI uses Ubuntu 11.10.
