### PR TITLE
package apt yum: use lz4 instead of lzo

### DIFF
--- a/packages/apt/env.sh.in
+++ b/packages/apt/env.sh.in
@@ -4,7 +4,7 @@ DEPENDED_PACKAGES="
 debhelper
 autotools-dev
 zlib1g-dev
-liblzo2-dev
+liblz4-dev
 libmsgpack-dev
 libzmq-dev
 libevent-dev

--- a/packages/yum/env.sh.in
+++ b/packages/yum/env.sh.in
@@ -11,7 +11,7 @@ libevent-devel
 python2-devel
 php-devel
 zlib-devel
-lzo-devel
+lz4-devel
 libedit-devel
 ruby
 tar


### PR DESCRIPTION
TODO: to use liblz4 needs as follows:
- enable universe repo in Ubuntu
- enable Wheezy-backports repo in Debian
- enable epel repo in CentOS

-> nothing to do in Fedora
