### PR TITLE
tokenize: support mode

### DIFF
--- a/test/command/suite/tokenize/add_mode.expected
+++ b/test/command/suite/tokenize/add_mode.expected
@@ -1,0 +1,30 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE ADD
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "あい",
+      "position": 0
+    },
+    {
+      "value": "い",
+      "position": 1
+    },
+    {
+      "value": "ab",
+      "position": 2
+    },
+    {
+      "value": "アイ",
+      "position": 3
+    },
+    {
+      "value": "イ",
+      "position": 4
+    }
+  ]
+]

--- a/test/command/suite/tokenize/add_mode.test
+++ b/test/command/suite/tokenize/add_mode.test
@@ -1,0 +1,1 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE ADD

--- a/test/command/suite/tokenize/get_mode.expected
+++ b/test/command/suite/tokenize/get_mode.expected
@@ -1,0 +1,22 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE GET
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "あい",
+      "position": 0
+    },
+    {
+      "value": "ab",
+      "position": 2
+    },
+    {
+      "value": "アイ",
+      "position": 3
+    }
+  ]
+]

--- a/test/command/suite/tokenize/get_mode.test
+++ b/test/command/suite/tokenize/get_mode.test
@@ -1,0 +1,1 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE GET

--- a/test/command/suite/tokenize/invalid/mode/unknown_mode.expected
+++ b/test/command/suite/tokenize/invalid/mode/unknown_mode.expected
@@ -1,0 +1,3 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE UNKNOWN
+[[[-22,0.0,0.0],"[tokenize] invalid mode: <UNKNOWN>"],[]]
+#|e| [tokenize] invalid mode: <UNKNOWN>

--- a/test/command/suite/tokenize/invalid/mode/unknown_mode.test
+++ b/test/command/suite/tokenize/invalid/mode/unknown_mode.test
@@ -1,0 +1,1 @@
+tokenize TokenBigram "あいabアイ" NormalizerAuto NONE UNKNOWN


### PR DESCRIPTION
Ngram tokenizer splits with different rules by `GRN_TOKEN_GET`/`GRN_TOKEN_ADD` mode.
I want to debug the different mode in the tokenize command.
