### PR TITLE
normalize:fix a crash bug when object is not normalizer

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -3006,7 +3006,9 @@ proc_normalize(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
     normalizer = grn_ctx_get(ctx,
                              GRN_TEXT_VALUE(normalizer_name),
                              GRN_TEXT_LEN(normalizer_name));
-    if (!normalizer) {
+    if (!normalizer ||
+        normalizer->header.type != GRN_PROC ||
+        grn_proc_get_type(ctx, normalizer) != GRN_PROC_NORMALIZER) {
       ERR(GRN_INVALID_ARGUMENT,
           "unknown normalizer: <%.*s>",
           (int)GRN_TEXT_LEN(normalizer_name),


### PR DESCRIPTION
I fixed the yoku0825 reports bug.

refs [[groonga-dev,02409]](http://sourceforge.jp/projects/groonga/lists/archive/dev/2014-June/002411.html)

I didn't create the test because of the error case.

The following is the error test.

```
> normalize TokenBigram "aBc"
[[-22,1401957669.16034,0.000719547271728516,"unknown normalizer: <TokenBigram>",[["proc_normalize","proc.c",3015]]],""
> normalize LongText "aBc"
[[-22,1401957690.85734,0.000305891036987305,"unknown normalizer: <LongText>",[["proc_normalize","proc.c",3015]]],""]
> normalize select "aBc"
[[-22,1401957710.69732,0.000345706939697266,"unknown normalizer: <select>",[["proc_normalize","proc.c",3015]]],""]

> normalize NormalizerAuto "aBc"
[[0,1401957736.58533,9.25064086914062e-05],{"normalized":"abc","types":[],"checks":[]}]
```
