### PR TITLE
packages fedora: add missing so extension for installing plugin library

### DIFF
--- a/packages/rpm/fedora/groonga.spec.in
+++ b/packages/rpm/fedora/groonga.spec.in
@@ -348,7 +348,7 @@ fi
 %dir %{_libdir}/groonga/plugins/token_filters
 %{_libdir}/groonga/plugins/table/table.so
 %{_libdir}/groonga/plugins/query_expanders/tsv.so
-%{_libdir}/groonga/plugins/token_filters/stop_word
+%{_libdir}/groonga/plugins/token_filters/stop_word.so
 %{_datadir}/groonga/
 %config(noreplace) %{_sysconfdir}/groonga/synonyms.tsv
 


### PR DESCRIPTION
Suddenly, I've found missing "so" extension for stop_word plugin in rpm spec for Fedora.
