### PR TITLE
doc install: introduce groonga-token-filter-stem package

### DIFF
--- a/doc/source/install/debian.rst
+++ b/doc/source/install/debian.rst
@@ -40,6 +40,13 @@ Install groonga-tokenizer-mecab package::
 
   % sudo apt-get install -y -V groonga-tokenizer-mecab
 
+If you want to use TokenFilterStem as a token filter, install
+groonga-token-filter-stem package.
+
+Install groonga-token-filter-stem package::
+
+  % sudo apt-get install -y -V groonga-token-filter-stem
+
 There is a package that provides `Munin
 <http://munin-monitoring.org/>`_ plugins. If you want to monitor
 groonga status by Munin, install groonga-munin-plugins package.

--- a/doc/source/install/ubuntu.rst
+++ b/doc/source/install/ubuntu.rst
@@ -49,6 +49,13 @@ Install groonga-tokenizer-mecab package::
 
   % sudo apt-get -y install groonga-tokenizer-mecab
 
+If you want to use TokenFilterStem as a token filter, install
+groonga-token-filter-stem package.
+
+Install groonga-token-filter-stem package::
+
+  % sudo apt-get -y install groonga-token-filter-stem
+
 There is a package that provides `Munin
 <http://munin-monitoring.org/>`_ plugins. If you want to monitor
 groonga status by Munin, install groonga-munin-plugins package.


### PR DESCRIPTION
I think we should help those people who wants to use TokenFilterStem. I tried to add a command for installing `groonga-token-filter-stem` package into debian.rst and ubuntu.rst.
