### PR TITLE
add `autogen.sh` to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,7 @@ SUBDIRS =					\
 #dist_data_DATA =
 EXTRA_DIST =					\
 	README.md				\
+	autogen.sh				\
 	bindings				\
 	version-gen.sh				\
 	base_version				\


### PR DESCRIPTION
`autogen.sh` does not contain in Groonga source package.
"does not contain `autogen.sh` in release source package" is expected result?
If it is bundled in Groonga released source package, users can re-generate configure script with `./autogen.sh`.

Sometimes Homebrew environment does not have automake-1.14, so, it causes build failure as follows:

``` log
==> make install
Making install in build
Making install in cmake_modules
make[3]: Nothing to be done for `install-exec-am'.
make[3]: Nothing to be done for `install-data-am'.
make[3]: Nothing to be done for `install-exec-am'.
make[3]: Nothing to be done for `install-data-am'.
Making install in include
Making install in groonga
make[3]: Nothing to be done for `install-exec-am'.
 ../.././install-sh -c -d '/usr/local/Cellar/groonga/4.0.8/include/groonga/groonga'
 /usr/bin/install -c -m 644 expr.h groonga.h ii.h plugin.h token.h tokenizer.h token_filter.h nfkc.h normalizer.h util.h '/usr/local/Cellar/groonga/4.0.8/include/groonga/groonga'
make[3]: Nothing to be done for `install-exec-am'.
 .././install-sh -c -d '/usr/local/Cellar/groonga/4.0.8/include/groonga'
 /usr/bin/install -c -m 644 groonga.h '/usr/local/Cellar/groonga/4.0.8/include/groonga'
Making install in vendor
Making install in onigmo
 cd ../.. && /bin/sh /private/tmp/groonga-7CRBLS/groonga-4.0.8/missing automake-1.14 --foreign vendor/onigmo/Makefile
/private/tmp/groonga-7CRBLS/groonga-4.0.8/missing: line 81: automake-1.14: command not found
WARNING: 'automake-1.14' is missing on your system.
         You should only need it if you modified 'Makefile.am' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'automake' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
make[2]: *** [Makefile.in] Error 127
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1
```
