### PR TITLE
doc: add client section

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -1,6 +1,7 @@
 absolute_source_files = \
 	$(top_srcdir)/doc/source/__init__.py \
 	$(top_srcdir)/doc/source/characteristic.rst \
+	$(top_srcdir)/doc/source/client.rst \
 	$(top_srcdir)/doc/source/community.rst \
 	$(top_srcdir)/doc/source/conf.py \
 	$(top_srcdir)/doc/source/contribution.rst \
@@ -542,6 +543,7 @@ absolute_theme_files = \
 source_files_relative_from_doc_dir = \
 	source/__init__.py \
 	source/characteristic.rst \
+	source/client.rst \
 	source/community.rst \
 	source/conf.py \
 	source/contribution.rst \
@@ -1082,6 +1084,7 @@ theme_files_relative_from_doc_dir = \
 
 po_files = \
 	characteristic.po \
+	client.po \
 	community.po \
 	conf.po \
 	contribution.po \
@@ -1101,6 +1104,7 @@ po_files = \
 
 po_files_relative_from_locale_dir = \
 	LC_MESSAGES/characteristic.po \
+	LC_MESSAGES/client.po \
 	LC_MESSAGES/community.po \
 	LC_MESSAGES/conf.po \
 	LC_MESSAGES/contribution.po \
@@ -1120,6 +1124,7 @@ po_files_relative_from_locale_dir = \
 
 edit_po_files = \
 	characteristic.edit \
+	client.edit \
 	community.edit \
 	conf.edit \
 	contribution.edit \
@@ -1139,6 +1144,7 @@ edit_po_files = \
 
 edit_po_files_relative_from_locale_dir = \
 	LC_MESSAGES/characteristic.edit \
+	LC_MESSAGES/client.edit \
 	LC_MESSAGES/community.edit \
 	LC_MESSAGES/conf.edit \
 	LC_MESSAGES/contribution.edit \
@@ -1158,6 +1164,7 @@ edit_po_files_relative_from_locale_dir = \
 
 mo_files = \
 	characteristic.mo \
+	client.mo \
 	community.mo \
 	conf.mo \
 	contribution.mo \
@@ -1177,6 +1184,7 @@ mo_files = \
 
 mo_files_relative_from_locale_dir = \
 	LC_MESSAGES/characteristic.mo \
+	LC_MESSAGES/client.mo \
 	LC_MESSAGES/community.mo \
 	LC_MESSAGES/conf.mo \
 	LC_MESSAGES/contribution.mo \
@@ -1198,6 +1206,7 @@ html_files_relative_from_locale_dir = \
 	html/.buildinfo \
 	html/_images/geo-points.png \
 	html/_sources/characteristic.txt \
+	html/_sources/client.txt \
 	html/_sources/community.txt \
 	html/_sources/contribution.txt \
 	html/_sources/contribution/development.txt \
@@ -1391,6 +1400,7 @@ html_files_relative_from_locale_dir = \
 	html/_static/us.png \
 	html/_static/websupport.js \
 	html/characteristic.html \
+	html/client.html \
 	html/community.html \
 	html/contribution.html \
 	html/contribution/development.html \

--- a/doc/locale/en/LC_MESSAGES/client.po
+++ b/doc/locale/en/LC_MESSAGES/client.po
@@ -1,0 +1,44 @@
+# -*- po -*-
+# English translations for Groonga package.
+# Copyright (C) 2009-2014, Brazil, Inc
+# This file is distributed under the same license as the Groonga package.
+# Kouhei Sutou <kou@clear-code.com>, 2014.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Groonga 4.0.1\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2014-05-23 12:44+0900\n"
+"Last-Translator: Kouhei Sutou <kou@clear-code.com>\n"
+"Language-Team: English\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Client"
+msgstr "Client"
+
+msgid ""
+"Groonga supports the original protocol (:doc:`/spec/gqtp`), the memcached "
+"binary protocol and HTTP."
+msgstr ""
+"Groonga supports the original protocol (:doc:`/spec/gqtp`), the memcached "
+"binary protocol and HTTP."
+
+msgid ""
+"As HTTP and memcached binary protocol is matured protocol, you can use "
+"existing client libraries."
+msgstr ""
+"As HTTP and memcached binary protocol is matured protocol, you can use "
+"existing client libraries."
+
+msgid ""
+"There are some client libraries which provides convenient API to connect to "
+"Groonga server in some program languages. See `Client libraries <http://"
+"groonga.org/related-projects.html#libraries>`_ for details."
+msgstr ""
+"There are some client libraries which provides convenient API to connect to "
+"Groonga server in some program languages. See `Client libraries <http://"
+"groonga.org/related-projects.html#libraries>`_ for details."

--- a/doc/locale/ja/LC_MESSAGES/client.po
+++ b/doc/locale/ja/LC_MESSAGES/client.po
@@ -1,0 +1,44 @@
+# -*- po -*-
+# Japanese translations for 1.2.5 package.
+# Copyright (C) 2009-2011, Brazil, Inc
+# This file is distributed under the same license as the groonga package.
+# Kouhei Sutou <kou@clear-code.com>, 2011.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.2.5\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2014-02-05 12:02+0900\n"
+"Last-Translator: Kouhei Sutou <kou@clear-code.com>\n"
+"Language-Team: Japanese\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Client"
+msgstr "クライアント"
+
+msgid ""
+"Groonga supports the original protocol (:doc:`/spec/gqtp`), the memcached "
+"binary protocol and HTTP."
+msgstr ""
+"Groongaは、Groongaの専用プロトコルである :doc:`/spec/gqtp` 、memcachedバイナ"
+"リプロトコル、HTTPの三種類をサポートしています。"
+
+msgid ""
+"As HTTP and memcached binary protocol is matured protocol, you can use "
+"existing client libraries."
+msgstr ""
+"HTTPとmemcachedバイナリプロトコルは、枯れたプロトコルなので既存のクライアント"
+"ライブラリを利用することができます。"
+
+msgid ""
+"There are some client libraries which provides convenient API to connect to "
+"Groonga server in some program languages. See `Client libraries <http://"
+"groonga.org/related-projects.html#libraries>`_ for details."
+msgstr ""
+"いくつかのプログラミング言語ではGroongaサーバーに接続するための便利なAPIを提"
+"供するクライアントライブラリがあります。詳細は、`クライアントライブラリ "
+"<http://groonga.org/ja/related-projects.html#libraries>`_ を参照して下さい。"

--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -1,0 +1,19 @@
+.. -*- rst -*-
+.. Groonga Project
+
+.. highlightlang:: none
+
+Client
+======
+
+Groonga supports the original protocol (:doc:`/spec/gqtp`), the memcached
+binary protocol and HTTP.
+
+As HTTP and memcached binary protocol is matured protocol, you can use
+existing client libraries.
+
+There are some client libraries which provides convenient API to connect
+to Groonga server in some program languages. See `Client libraries
+<http://groonga.org/related-projects.html#libraries>`_ for details.
+
+

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -22,6 +22,7 @@ Groonga documentation
    suggest
    geolocation_search
    server
+   client
    reference
    spec
    limitations


### PR DESCRIPTION
「7. サーバー」と「8. リファレンスマニュアル」の間に「クライアント」というセクションを追加しました。

ドキュメントから[関連プロジェクト#クライアントライブラリ](http://groonga.org/related-projects.html#libraries)への導線を目的としており、非常に簡単な説明だけです。

関連プロジェクト#クライアントライブラリに、現状で動きそうなクライアントライブラリを試してみてのせていきます（できれば）。
