### PR TITLE
fix lz4 support reporting in --version

### DIFF
--- a/src/groonga.c
+++ b/src/groonga.c
@@ -2277,8 +2277,8 @@ show_version(void)
 #ifdef GRN_WITH_ZLIB
   printf(",zlib");
 #endif
-#ifdef GRN_WITH_LZO
-  printf(",lzo");
+#ifdef GRN_WITH_LZ4
+  printf(",lz4");
 #endif
 #ifdef USE_KQUEUE
   printf(",kqueue");


### PR DESCRIPTION
- In #223, lzo compression support dropped and add lz4 compression support.
