### PR TITLE
Added Aarch64 Atomics

### DIFF
--- a/lib/groonga_in.h
+++ b/lib/groonga_in.h
@@ -499,8 +499,8 @@ typedef int grn_cond;
                                                         : "=&r"(r)               \
                                                         : "r"(p), "r"(i)         \
                                                         :"x0", "memory");
-#  define GRN_BIT_SCAN_REV(v,r)  __asm__ __volatile__ ("clz %0, %1;mov x9, #63;sub %0, x9, %0;":"=r"(r):"r"(v):"x9")
-#  define GRN_BIT_SCAN_REV0(v,r)  GRN_BIT_SCAN_REV(v, r)
+#  define GRN_BIT_SCAN_REV(v,r)  __asm__ __volatile__ ("clz %0, %1;mov x9, #63;sub %0, x9, %0;dsb sy;":"=r"(r):"r"(v):"x9")
+#  define GRN_BIT_SCAN_REV0(v,r)  __asm__ __volatile__ ("clz %0, %1;mov x9, #63;sub %0, x9, %0;mov x9, #0;cmp %0, x9;csel %0, %0, x9, ge;dsb sy;":"=r"(r):"r"(v):"x9", "cc")
 # else /* ATOMIC ADD */
 /* todo */
 #  define GRN_BIT_SCAN_REV(v,r)  for (r = 31; r && !((1 << r) & v); r--)


### PR DESCRIPTION
I added the Aarch64 version of Groonga's atomics that were written in assembly. I have successfully built Groonga with the new code on Qemu emulating Aarch64. I didn't test Groonga with the new code though. Maybe somebody with more experience with Groonga can test it for me?
