### PR TITLE
Fix memory leak in compress zlib/lzo column

### DIFF
--- a/lib/io.h
+++ b/lib/io.h
@@ -75,6 +75,7 @@ typedef struct {
 #if defined(WIN32) && defined(WIN32_FMO_EACH)
   HANDLE fmo;
 #endif /* defined(WIN32) && defined(WIN32_FMO_EACH) */
+  void *value;
 } grn_io_win;
 
 typedef struct {

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1102,6 +1102,12 @@ grn_parse_column_create_flags(grn_ctx *ctx, const char *nptr, const char *end)
     } else if (!memcmp(nptr, "COLUMN_INDEX", 12)) {
       flags |= GRN_OBJ_COLUMN_INDEX;
       nptr += 12;
+    } else if (!memcmp(nptr, "COMPRESS_ZLIB", 13)) {
+      flags |= GRN_OBJ_COMPRESS_ZLIB;
+      nptr += 13;
+    } else if (!memcmp(nptr, "COMPRESS_LZO", 12)) {
+      flags |= GRN_OBJ_COMPRESS_LZO;
+      nptr += 12;
     } else if (!memcmp(nptr, "WITH_SECTION", 12)) {
       flags |= GRN_OBJ_WITH_SECTION;
       nptr += 12;

--- a/test/command/suite/select/output/lzo/scalar.expected
+++ b/test/command/suite/select/output/lzo/scalar.expected
@@ -1,0 +1,55 @@
+table_create Entries TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR|COMPRESS_LZO Text
+[[0,0.0,0.0],true]
+load --table Entries
+[
+  {
+    "_key": "Groonga",
+    "content": "I found Groonga that is a fast fulltext search engine!"
+  },
+  {
+    "_key": "Mroonga",
+    "content": "I found Mroonga that is a MySQL storage engine to use Groonga!"
+  }
+]
+[[0,0.0,0.0],2]
+select Entries
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        "Groonga",
+        "I found Groonga that is a fast fulltext search engine!"
+      ],
+      [
+        2,
+        "Mroonga",
+        "I found Mroonga that is a MySQL storage engine to use Groonga!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/output/lzo/scalar.test
+++ b/test/command/suite/select/output/lzo/scalar.test
@@ -1,0 +1,16 @@
+table_create Entries TABLE_PAT_KEY ShortText
+column_create Entries content COLUMN_SCALAR|COMPRESS_LZO Text
+
+load --table Entries
+[
+  {
+    "_key": "Groonga",
+    "content": "I found Groonga that is a fast fulltext search engine!"
+  },
+  {
+    "_key": "Mroonga",
+    "content": "I found Mroonga that is a MySQL storage engine to use Groonga!"
+  }
+]
+
+select Entries

--- a/test/command/suite/select/output/zlib/scalar.expected
+++ b/test/command/suite/select/output/zlib/scalar.expected
@@ -1,0 +1,55 @@
+table_create Entries TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR|COMPRESS_ZLIB Text
+[[0,0.0,0.0],true]
+load --table Entries
+[
+  {
+    "_key": "Groonga",
+    "content": "I found Groonga that is a fast fulltext search engine!"
+  },
+  {
+    "_key": "Mroonga",
+    "content": "I found Mroonga that is a MySQL storage engine to use Groonga!"
+  }
+]
+[[0,0.0,0.0],2]
+select Entries
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "content",
+          "Text"
+        ]
+      ],
+      [
+        1,
+        "Groonga",
+        "I found Groonga that is a fast fulltext search engine!"
+      ],
+      [
+        2,
+        "Mroonga",
+        "I found Mroonga that is a MySQL storage engine to use Groonga!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/output/zlib/scalar.test
+++ b/test/command/suite/select/output/zlib/scalar.test
@@ -1,0 +1,16 @@
+table_create Entries TABLE_PAT_KEY ShortText
+column_create Entries content COLUMN_SCALAR|COMPRESS_ZLIB Text
+
+load --table Entries
+[
+  {
+    "_key": "Groonga",
+    "content": "I found Groonga that is a fast fulltext search engine!"
+  },
+  {
+    "_key": "Mroonga",
+    "content": "I found Mroonga that is a MySQL storage engine to use Groonga!"
+  }
+]
+
+select Entries


### PR DESCRIPTION
現在のGroongaでは、zlib圧縮、lzo圧縮させたカラムを参照すると、
伸長させるためにメモリアロケーションした`value`を開放するタイミング
がなく、メモリリークとなっています。
（既知の不具合で現在、デフォルトでは作れないようになっています。）

https://github.com/groonga/groonga/blob/master/lib/store.c#L1215

これを回避する方法として、`grn_io_win`に圧縮データを伸長させた値
へのポインタを保持するメンバ`value`を追加するのはいかがでしょうか？

`grn_io_win`にMALLOCしたポインタを保持させれば、`grn_ja_unref`で
メモリを開放させてやることができます。

これにより、APIに大きな変更を与えることなくzlib圧縮がメモリリーク
することなく使えるようになると思うのですがいかがでしょうか？

（そもそも`grn_io_win`に乗せるべき値ではないかもしれませんし、
APIの仕様を変えたほうがいいのかもしれませんが。。）

お手数ですが、ご検討ください。

伸長にかかるCPUコストやメモリアロケーションのコストにより、どれほど
利用価値があるものになるかはまだ検証できていませんが、zlibの圧縮率
は高く、Groongaはカラム指向でカラムごとに柔軟に設定できるので、
zlib圧縮が使えると非常に嬉しいなぁと考えています。
