### PR TITLE
Support weight in UVECTOR

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -896,6 +896,19 @@ GRN_API unsigned int grn_vector_get_element(grn_ctx *ctx, grn_obj *vector,
                                             unsigned int *weight, grn_id *domain);
 
 /*-------------------------------------------------------------
+ * grn_uvector
+*/
+
+GRN_API unsigned int grn_uvector_size(grn_ctx *ctx, grn_obj *uvector);
+
+GRN_API grn_rc grn_uvector_add_element(grn_ctx *ctx, grn_obj *vector,
+                                       grn_id id, unsigned int weight);
+
+GRN_API grn_id grn_uvector_get_element(grn_ctx *ctx, grn_obj *uvector,
+                                       unsigned int offset,
+                                       unsigned int *weight);
+
+/*-------------------------------------------------------------
  * API for hook
  */
 


### PR DESCRIPTION
If uvector->header.impl_flags has GRN_OBJ_WITH_WEIGHT flag, the
uvector has weight information.

If an uvector has weight information, it uses the following format:

```
|grn_id1|weight1|grn_id2|weight2|...|
 uint    uint    uint    uint
```

Uvector without weight uses the following format:

```
|grn_id1|grn_id2|...|
 uint    uint
```
