### PR TITLE
grn.h OS X: OS X does not have off64_t

### DIFF
--- a/lib/grn.h
+++ b/lib/grn.h
@@ -174,6 +174,10 @@ typedef SOCKET grn_sock;
 #  include <unistd.h>
 # endif /* HAVE_UNISTD_H */
 
+# ifdef __APPLE__
+typedef off_t off64_t;
+# endif
+
 # ifndef PATH_MAX
 #  if defined(MAXPATHLEN)
 #   define PATH_MAX MAXPATHLEN


### PR DESCRIPTION
OS X's `off_t` is already 64bit.

``` c
/usr/include/sys/_types/_off_t.h
30:typedef __darwin_off_t       off_t;

/usr/include/sys/_types.h
110:typedef __int64_t   __darwin_off_t;     /* [???] Used for file sizes
*/
```
