### PR TITLE
Fix a bug that "*" with single character can't prefix search

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6157,7 +6157,7 @@ get_word_(grn_ctx *ctx, efs_info *q)
       GRN_INT32_PUT(ctx, &q->mode_stack, mode);
 
       return GRN_SUCCESS;
-    } else if (GRN_TEXT_LEN(&q->buf) > 1 && *end == GRN_QUERY_PREFIX) {
+    } else if (GRN_TEXT_LEN(&q->buf) > 0 && *end == GRN_QUERY_PREFIX) {
       q->cur = end + 1;
       GRN_INT32_PUT(ctx, &q->mode_stack, GRN_OP_PREFIX);
       break;

--- a/test/command/suite/select/query/asterisk/with_single_character.expected
+++ b/test/command/suite/select/query/asterisk/with_single_character.expected
@@ -1,0 +1,63 @@
+table_create Diaries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Diaries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms diaries_content COLUMN_INDEX|WITH_POSITION Diaries content
+[[0,0.0,0.0],true]
+load --table Diaries
+[
+{"content": "It'll be fine tomorrow as well."},
+{"content": "It'll rain tomorrow."},
+{"content": "It's fine today. It'll be fine tomorrow as well."},
+{"content": "It's fine today. But it'll rain tomorrow."},
+{"content": "Ring the bell."},
+{"content": "I love dumbbells."}
+]
+[[0,0.0,0.0],6]
+select   --table Diaries   --match_columns content   --query "t*"   --output_columns content,_score   --sortby _id
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        5
+      ],
+      [
+        [
+          "content",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "It'll be fine tomorrow as well.",
+        1
+      ],
+      [
+        "It'll rain tomorrow.",
+        1
+      ],
+      [
+        "It's fine today. It'll be fine tomorrow as well.",
+        2
+      ],
+      [
+        "It's fine today. But it'll rain tomorrow.",
+        2
+      ],
+      [
+        "Ring the bell.",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/query/asterisk/with_single_character.test
+++ b/test/command/suite/select/query/asterisk/with_single_character.test
@@ -1,0 +1,24 @@
+table_create Diaries TABLE_NO_KEY
+column_create Diaries content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms diaries_content COLUMN_INDEX|WITH_POSITION Diaries content
+
+load --table Diaries
+[
+{"content": "It'll be fine tomorrow as well."},
+{"content": "It'll rain tomorrow."},
+{"content": "It's fine today. It'll be fine tomorrow as well."},
+{"content": "It's fine today. But it'll rain tomorrow."},
+{"content": "Ring the bell."},
+{"content": "I love dumbbells."}
+]
+
+select \
+  --table Diaries \
+  --match_columns content \
+  --query "t*" \
+  --output_columns content,_score \
+  --sortby _id


### PR DESCRIPTION
GitHub: #242 について、
ほかのところへの影響を把握しきれていませんが、単純に以下の修正で直ったように見えました。
`*`のテストもnear_searchのテストも通りました。ご検討ください。
