### PR TITLE
Add missing scorer.h in packaged source

### DIFF
--- a/include/groonga/Makefile.am
+++ b/include/groonga/Makefile.am
@@ -8,6 +8,7 @@ groonga_include_HEADERS =			\
 	output.h				\
 	plugin.h				\
 	request_canceler.h			\
+	scorer.h				\
 	token.h					\
 	tokenizer.h				\
 	token_filter.h				\


### PR DESCRIPTION
Because following error occcurred in nightly package http://packages.groonga.org/nightly/mariadb-10.0.16-with-mroonga-5.00-for-windows.2015.02.20.zip:

```log
 c:\jw\workspace\dmbvc2013\powershell\work\source\storage\mroonga\vendor\groonga\lib\grn_db.h(27):
 fatal error C1083: include ファイルを開けません。'groonga/scorer.h':No
 such file or directory
 (C:\jw\workspace\dmbvc2013\powershell\work\source\storage\mroonga\vendor\groonga\lib\command.c)
 [C:\jw\workspace\dmbvc2013\powershell\work\build-vc2013-zip-32\storage\mroonga\vendor\groonga\lib\libgroonga.vcxproj]
```