### PR TITLE
doc release: don't fold a line

### DIFF
--- a/doc/source/contribution/development/release.rst
+++ b/doc/source/contribution/development/release.rst
@@ -29,8 +29,7 @@
 
 なお、ビルド環境としては Ubuntu 12.04 LTS(Precise Pangolin)を前提として説明しているため、その他の環境では適宜読み替えて下さい。::
 
-    % sudo apt-get install -V debootstrap createrepo rpm
-    mercurial python-docutils python-jinja2 ruby1.9.1-full mingw-w64 g++-mingw-w64 mecab libmecab-dev nsis gnupg2
+    % sudo apt-get install -V debootstrap createrepo rpm mercurial python-docutils python-jinja2 ruby1.9.1-full mingw-w64 g++-mingw-w64 mecab libmecab-dev nsis gnupg2
 
 rinseのバージョンが古いとCentOS 5/6パッケージのビルドを行うことができません。
 別途debパッケージを以下のコマンドを実行して最新版をインストールします。::


### PR DESCRIPTION
Because this command must be executed on a single line.

Or we should put a backslash the end of the first line:

    % sudo apt-get install -V debootstrap createrepo rpm \
    mercurial python-docutils python-jinja2 ...