### PR TITLE
package deb: use liblz4 instead of liblzo2

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -7,7 +7,7 @@ Build-Depends:
   debhelper (>= 9),
   autotools-dev,
   zlib1g-dev,
-  liblzo2-dev,
+  liblz4-dev,
   libmsgpack-dev,
   libzmq3-dev | libzmq-dev,
   libevent-dev,


### PR DESCRIPTION
liblz4-dev provided in sid/jessie/wheezy-backport.
Using liblz4-dev in Debian Wheezy, it needs to be enable `wheezy-back-port` repo.
