### PR TITLE
mrb mrb_ctx.h: fix error: unknown type name 'mrb_state'

### DIFF
--- a/lib/mrb/mrb_ctx.h
+++ b/lib/mrb/mrb_ctx.h
@@ -26,7 +26,9 @@ extern "C" {
 #endif
 
 void grn_mrb_ctx_init(grn_ctx *ctx);
+#ifdef GRN_WITH_MRUBY
 void grn_mrb_ctx_check(mrb_state *mrb);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
If it disables `--enable-mruby`, `mrb_state` type doesn't exist in this scope.
It generates following error:

``` log
CC       ctx_impl_mrb.lo
In file included from ctx_impl_mrb.c:26:
./mrb/mrb_ctx.h:29:24: error: unknown type name 'mrb_state'
void grn_mrb_ctx_check(mrb_state *mrb);
                       ^
1 error generated.
make[4]: *** [ctx_impl_mrb.lo] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```
