### PR TITLE
package ubuntu: add Ubuntu code name "utopic"

### DIFF
--- a/packages/ubuntu/Makefile.am
+++ b/packages/ubuntu/Makefile.am
@@ -1,4 +1,4 @@
-CODE_NAMES = precise,trusty
+CODE_NAMES = precise,trusty,utopic
 SOURCE = ../$(PACKAGE)-$(VERSION).tar.gz
 
 all:


### PR DESCRIPTION
"Utopic Unicorn" has been released in Oct 24 2014.

Groonga 4.0.7 will support Ubuntu 14.10 (Utopic Unicorn)?
