### PR TITLE
doc: update execution example

### DIFF
--- a/doc/source/example/reference/commands/table_create/tag_index_table_hash_key.log
+++ b/doc/source/example/reference/commands/table_create/tag_index_table_hash_key.log
@@ -1,4 +1,4 @@
 Execution example::
 
-  table_create Ages TABLE_DAT_KEY UInt32
+  table_create Tags TABLE_HASH_KEY ShortText
   # [[0, 1337566253.89858, 0.000355720520019531], true]


### PR DESCRIPTION
GitHub: groonga/groonga.org#14

There was conflict between description and execution example!

7.3.29. table_create — Groonga v4.0.7 documentation
http://groonga.org/docs/reference/commands/table_create.html#create-tag-index-table
