### PR TITLE
doc select:fix default drilldown_output_columns

### DIFF
--- a/doc/source/reference/commands/select.txt
+++ b/doc/source/reference/commands/select.txt
@@ -34,7 +34,7 @@ Syntax
          [limit=10]
          [drilldown=null]
          [drilldown_sortby=null]
-         [drilldown_output_columns=null]
+         [drilldown_output_columns="_key, _nsubrecs"]
          [drilldown_offset=0]
          [drilldown_limit=10]
          [cache=yes]


### PR DESCRIPTION
Because default value is "_key, _nsubrecs"

https://github.com/groonga/groonga/blob/master/lib/proc.c#L377
