### PR TITLE
Change the default internal weight to 1 from 0

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1,5 +1,5 @@
 /* -*- c-basic-offset: 2 -*- */
-/* Copyright(C) 2009-2013 Brazil
+/* Copyright(C) 2009-2014 Brazil
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -2807,7 +2807,7 @@ grn_obj_search_accessor(grn_ctx *ctx, grn_obj *obj, grn_obj *query,
           posting.rid = *record_id;
           posting.sid = 1;
           posting.pos = 0;
-          posting.weight = recinfo->score - 1;
+          posting.weight = recinfo->score;
           grn_ii_posting_add(ctx, &posting, (grn_hash *)res, op);
         });
         grn_ii_resolve_sel_and(ctx, (grn_hash *)res, op);
@@ -3976,7 +3976,7 @@ grn_vector_decode(grn_ctx *ctx, grn_obj *v, const char *data, uint32_t data_size
       GRN_B_DEC(l, p);
       vp->length = l;
       vp->offset = o;
-      vp->weight = 0;
+      vp->weight = 1;
       vp->domain = 0;
       o += l;
     }
@@ -9706,7 +9706,8 @@ set_vector(grn_ctx *ctx, grn_obj *column, grn_id id, grn_obj *vector)
           if (!cast_failed) {
             grn_vector_add_element(ctx, &buf,
                                    GRN_TEXT_VALUE(element),
-                                   GRN_TEXT_LEN(element), 0,
+                                   GRN_TEXT_LEN(element),
+                                   1,
                                    element->header.domain);
           }
           if (element == &casted_element) { GRN_OBJ_FIN(ctx, element); }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -4322,7 +4322,7 @@ scan_info_build_find_index_column_inverted_index(grn_ctx *ctx,
   uint32_t offset = 0;
   grn_obj *index;
   int sid = 0;
-  int32_t weight = 0;
+  int32_t weight = 1;
 
   index = ec->value;
   if (n_rest_codes > 2 &&
@@ -4968,7 +4968,7 @@ grn_table_select_index(grn_ctx *ctx, grn_obj *table, scan_info *si,
           grn_ii_posting posting;
           posting.sid = 1;
           posting.pos = 0;
-          posting.weight = 0;
+          posting.weight = 1;
           switch (a->action) {
           case GRN_ACCESSOR_GET_ID :
             GRN_UINT32_INIT(&dest, 0);
@@ -5043,7 +5043,7 @@ grn_table_select_index(grn_ctx *ctx, grn_obj *table, scan_info *si,
           grn_ii_posting posting;
           posting.sid = 1;
           posting.pos = 0;
-          posting.weight = 0;
+          posting.weight = 1;
           switch (a->action) {
           case GRN_ACCESSOR_GET_ID :
             /* todo */
@@ -6935,7 +6935,7 @@ grn_column_filter(grn_ctx *ctx, grn_obj *column,
   uint32_t value_ = grn_atoui(GRN_TEXT_VALUE(value), GRN_BULK_CURR(value), NULL);
   posting.sid = 1;
   posting.pos = 0;
-  posting.weight = 0;
+  posting.weight = 1;
   GRN_COLUMN_EACH(ctx, column, id, vp, {
     if (*vp < value_) {
       posting.rid = id;

--- a/test/command/suite/select/adjuster/multiple.expected
+++ b/test/command/suite/select/adjuster/multiple.expected
@@ -53,15 +53,15 @@ select Memos   --filter true   --adjuster 'tags @ "groonga" * 4 + tags @ "mroong
       ],
       [
         "Groonga is fast",
-        405
+        401
       ],
       [
         "Mroonga is also fast",
-        348
+        341
       ],
       [
         "Ruby is an object oriented script language",
-        203
+        201
       ]
     ]
   ]

--- a/test/command/suite/select/adjuster/no_factor.expected
+++ b/test/command/suite/select/adjuster/no_factor.expected
@@ -53,11 +53,11 @@ select Memos   --filter true   --adjuster 'tags @ "groonga" + tags @ "mroonga"' 
       ],
       [
         "Groonga is fast",
-        102
+        101
       ],
       [
         "Mroonga is also fast",
-        113
+        111
       ],
       [
         "Ruby is an object oriented script language",

--- a/test/command/suite/select/adjuster/not_all_match.expected
+++ b/test/command/suite/select/adjuster/not_all_match.expected
@@ -56,11 +56,11 @@ select Memos   --filter '_id != 1'   --adjuster 'tags @ "groonga" * 1'   --outpu
       ],
       [
         "Groonga is fast",
-        102
+        101
       ],
       [
         "Mroonga is also fast",
-        12
+        11
       ],
       [
         "Ruby is an object oriented script language",

--- a/test/command/suite/select/adjuster/one.expected
+++ b/test/command/suite/select/adjuster/one.expected
@@ -53,11 +53,11 @@ select Memos   --filter true   --adjuster 'tags @ "groonga" * 2'   --output_colu
       ],
       [
         "Groonga is fast",
-        203
+        201
       ],
       [
         "Mroonga is also fast",
-        23
+        21
       ],
       [
         "Ruby is an object oriented script language",

--- a/test/command/suite/select/match_columns/weight/forward_index.expected
+++ b/test/command/suite/select/match_columns/weight/forward_index.expected
@@ -53,11 +53,11 @@ select Memos   --match_columns 'tags * 10'   --query groonga   --output_columns 
       ],
       [
         "Groonga is fast",
-        1010
+        1000
       ],
       [
         "Mroonga is also fast",
-        110
+        100
       ]
     ]
   ]

--- a/test/command/suite/select/match_columns/weight/nested_forward_index.expected
+++ b/test/command/suite/select/match_columns/weight/nested_forward_index.expected
@@ -97,15 +97,15 @@ select Programmers   --match_columns 'products.tags * 10'   --query groonga   --
       ],
       [
         "daijiro",
-        1520
+        1500
       ],
       [
         "kou",
-        1630
+        1600
       ],
       [
         "maruyama",
-        510
+        500
       ]
     ]
   ]

--- a/test/command/suite/select/query/forward_index.expected
+++ b/test/command/suite/select/query/forward_index.expected
@@ -53,11 +53,11 @@ select Memos   --match_columns tags   --query groonga   --output_columns _key,_s
       ],
       [
         "Groonga is fast",
-        101
+        100
       ],
       [
         "Mroonga is also fast",
-        11
+        10
       ]
     ]
   ]


### PR DESCRIPTION
If the default internal weight is 0, "weight 10" produces "score
11". It is strange.

The following chunks in ii.c may be wrong:

```
@@ -5705,7 +5705,7 @@ grn_ii_similar_search(grn_ctx *ctx, grn_ii *ii,
         while (grn_ii_cursor_next(ctx, c)) {
           pos = c->post;
           if ((w2 = get_weight(ctx, s, pos->rid, pos->sid, wvm, optarg))) {
-            res_add(ctx, s, (grn_rset_posinfo *) pos, *w1 * w2 * (pos->tf + pos->weight), op);
+            res_add(ctx, s, (grn_rset_posinfo *) pos, *w1 * w2 * pos->tf * pos->weight, op);
           }
         }
       }

@@ -5926,6 +5926,7 @@ grn_ii_select(grn_ctx *ctx, grn_ii *ii, const char *string, unsigned int string_
               if (max - min <= max_interval) {
                 if (rep) { pi.pos = min; res_add(ctx, s, &pi, weight, op); }
                 noccur++;
+                tscore += ti->p->weight; /* FIXME: Is it right? */
                 if (ti->pos == max + 1) {
                   break;
                 }

@@ -5950,14 +5951,14 @@ grn_ii_select(grn_ctx *ctx, grn_ii *ii, const char *string, unsigned int string_
...
-              tscore += score;
+              tscore += score / count;
               score = 0; count = 0; pos++;
               noccur++;
...

@@ -5950,14 +5951,14 @@ grn_ii_select(grn_ctx *ctx, grn_ii *ii, const char *string, unsigned int string_
...
             }
           }
         }
-        if (noccur && !rep) { res_add(ctx, s, &pi, (noccur + tscore) * weight, op); }
+        if (noccur && !rep) { res_add(ctx, s, &pi, (noccur * tscore) * weight, op); }
```
