### PR TITLE
Use . (dot) rather than source to be compat with POSIX.2.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,7 @@ GRN_DLL_FILENAME="libgroonga-\$(LT_CURRENT).dll"
 AC_SUBST(GRN_DLL_FILENAME)
 
 if test "$srcdir/version.sh"; then
-  source "$srcdir/version.sh"
+  . "$srcdir/version.sh"
   AC_SUBST(GRN_VERSION)
   AC_DEFINE_UNQUOTED(GRN_VERSION, ["$GRN_VERSION"], [groonga version])
 fi


### PR DESCRIPTION
bash's "source" command extension is not in POSIX.2 standard.  Use
. (dot) command to be worked on non-bash environment (like FreeBSD).