### PR TITLE
Make grn_obj_cast() for table with nonexistent key failure

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -4635,7 +4635,11 @@ grn_obj_is_persistent(grn_ctx *ctx, grn_obj *obj)
       if (GRN_BULK_VSIZE(p_key)) {\
         id = addp ? grn_table_add_by_key(ctx, table, p_key, NULL)\
                   : grn_table_get_by_key(ctx, table, p_key);\
-        if (id) { GRN_RECORD_SET(ctx, dest, id); }\
+        if (id) {\
+          GRN_RECORD_SET(ctx, dest, id);\
+        } else {\
+          rc = GRN_INVALID_ARGUMENT;\
+        }\
       } else {\
         GRN_RECORD_SET(ctx, dest, GRN_ID_NIL);\
       }\


### PR DESCRIPTION
The current behavior doesn't report any error and not set any value.
Users should check both return value of grn_obj_cast() and
GRN_BULK_VSIE(dest) is increased.

With this change, users only check return value of grn_obj_cast().