### PR TITLE
mrb: bind Groonga::ContentType module

### DIFF
--- a/lib/ctx_impl_mrb.c
+++ b/lib/ctx_impl_mrb.c
@@ -52,6 +52,7 @@
 # include "mrb/mrb_command_input.h"
 # include "mrb/mrb_table_cursor.h"
 # include "mrb/mrb_table_cursor_flags.h"
+# include "mrb/mrb_content_type.h"
 # include "mrb/mrb_writer.h"
 
 # include <mruby/array.h>
@@ -135,6 +136,7 @@ grn_ctx_impl_mrb_init_bindings(grn_ctx *ctx)
   grn_mrb_command_input_init(ctx);
   grn_mrb_table_cursor_init(ctx);
   grn_mrb_table_cursor_flags_init(ctx);
+  grn_mrb_content_type_init(ctx);
   grn_mrb_writer_init(ctx);
 
   grn_mrb_load(ctx, "initialize/post.rb");

--- a/lib/mrb/mrb_content_type.c
+++ b/lib/mrb/mrb_content_type.c
@@ -1,0 +1,50 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2015 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "../grn_ctx_impl.h"
+
+#ifdef GRN_WITH_MRUBY
+#include <mruby.h>
+#include <mruby/data.h>
+
+#include "mrb_ctx.h"
+#include "mrb_content_type.h"
+
+void
+grn_mrb_content_type_init(grn_ctx *ctx)
+{
+  grn_mrb_data *data = &(ctx->impl->mrb);
+  mrb_state *mrb = data->state;
+  struct RClass *module;
+
+  module = mrb_define_module_under(mrb, data->module, "ContentType");
+
+  mrb_define_const(mrb, module, "NONE",
+                   mrb_fixnum_value(GRN_CONTENT_NONE));
+  mrb_define_const(mrb, module, "TSV",
+                   mrb_fixnum_value(GRN_CONTENT_TSV));
+  mrb_define_const(mrb, module, "JSON",
+                   mrb_fixnum_value(GRN_CONTENT_JSON));
+  mrb_define_const(mrb, module, "XML",
+                   mrb_fixnum_value(GRN_CONTENT_XML));
+  mrb_define_const(mrb, module, "MSGPACK",
+                   mrb_fixnum_value(GRN_CONTENT_MSGPACK));
+  mrb_define_const(mrb, module, "GROONGA_COMMAND_LIST",
+                   mrb_fixnum_value(GRN_CONTENT_GROONGA_COMMAND_LIST));
+}
+#endif

--- a/lib/mrb/mrb_content_type.h
+++ b/lib/mrb/mrb_content_type.h
@@ -1,0 +1,34 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2015 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef GRN_MRB_CONTENT_TYPE_H
+#define GRN_MRB_CONTENT_TYPE_H
+
+#include "../grn_ctx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void grn_mrb_content_type_init(grn_ctx *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GRN_MRB_CONTENT_TYPE_H */

--- a/lib/mrb/sources.am
+++ b/lib/mrb/sources.am
@@ -11,6 +11,8 @@ libgrnmrb_la_SOURCES =				\
 	mrb_command.h				\
 	mrb_command_input.c			\
 	mrb_command_input.h			\
+	mrb_content_type.c			\
+	mrb_content_type.h			\
 	mrb_converter.c				\
 	mrb_converter.h				\
 	mrb_ctx.c				\


### PR DESCRIPTION
#285 のための対応です。レビューをお願いします。

手元では`Groonga::Writer#content_type=`も実装できているので、
これがマージされたらpull requestを出します。