### PR TITLE
Fix a bug that stop_word plugin use offline index construction

### DIFF
--- a/plugins/token_filters/stop_word.c
+++ b/plugins/token_filters/stop_word.c
@@ -38,6 +38,9 @@ stop_word_init(grn_ctx *ctx, grn_obj *table, grn_token_mode mode)
 {
   grn_stop_word_token_filter *token_filter;
 
+  if (mode != GRN_TOKEN_GET) {
+    return NULL;
+  }
   token_filter = GRN_PLUGIN_MALLOC(ctx, sizeof(grn_stop_word_token_filter));
   if (!token_filter) {
     GRN_PLUGIN_ERROR(ctx, GRN_NO_MEMORY_AVAILABLE,
@@ -84,6 +87,9 @@ stop_word_filter(grn_ctx *ctx,
 {
   grn_stop_word_token_filter *token_filter = user_data;
 
+  if (!token_filter) {
+    return;
+  }
   if (token_filter->mode == GRN_TOKEN_GET) {
     grn_id id;
     grn_obj *data;

--- a/test/command/suite/token_filters/stop_word/offline_index_construction.expected
+++ b/test/command/suite/token_filters/stop_word/offline_index_construction.expected
@@ -1,0 +1,57 @@
+register token_filters/stop_word
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"content": "Hello"},
+{"content": "Hello and Good-bye"},
+{"content": "Good-bye"}
+]
+[[0,0.0,0.0],3]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters TokenFilterStopWord
+[[0,0.0,0.0],true]
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+[[0,0.0,0.0],true]
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+[[0,0.0,0.0],true]
+load --table Terms
+[
+{"_key": "and", "is_stop_word": true}
+]
+[[0,0.0,0.0],1]
+select Memos --match_columns content --query "Hello and"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "content",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "Hello"
+      ],
+      [
+        2,
+        "Hello and Good-bye"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/token_filters/stop_word/offline_index_construction.test
+++ b/test/command/suite/token_filters/stop_word/offline_index_construction.test
@@ -1,0 +1,25 @@
+register token_filters/stop_word
+
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+load --table Memos
+[
+{"content": "Hello"},
+{"content": "Hello and Good-bye"},
+{"content": "Good-bye"}
+]
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto \
+  --token_filters TokenFilterStopWord
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+
+load --table Terms
+[
+{"_key": "and", "is_stop_word": true}
+]
+
+select Memos --match_columns content --query "Hello and"


### PR DESCRIPTION
オフラインインデックス構築時はtmp_lexiconで無名テーブルが渡されるので、``is_stop_word``カラム見つからなくてエラーになっちゃうので、``GRN_TOKEN_GET``時以外は、NULLを返すようにしました。