### PR TITLE
Add "GRN_TOKENIZER_TOKEN_FORCE_PREFIX"

### DIFF
--- a/include/groonga/tokenizer.h
+++ b/include/groonga/tokenizer.h
@@ -183,6 +183,8 @@ typedef unsigned int grn_tokenizer_status;
 #define GRN_TOKENIZER_TOKEN_SKIP               (0x01L<<4)
 /* GRN_TOKENIZER_TOKEN_SKIP_WITH_POSITION means that the token and postion is skipped */
 #define GRN_TOKENIZER_TOKEN_SKIP_WITH_POSITION (0x01L<<5)
+/* GRN_TOKENIZER_TOKEN_FORCE_PREIX that the token is used common prefix search */
+#define GRN_TOKENIZER_TOKEN_FORCE_PREFIX       (0x01L<<6)
 
 /*
  * GRN_TOKENIZER_CONTINUE and GRN_TOKENIZER_LAST are deprecated. They

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -5431,6 +5431,7 @@ token_info_build(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii, const char *string,
     tis[(*n)++] = ti;
     while (token_cursor->status == GRN_TOKEN_DOING) {
       tid = grn_token_cursor_next(ctx, token_cursor);
+      if (token_cursor->force_prefix) { ef |= EX_PREFIX; }
       switch (token_cursor->status) {
       case GRN_TOKEN_DONE_SKIP :
         continue;

--- a/lib/token_cursor.c
+++ b/lib/token_cursor.c
@@ -212,6 +212,7 @@ grn_token_cursor_next(grn_ctx *ctx, grn_token_cursor *token_cursor)
         }
       }
 #undef SKIP_FLAGS
+      if (status & GRN_TOKENIZER_TOKEN_FORCE_PREFIX) { token_cursor->force_prefix = 1; }
       if (token_cursor->curr_size == 0) {
         char tokenizer_name[GRN_TABLE_MAX_KEY_SIZE];
         int tokenizer_name_length;


### PR DESCRIPTION
現在、`grn_token_cursor`（旧`grn_token`)には、`force_prefix`というメンバーがいます。
https://github.com/groonga/groonga/blob/master/lib/grn_token_cursor.h#L50

Ngramトークナイザーで`GRN_TOKENIZER_TOKEN_UNMATURED`、すなわち、NgramのNに満たないトークン（たとえば、Bigramのときは1文字）だけが入力されたときは自動的に強制前方一致検索されるようになっています。
https://github.com/groonga/groonga/blob/master/lib/token_cursor.c#L240
https://github.com/groonga/groonga/blob/master/lib/ii.c#L5404

(1)このケース以外に自由にトークナイザープラグインから強制前方一致を設定できるようにトークナイザーのステータスに`GRN_TOKENIZER_TOKEN_FORCE_PREFIX`追加していただけないでしょうか？

(2)さらに、そのうえで、最初のトークンだけでなく、2個目以降のトークンも`ef |= EX_PREFIX`を設定するようにしていただけませんでしょうか？

これらを追加していただけると、以下のように静的な頻度情報に応じたVgramトークナイザーを構築することができます。（トライのCommon prefix searchがないと可変のNgramを実現することができません。）

https://github.com/naoa/groonga-tokenizer-yangram#variable-ngram

実際に実験してみて、ヒット件数が変わらずに、キー数、キーサイズを抑えつつ、TokenBigramよりも検索速度が向上できることを確認しています。

お手数ですが、ご検討のほどよろしくお願いします。
