### PR TITLE
packages yum: fix typo

### DIFF
--- a/packages/yum/build-rpm.sh
+++ b/packages/yum/build-rpm.sh
@@ -86,7 +86,7 @@ build_fedora_srpm()
     run mv *.spec ~/rpmbuild/SPECS/
     run mv * ~/rpmbuild/SOURCES/
     run cd -
-    rn rm -rf tmp
+    run rm -rf tmp
 
     mecab_build_options="--buildroot ${HOME}/rpmbuild/BUILDROOT/${srpm_base}"
     case "${architecture}" in


### PR DESCRIPTION
``` log
r n ->
run
 +
```

This typo causes following error:

`````` log
25626 blocks
/tmp/vagrant-shell: line 89: rn: command not found
```log
``````
