### PR TITLE
Use grn_obj_get_value() in grn_expr_exec()

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -5003,11 +5003,13 @@ grn_accessor_get_value(grn_ctx *ctx, grn_accessor *a, grn_id id, grn_obj *value)
   uint32_t vs = 0;
   uint32_t size0;
   void *vp = NULL;
+  grn_id original_domain;
   if (!value) {
     if (!(value = grn_obj_open(ctx, GRN_BULK, 0, 0))) { return NULL; }
   } else {
     value->header.type = GRN_BULK;
   }
+  original_domain = value->header.domain;
   size0 = GRN_BULK_VSIZE(value);
   for (;;) {
     grn_bulk_truncate(ctx, value, size0);
@@ -5033,6 +5035,7 @@ grn_accessor_get_value(grn_ctx *ctx, grn_accessor *a, grn_id id, grn_obj *value)
         grn_rset_recinfo *ri = (grn_rset_recinfo *)grn_obj_get_value_(ctx, a->obj, id, &vs);
         GRN_INT32_PUT(ctx, value, ri->score);
       }
+      value->header.domain = GRN_DB_INT32;
       break;
     case GRN_ACCESSOR_GET_NSUBRECS :
       {
@@ -5060,6 +5063,7 @@ grn_accessor_get_value(grn_ctx *ctx, grn_accessor *a, grn_id id, grn_obj *value)
     }
     if ((a = a->next)) {
       id = *((grn_id *)vp);
+      value->header.domain = original_domain;
     } else {
       break;
     }
@@ -5799,8 +5803,8 @@ grn_obj_get_value(grn_ctx *ctx, grn_obj *obj, grn_id id, grn_obj *value)
   switch (obj->header.type) {
   case GRN_ACCESSOR :
     grn_obj_ensure_bulk(ctx, value);
-    value = grn_accessor_get_value(ctx, (grn_accessor *)obj, id, value);
     value->header.domain = grn_obj_get_range(ctx, obj);
+    value = grn_accessor_get_value(ctx, (grn_accessor *)obj, id, value);
     break;
   case GRN_TABLE_PAT_KEY :
     {

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -2924,9 +2924,6 @@ grn_expr_exec(grn_ctx *ctx, grn_obj *expr, int nargs)
           grn_obj pat_value;
           GRN_TEXT_INIT(&pat_value, 0);
           do {
-            uint32_t size;
-            const char *value;
-            grn_bool is_pat_key_accessor = GRN_FALSE;
             if (code->nargs == 1) {
               rec = v0;
               if (code->value) {
@@ -2950,33 +2947,11 @@ grn_expr_exec(grn_ctx *ctx, grn_obj *expr, int nargs)
             }
             if (col) {
               grn_obj_reinit_for(ctx, res, col);
-              if (col->header.type == GRN_ACCESSOR &&
-                  ((grn_accessor *)col)->action == GRN_ACCESSOR_GET_KEY &&
-                  ((grn_accessor *)col)->obj->header.type == GRN_TABLE_PAT_KEY) {
-                is_pat_key_accessor = GRN_TRUE;
-                GRN_BULK_REWIND(&pat_value);
-                grn_obj_get_value(ctx, col, GRN_RECORD_VALUE(rec), &pat_value);
-                value = GRN_BULK_HEAD(&pat_value);
-                size = GRN_BULK_VSIZE(&pat_value);
-              } else {
-                value = grn_obj_get_value_(ctx, col, GRN_RECORD_VALUE(rec),
-                                           &size);
-              }
+              grn_obj_get_value(ctx, col, GRN_RECORD_VALUE(rec), res);
             } else {
               ERR(GRN_INVALID_ARGUMENT, "col resolve failed");
               GRN_OBJ_FIN(ctx, &pat_value);
               goto exit;
-            }
-            if (!is_pat_key_accessor && size == GRN_OBJ_GET_VALUE_IMD) {
-              GRN_RECORD_SET(ctx, res, (uintptr_t)value);
-            } else {
-              if (value) {
-                if (res->header.type == GRN_VECTOR) {
-                  grn_vector_decode(ctx, res, value, size);
-                } else {
-                  grn_bulk_write_from(ctx, res, value, 0, size);
-                }
-              }
             }
             code++;
           } while (code < ce && code->op == GRN_OP_GET_VALUE);

--- a/test/command/suite/select/output/accessor/index.expected
+++ b/test/command/suite/select/output/accessor/index.expected
@@ -1,0 +1,47 @@
+table_create Memos TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+column_create Tags memos_tag COLUMN_INDEX Memos tag
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is a full text search engine.", "tag": "groonga"}
+]
+[[0,0.0,0.0],1]
+select Tags --filter true --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "memos_tag",
+          "Memos"
+        ]
+      ],
+      [
+        1,
+        "groonga",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/output/accessor/index.test
+++ b/test/command/suite/select/output/accessor/index.test
@@ -1,0 +1,12 @@
+table_create Memos TABLE_PAT_KEY ShortText
+table_create Tags TABLE_PAT_KEY ShortText
+
+column_create Memos tag COLUMN_SCALAR Tags
+column_create Tags memos_tag COLUMN_INDEX Memos tag
+
+load --table Memos
+[
+{"_key": "Groonga is a full text search engine.", "tag": "groonga"}
+]
+
+select Tags --filter true --command_version 2

--- a/test/command/suite/select/output/reference/key/command_version2.expected
+++ b/test/command/suite/select/output/reference/key/command_version2.expected
@@ -1,0 +1,40 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Bookmarks TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Bookmarks user COLUMN_SCALAR Users
+[[0,0.0,0.0],true]
+load --table Bookmarks
+[
+{"_key": "http://groonga.org/", "user": "mori"}
+]
+[[0,0.0,0.0],1]
+select Bookmarks --output_columns _key,user._key --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "user._key",
+          "ShortText"
+        ]
+      ],
+      [
+        "http://groonga.org/",
+        "mori"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/output/reference/key/command_version2.test
+++ b/test/command/suite/select/output/reference/key/command_version2.test
@@ -1,0 +1,11 @@
+table_create Users TABLE_HASH_KEY ShortText
+
+table_create Bookmarks TABLE_HASH_KEY ShortText
+column_create Bookmarks user COLUMN_SCALAR Users
+
+load --table Bookmarks
+[
+{"_key": "http://groonga.org/", "user": "mori"}
+]
+
+select Bookmarks --output_columns _key,user._key --command_version 2

--- a/test/command/suite/select/output/score/command_version2.expected
+++ b/test/command/suite/select/output/score/command_version2.expected
@@ -1,0 +1,36 @@
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is full text search engine."}
+]
+[[0,0.0,0.0],1]
+select Memos --filter true --output_columns _key,_score --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Groonga is full text search engine.",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/output/score/command_version2.test
+++ b/test/command/suite/select/output/score/command_version2.test
@@ -1,0 +1,8 @@
+table_create Memos TABLE_HASH_KEY ShortText
+
+load --table Memos
+[
+{"_key": "Groonga is full text search engine."}
+]
+
+select Memos --filter true --output_columns _key,_score --command_version 2


### PR DESCRIPTION
grn_expr_exec() uses grn_obj_get_value_() that returns a pointer to
the value and value size. So we can't get value that is not owned by
object with grn_obj_get_value_(). GRN_COLUMN_INDEX returns estimate
size as value and it is not owned value. In other words, we can't use
grn_obj_get_value_() for GRN_COLUMN_INDEX.

grn_obj_get_value() writes value to the passed grn_obj. So
grn_obj_get_value() can returns not owned value.

grn_obj_get_value_() is lighter API rather than grn_obj_get_value()
because grn_obj_get_value_() is just returns a pointer. It doesn't
write the value. Maybe, it is the reason why grn_expr_exec() uses
grn_obj_get_value_().

But grn_expr_exec() always writes value returned from
grn_obj_get_value_(). There is no speed merit. So we can use
grn_obj_get_value() rather than grn_obj_get_value_() without speed
down.

We can get value of GRN_COLUMN_INDEX by using grn_obj_get_value().