### PR TITLE
between:support outside of key range

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -4645,7 +4645,7 @@ selector_between(grn_ctx *ctx, grn_obj *table, grn_obj *index,
   grn_rc rc = GRN_SUCCESS;
   int offset = 0;
   int limit = -1;
-  int flags = GRN_CURSOR_ASCENDING | GRN_CURSOR_BY_ID;
+  int flags = GRN_CURSOR_ASCENDING | GRN_CURSOR_BY_KEY;
   between_data data;
   grn_obj casted_min, casted_max;
   grn_obj *used_min = NULL;

--- a/test/command/suite/select/function/between/with_index/range_outside/max_over.expected
+++ b/test/command/suite/select/function/between/with_index/range_outside/max_over.expected
@@ -1,0 +1,61 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+table_create Ages TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+column_create Ages users_age COLUMN_INDEX Users age
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 18, "exclude", 22, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ],
+      [
+        5,
+        "eric",
+        21
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/with_index/range_outside/max_over.test
+++ b/test/command/suite/select/function/between/with_index/range_outside/max_over.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+table_create Ages TABLE_PAT_KEY Int32
+column_create Ages users_age COLUMN_INDEX Users age
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 18, "exclude", 22, "exclude")'

--- a/test/command/suite/select/function/between/with_index/range_outside/min_less.expected
+++ b/test/command/suite/select/function/between/with_index/range_outside/min_less.expected
@@ -1,0 +1,61 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+table_create Ages TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+column_create Ages users_age COLUMN_INDEX Users age
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 16, "exclude", 20, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        17
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/with_index/range_outside/min_less.test
+++ b/test/command/suite/select/function/between/with_index/range_outside/min_less.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+table_create Ages TABLE_PAT_KEY Int32
+column_create Ages users_age COLUMN_INDEX Users age
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 16, "exclude", 20, "exclude")'

--- a/test/command/suite/select/function/between/with_index/range_outside/min_less_and_max_over.expected
+++ b/test/command/suite/select/function/between/with_index/range_outside/min_less_and_max_over.expected
@@ -1,0 +1,71 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+table_create Ages TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+column_create Ages users_age COLUMN_INDEX Users age
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 16, "exclude", 22, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        5
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        17
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ],
+      [
+        5,
+        "eric",
+        21
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/with_index/range_outside/min_less_and_max_over.test
+++ b/test/command/suite/select/function/between/with_index/range_outside/min_less_and_max_over.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+table_create Ages TABLE_PAT_KEY Int32
+column_create Ages users_age COLUMN_INDEX Users age
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 16, "exclude", 22, "exclude")'

--- a/test/command/suite/select/function/between/without_index/range_outside/max_over.expected
+++ b/test/command/suite/select/function/between/without_index/range_outside/max_over.expected
@@ -1,0 +1,57 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 18, "exclude", 22, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ],
+      [
+        5,
+        "eric",
+        21
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/without_index/range_outside/max_over.test
+++ b/test/command/suite/select/function/between/without_index/range_outside/max_over.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 18, "exclude", 22, "exclude")'

--- a/test/command/suite/select/function/between/without_index/range_outside/min_less.expected
+++ b/test/command/suite/select/function/between/without_index/range_outside/min_less.expected
@@ -1,0 +1,57 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 16, "exclude", 20, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        17
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/without_index/range_outside/min_less.test
+++ b/test/command/suite/select/function/between/without_index/range_outside/min_less.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 16, "exclude", 20, "exclude")'

--- a/test/command/suite/select/function/between/without_index/range_outside/min_less_and_max_over.expected
+++ b/test/command/suite/select/function/between/without_index/range_outside/min_less_and_max_over.expected
@@ -1,0 +1,67 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 16, "exclude", 22, "exclude")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        5
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        1,
+        "alice",
+        17
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ],
+      [
+        5,
+        "eric",
+        21
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/without_index/range_outside/min_less_and_max_over.test
+++ b/test/command/suite/select/function/between/without_index/range_outside/min_less_and_max_over.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 16, "exclude", 22, "exclude")'


### PR DESCRIPTION
Returns empty record If between function specify outside of key range.

Returns correct record if cursor flag is changed to `GRN_CURSOR_BY_KEY` from `GRN_CURSOR_BY_ID`.

Is this fix correct?
