### PR TITLE
Add LZ4 compression instead of LZO compression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -880,15 +880,15 @@ else
 fi
 AC_SUBST(GRN_WITH_ZLIB)
 
-# LZO
-AC_ARG_WITH(lzo,
-  [AS_HELP_STRING([--with-lzo],
-    [use LZO for data compression. [default=no]])],
-  [with_lzo="$withval"],
-  [with_lzo="no"])
-if test "x$with_lzo" = "xyes"; then
-  AC_DEFINE(GRN_WITH_LZO, [1], [with lzo])
-  AC_SEARCH_LIBS(lzo1_compress, lzo2, [], [AC_MSG_ERROR("No liblzo2 found")])
+# LZ4
+AC_ARG_WITH(lz4,
+  [AS_HELP_STRING([--with-lz4],
+    [use LZ4 for data compression. [default=no]])],
+  [with_lz4="$withval"],
+  [with_lz4="no"])
+if test "x$with_lz4" = "xyes"; then
+  AC_DEFINE(GRN_WITH_LZ4, [1], [with lz4])
+  AC_SEARCH_LIBS(LZ4_compress, lz4, [], [AC_MSG_ERROR("No liblz4 found")])
 fi
 
 # MeCab

--- a/include/groonga.h
+++ b/include/groonga.h
@@ -104,7 +104,7 @@ typedef enum {
   GRN_OPERATION_NOT_SUPPORTED = -58,
   GRN_ADDRESS_IS_IN_USE = -59,
   GRN_ZLIB_ERROR = -60,
-  GRN_LZO_ERROR = -61,
+  GRN_LZ4_ERROR = -61,
   GRN_STACK_OVER_FLOW = -62,
   GRN_SYNTAX_ERROR = -63,
   GRN_RETRY_MAX = -64,
@@ -300,7 +300,7 @@ typedef unsigned short int grn_obj_flags;
 #define GRN_OBJ_COMPRESS_MASK          (0x07<<4)
 #define GRN_OBJ_COMPRESS_NONE          (0x00<<4)
 #define GRN_OBJ_COMPRESS_ZLIB          (0x01<<4)
-#define GRN_OBJ_COMPRESS_LZO           (0x02<<4)
+#define GRN_OBJ_COMPRESS_LZ4           (0x02<<4)
 
 #define GRN_OBJ_WITH_SECTION           (0x01<<7)
 #define GRN_OBJ_WITH_WEIGHT            (0x01<<8)
@@ -791,7 +791,7 @@ typedef enum {
   GRN_INFO_PARTIAL_MATCH_THRESHOLD,
   GRN_INFO_II_SPLIT_THRESHOLD,
   GRN_INFO_SUPPORT_ZLIB,
-  GRN_INFO_SUPPORT_LZO,
+  GRN_INFO_SUPPORT_LZ4,
   GRN_INFO_NORMALIZER,
   GRN_INFO_TOKEN_FILTERS
 } grn_info_type;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(libgroonga
   ${RT_LIBS}
   ${PTHREAD_LIBS}
   ${Z_LIBS}
-  ${LZO2_LIBS}
+  ${LZ4_LIBS}
   ${DL_LIBS}
   ${WS2_32_LIBS})
 

--- a/lib/db.c
+++ b/lib/db.c
@@ -6195,17 +6195,17 @@ grn_obj_get_info(grn_ctx *ctx, grn_obj *obj, grn_info_type type, grn_obj *valueb
     GRN_BOOL_PUT(ctx, valuebuf, GRN_FALSE);
 #endif
     break;
-  case GRN_INFO_SUPPORT_LZO :
+  case GRN_INFO_SUPPORT_LZ4 :
     if (!valuebuf && !(valuebuf = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_BOOL))) {
       ERR(GRN_INVALID_ARGUMENT,
-          "failed to open value buffer for GRN_INFO_LZO_SUPPORT");
+          "failed to open value buffer for GRN_INFO_LZ4_SUPPORT");
       goto exit;
     }
-#ifdef GRN_WITH_LZO
+#ifdef GRN_WITH_LZ4
     GRN_BOOL_PUT(ctx, valuebuf, GRN_TRUE);
-#else /* GRN_WITH_LZO */
+#else /* GRN_WITH_LZ4 */
     GRN_BOOL_PUT(ctx, valuebuf, GRN_FALSE);
-#endif /* GRN_WITH_LZO */
+#endif /* GRN_WITH_LZ4 */
     break;
   default :
     if (!obj) {

--- a/lib/mrb/mrb_ctx.c
+++ b/lib/mrb/mrb_ctx.c
@@ -568,10 +568,10 @@ grn_mrb_ctx_check(mrb_state *mrb)
              "zlib error: <%s>(%d)",
              ctx->errbuf, ctx->rc);
     break;
-  case GRN_LZO_ERROR:
-    error_class = mrb_class_get_under(mrb, module, "LzoError");
+  case GRN_LZ4_ERROR:
+    error_class = mrb_class_get_under(mrb, module, "Lz4Error");
     snprintf(message, MESSAGE_SIZE,
-             "LZO error: <%s>(%d)",
+             "LZ4 error: <%s>(%d)",
              ctx->errbuf, ctx->rc);
     break;
   case GRN_STACK_OVER_FLOW:

--- a/lib/mrb/mrb_error.c
+++ b/lib/mrb/mrb_error.c
@@ -157,7 +157,7 @@ grn_mrb_error_init(grn_ctx *ctx)
                          error_class);
   mrb_define_class_under(mrb, module, "ZlibError",
                          error_class);
-  mrb_define_class_under(mrb, module, "LzoError",
+  mrb_define_class_under(mrb, module, "Lz4Error",
                          error_class);
   mrb_define_class_under(mrb, module, "StackOverFlow",
                          error_class);

--- a/lib/mrb/scripts/context/rc.rb
+++ b/lib/mrb/scripts/context/rc.rb
@@ -82,7 +82,7 @@ module Groonga
       OPERATION_NOT_SUPPORTED             = new(:operation_not_supported, -58)
       ADDRESS_IS_IN_USE                   = new(:address_is_in_use, -59)
       ZLIB_ERROR                          = new(:zlib_error, -60)
-      LZO_ERROR                           = new(:lzo_error, -61)
+      LZ4_ERROR                           = new(:lz4_error, -61)
       STACK_OVER_FLOW                     = new(:stack_over_flow, -62)
       SYNTAX_ERROR                        = new(:syntax_error, -63)
       RETRY_MAX                           = new(:retry_max, -64)

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1105,8 +1105,8 @@ grn_parse_column_create_flags(grn_ctx *ctx, const char *nptr, const char *end)
     } else if (!memcmp(nptr, "COMPRESS_ZLIB", 13)) {
       flags |= GRN_OBJ_COMPRESS_ZLIB;
       nptr += 13;
-    } else if (!memcmp(nptr, "COMPRESS_LZO", 12)) {
-      flags |= GRN_OBJ_COMPRESS_LZO;
+    } else if (!memcmp(nptr, "COMPRESS_LZ4", 12)) {
+      flags |= GRN_OBJ_COMPRESS_LZ4;
       nptr += 12;
     } else if (!memcmp(nptr, "WITH_SECTION", 12)) {
       flags |= GRN_OBJ_WITH_SECTION;
@@ -1191,8 +1191,8 @@ grn_column_create_flags_to_text(grn_ctx *ctx, grn_obj *buf, grn_obj_flags flags)
   case GRN_OBJ_COMPRESS_ZLIB:
     GRN_TEXT_PUTS(ctx, buf, "|COMPRESS_ZLIB");
     break;
-  case GRN_OBJ_COMPRESS_LZO:
-    GRN_TEXT_PUTS(ctx, buf, "|COMPRESS_LZO");
+  case GRN_OBJ_COMPRESS_LZ4:
+    GRN_TEXT_PUTS(ctx, buf, "|COMPRESS_LZ4");
     break;
   }
   if (flags & GRN_OBJ_PERSISTENT) {

--- a/lib/util.c
+++ b/lib/util.c
@@ -400,8 +400,8 @@ grn_store_inspect_body(grn_ctx *ctx, grn_obj *buf, grn_obj *obj)
   case GRN_OBJ_COMPRESS_ZLIB :
     GRN_TEXT_PUTS(ctx, buf, "zlib");
     break;
-  case GRN_OBJ_COMPRESS_LZO :
-    GRN_TEXT_PUTS(ctx, buf, "lzo");
+  case GRN_OBJ_COMPRESS_LZ4 :
+    GRN_TEXT_PUTS(ctx, buf, "lz4");
     break;
   default:
     break;

--- a/test/command/suite/select/output/lz4/scalar.expected
+++ b/test/command/suite/select/output/lz4/scalar.expected
@@ -1,6 +1,6 @@
 table_create Entries TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Entries content COLUMN_SCALAR|COMPRESS_LZO Text
+column_create Entries content COLUMN_SCALAR|COMPRESS_LZ4 Text
 [[0,0.0,0.0],true]
 load --table Entries
 [

--- a/test/command/suite/select/output/lz4/scalar.test
+++ b/test/command/suite/select/output/lz4/scalar.test
@@ -1,5 +1,5 @@
 table_create Entries TABLE_PAT_KEY ShortText
-column_create Entries content COLUMN_SCALAR|COMPRESS_LZO Text
+column_create Entries content COLUMN_SCALAR|COMPRESS_LZ4 Text
 
 load --table Entries
 [

--- a/test/unit/core/test-context.c
+++ b/test/unit/core/test-context.c
@@ -149,11 +149,11 @@ test_support_lzo(void)
 
   cut_assert_ensure_context();
   GRN_BOOL_INIT(&grn_support_p, 0);
-  grn_obj_get_info(context, NULL, GRN_INFO_SUPPORT_LZO, &grn_support_p);
+  grn_obj_get_info(context, NULL, GRN_INFO_SUPPORT_LZ4, &grn_support_p);
   support_p = GRN_BOOL_VALUE(&grn_support_p);
   GRN_OBJ_FIN(context, &grn_support_p);
 
-#ifdef GRN_WITH_LZO
+#ifdef GRN_WITH_LZ4
   cut_assert_true(support_p);
 #else
   cut_assert_false(support_p);

--- a/test/unit/lib/grn-test-utils.c
+++ b/test/unit/lib/grn-test-utils.c
@@ -149,8 +149,8 @@ grn_rc_to_string(grn_rc rc)
     return "GRN_ADDRESS_IS_IN_USE";
   case GRN_ZLIB_ERROR:
     return "GRN_ZLIB_ERROR";
-  case GRN_LZO_ERROR:
-    return "GRN_LZO_ERROR";
+  case GRN_LZ4_ERROR:
+    return "GRN_LZ4_ERROR";
   case GRN_STACK_OVER_FLOW:
     return "GRN_STACK_OVER_FLOW";
   case GRN_SYNTAX_ERROR:


### PR DESCRIPTION
https://github.com/groonga/groonga/pull/221 よりLZOはGPLだったんですね。気づきませんでした。
調べてみると他のオープンソースもライセンスの問題でLZOだけ外出ししていたりするみたいですね。

LZ4とLZ4HCの性能が気になって仕方がなかったので同じようにベンチマークを取ってみました。

結果としてはやはりselectで10件出力するぐらいではSnappyとあまり変化は見えない感じですね。zlibはあきらかにqpsが落ちていますが、LZ4はほとんどqpsが落ちていません。(14クライアントだけ少し差がでていますが。)
カラムからデータを取り出すところに高負荷がかかるような処理を加えればSnappyとも少しは変わってくるかもしれません。

LZ4HCも試しましたが読み出し速度を保ったまま、書き出し速度を犠牲するにことにより多少サイズが減らせますが
わざわざ用意する必要があるかは微妙な感じでした。

LZ4かSnappyが使えれば、LZOを選択する必要はなさそうですし私もLZOの代わりにLZ4が入るといいなぁと思います。

よければご検討をお願いします。

![qps_lz4](https://cloud.githubusercontent.com/assets/5455147/4717289/05d65040-5913-11e4-8306-bb5fd5a98507.png)

![size_lz4](https://cloud.githubusercontent.com/assets/5455147/4717292/0bd6538c-5913-11e4-8575-0123b4d8b04e.png)

![load_lz4](https://cloud.githubusercontent.com/assets/5455147/4717299/1a24aaa6-5913-11e4-848e-f56ec85cadcf.png)
