### PR TITLE
dump: check table key type for token_filters

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -2750,7 +2750,7 @@ dump_table(grn_ctx *ctx, grn_obj *outbuf, grn_obj *table,
     GRN_TEXT_PUTS(ctx, outbuf, " --normalizer ");
     dump_obj_name(ctx, outbuf, normalizer);
   }
-  {
+  if (table->header.type != GRN_TABLE_NO_KEY) {
     grn_obj token_filters;
     int n_token_filters;
 

--- a/test/command/suite/dump/schema/table/no_key/no_key.expected
+++ b/test/command/suite/dump/schema/table/no_key/no_key.expected
@@ -1,0 +1,5 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_NO_KEY
+

--- a/test/command/suite/dump/schema/table/no_key/no_key.test
+++ b/test/command/suite/dump/schema/table/no_key/no_key.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_NO_KEY
+
+dump


### PR DESCRIPTION
In case of `TABLE_NO_KEY`, `grn_obj_get_info(ctx, table, GRN_INFO_TOKEN_FILTERS, &token_filters)` outputs a following error message.

```
#|e| [info][get][token-filters] target object must be one of GRN_TABLE_HASH_KEY, GRN_TABLE_PAT_KEY and GRN_TABLE_DAT_KEY: 51
```
