### PR TITLE
packages deb: bundle token_filter stop word plugin

### DIFF
--- a/packages/debian/libgroonga0.install
+++ b/packages/debian/libgroonga0.install
@@ -1,4 +1,5 @@
 usr/lib/*/libgroonga*.so.*
 usr/lib/*/groonga/plugins/table/*
 usr/lib/*/groonga/plugins/query_expanders/*
+usr/lib/*/groonga/plugins/token_filters/*
 etc/groonga/synonyms.tsv


### PR DESCRIPTION
rpm package bundles token_filter plugin.
But, debian package does not bundle it.
It is unnatural. Let's bundle it!
