### PR TITLE
Make sure to use the header files of onigmo in vendor.

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,12 +11,12 @@ AM_CFLAGS =					\
 	$(GRN_CFLAGS)				\
 	$(MESSAGE_PACK_CFLAGS)			\
 	$(MRUBY_CFLAGS)				\
-	$(ONIGMO_CFLAGS)			\
 	$(LIBLZ4_CFLAGS)
 
 DEFAULT_INCLUDES =				\
 	-I$(top_builddir)			\
-	-I$(top_srcdir)/include
+	-I$(top_srcdir)/include			\
+	$(ONIGMO_CFLAGS)
 
 DEFS += -D_REENTRANT $(GRN_DEFS) -DGRN_DAT_EXPORT
 


### PR DESCRIPTION
Groonga currently includes their header files with <>, and lists the -I flags too late, so the build shall fail if the system has an incompatible version of onigmo/oniguruma or mruby headers installed.