### PR TITLE
Fix flags parameter for BSD mkostemp(3).

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -7173,6 +7173,9 @@ grn_ii_buffer_open(grn_ctx *ctx, grn_ii *ii,
 #ifdef WIN32
           open_flags |= O_BINARY;
 #endif
+#if defined(BSD)
+          open_flags = 0;
+#endif
           snprintf(ii_buffer->tmpfpath, PATH_MAX,
                    "%sXXXXXX", grn_io_path(ii->seg));
           ii_buffer->block_buf_size = II_BUFFER_BLOCK_SIZE;


### PR DESCRIPTION
FreeBSD では 10.0 から mkostemp(3) が入ったようなのですが、これ flags に O_APPEND, O_DIRECT, O_SHLOCK, O_EXLOCK, O_SYNC, O_CLOEXEC しか受け付けない仕様になっているようです。

このままだと実行時にエラーとなってしまうので、差分のように修正してみました。manpage 見る限り NetBSD, OpenBSD も同じ仕様のようなので、 defined(BSD) でくくってあります。
