### PR TITLE
plugin:add initial setting API for command plugin

### DIFF
--- a/include/groonga/plugin.h
+++ b/include/groonga/plugin.h
@@ -215,6 +215,30 @@ GRN_API int grn_plugin_charlen(grn_ctx *ctx, const char *str_ptr,
 GRN_API int grn_plugin_isspace(grn_ctx *ctx, const char *str_ptr,
                                unsigned int str_length, grn_encoding encoding);
 
+/*
+  grn_plugin_expr_var_init() initializes a grn_expr_var.
+
+  If `name_size` is negative, `name` must be
+  NUL-terminated. `name_size` is computed by `strlen(name)` for the case.
+*/
+
+GRN_API grn_rc grn_plugin_expr_var_init(grn_ctx *ctx,
+                                        grn_expr_var *var,
+                                        const char *name,
+                                        int name_size);
+
+/*
+  grn_plugin_command_create() creates a command.
+
+  If `name_size` is negative, `name` must be
+  NUL-terminated. `name_size` is computed by `strlen(name)` for the case.
+*/
+GRN_API grn_obj * grn_plugin_command_create(grn_ctx *ctx,
+                                            const char *name,
+                                            int name_size,
+                                            grn_proc_func func,
+                                            unsigned int n_vars,
+                                            grn_expr_var *vars);
 
 
 #ifdef __cplusplus

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -51,6 +51,19 @@ static grn_critical_section grn_plugins_lock;
 #  define grn_dl_clear_error()
 #endif
 
+static int
+compute_name_size(const char *name, int name_size)
+{
+  if (name_size < 0) {
+    if (name) {
+      name_size = strlen(name);
+    } else {
+      name_size = 0;
+    }
+  }
+  return name_size;
+}
+
 grn_id
 grn_plugin_reference(grn_ctx *ctx, const char *filename)
 {
@@ -638,13 +651,7 @@ grn_obj *
 grn_plugin_proc_get_var(grn_ctx *ctx, grn_user_data *user_data,
                         const char *name, int name_size)
 {
-  if (name_size < 0) {
-    if (name) {
-      name_size = strlen(name);
-    } else {
-      name_size = 0;
-    }
-  }
+  name_size = compute_name_size(name, name_size);
   return grn_proc_get_var(ctx, user_data, name, name_size);
 }
 
@@ -716,4 +723,30 @@ grn_plugin_isspace(grn_ctx *ctx, const char *str_ptr,
     break;
   }
   return 0;
+}
+
+grn_rc
+grn_plugin_expr_var_init(grn_ctx *ctx,
+                         grn_expr_var *var,
+                         const char *name,
+                         int name_size)
+{
+  var->name = name;
+  var->name_size = compute_name_size(name, name_size);
+  GRN_TEXT_INIT(&var->value, 0);
+  return GRN_SUCCESS;
+}
+
+grn_obj *
+grn_plugin_command_create(grn_ctx *ctx,
+                          const char *name,
+                          int name_size,
+                          grn_proc_func func,
+                          unsigned int n_vars,
+                          grn_expr_var *vars)
+{
+  name_size = compute_name_size(name, name_size);
+  grn_proc_create(ctx, name, name_size, GRN_PROC_COMMAND,
+                  func, NULL, NULL, n_vars, vars);
+  return GRN_SUCCESS;
 }


### PR DESCRIPTION
I added initial setting plugin API to make it easy to create a command plugin. 

refs [[groonga-dev,02344]](http://sourceforge.jp/projects/groonga/lists/archive/dev/2014-May/002344.html)

If this is merge, I will document it later.

Should I be modified to use this API in the following builtin plugins?

[groonga/plugins/ruby/eval.c](https://github.com/groonga/groonga/blob/master/plugins/ruby/eval.c)
[groonga/plugins/ruby/load.c](https://github.com/groonga/groonga/blob/master/plugins/ruby/load.c)
[groonga/plugins/ruby/ruby_plugin.h](https://github.com/groonga/groonga/blob/master/plugins/ruby/ruby_plugin.h)
[groonga/plugins/suggest/suggest.c](https://github.com/groonga/groonga/blob/master/plugins/suggest/suggest.c)
[groonga/plugins/table/table.c](https://github.com/groonga/groonga/blob/master/plugins/table/table.c)
