### PR TITLE
Really support weight in uvector

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -37,7 +37,7 @@ typedef struct {
   unsigned int weight;
 } weight_uvector_entry;
 
-#define IS_WEIGHT_UVECTOR(obj) ((obj)->header.impl_flags & GRN_OBJ_WITH_WEIGHT)
+#define IS_WEIGHT_UVECTOR(obj) ((obj)->header.flags & GRN_OBJ_WITH_WEIGHT)
 
 #define NEXT_ADDR(p) (((byte *)(p)) + sizeof(*(p)))
 
@@ -5625,7 +5625,7 @@ grn_obj_set_value_column_var_size_vector_uvector(grn_ctx *ctx, grn_obj *column,
   if (need_convert) {
     unsigned int i, n;
     GRN_VALUE_FIX_SIZE_INIT(&uvector, GRN_OBJ_VECTOR, value->header.domain);
-    uvector.header.impl_flags |= uvector_flags;
+    uvector.header.flags |= uvector_flags;
     n = grn_uvector_size(ctx, value);
     for (i = 0; i < n; i++) {
       grn_id id;
@@ -5982,9 +5982,9 @@ grn_obj_get_value_column_vector(grn_ctx *ctx, grn_obj *obj,
     grn_ja_get_value(ctx, (grn_ja *)obj, id, value);
     value->header.type = GRN_UVECTOR;
     if (obj->header.flags & GRN_OBJ_WITH_WEIGHT) {
-      value->header.impl_flags |= GRN_OBJ_WITH_WEIGHT;
+      value->header.flags |= GRN_OBJ_WITH_WEIGHT;
     } else {
-      value->header.impl_flags &= ~GRN_OBJ_WITH_WEIGHT;
+      value->header.flags &= ~GRN_OBJ_WITH_WEIGHT;
     }
   }
 
@@ -8099,7 +8099,7 @@ grn_obj_ensure_vector(grn_ctx *ctx, grn_obj *obj)
 {
   if (obj->header.type != GRN_VECTOR) { grn_bulk_fin(ctx, obj); }
   obj->header.type = GRN_VECTOR;
-  obj->header.impl_flags &= ~GRN_OBJ_WITH_WEIGHT;
+  obj->header.flags &= ~GRN_OBJ_WITH_WEIGHT;
 }
 
 static void
@@ -8107,7 +8107,7 @@ grn_obj_ensure_bulk(grn_ctx *ctx, grn_obj *obj)
 {
   if (obj->header.type == GRN_VECTOR) { VECTOR_CLEAR(ctx, obj); }
   obj->header.type = GRN_BULK;
-  obj->header.impl_flags &= ~GRN_OBJ_WITH_WEIGHT;
+  obj->header.flags &= ~GRN_OBJ_WITH_WEIGHT;
 }
 
 grn_rc

--- a/lib/str.c
+++ b/lib/str.c
@@ -2000,7 +2000,8 @@ grn_bulk_truncate(grn_ctx *ctx, grn_obj *bulk, unsigned int len)
     if (GRN_BULK_BUFSIZE < len) {
       return grn_bulk_space_clear(ctx, bulk, len);
     } else {
-      bulk->header.flags = len;
+      bulk->header.flags &= ~GRN_BULK_BUFSIZE_MAX;
+      bulk->header.flags += len;
     }
   }
   return GRN_SUCCESS;


### PR DESCRIPTION
The current bulk stores its value size into flags field when value
embedded mode (= !GRN_BULK_OUTP(bulk)). We can't use flags field to
store GRN_OBJ_WITH_WEIGHT flag when the bulk is value embedded mode.

This commit changes flags behavior in value embedded mode. The current
GRN_BULK_BUFSIZE is 24 bytes. So we can use higher order bits in flags
field. To use higher order bits in flags field, this change use mask
to get value size in value embedded mode.

This change will not break API and ABI. But we need to rebuild related
codes that use uvector with weight. Rroonga will be the code. It will
not be a problem because there are no these codes for now. Newer codes
must be built.

TODO:
- Support outputting uvector with weight in select command and dump command.
