### PR TITLE
Support force prefix search when unmatured token is 2 characters or more

### DIFF
--- a/lib/token_cursor.c
+++ b/lib/token_cursor.c
@@ -245,7 +245,7 @@ grn_token_cursor_next(grn_ctx *ctx, grn_token_cursor *token_cursor)
             continue;
           }
         } else {
-          if (status & GRN_TOKEN_LAST) {
+          if (status & GRN_TOKEN_REACH_END) {
             token_cursor->force_prefix = GRN_TRUE;
           }
         }

--- a/test/command/suite/tokenizers/trigram/force_prefix/multiple_tokens/unmatured_two_characters.expected
+++ b/test/command/suite/tokenizers/trigram/force_prefix/multiple_tokens/unmatured_two_characters.expected
@@ -14,7 +14,7 @@ tokenize TokenTrigram "ABCだよ" NormalizerAuto --mode GET
     {
       "value": "だよ",
       "position": 1,
-      "force_prefix": false
+      "force_prefix": true
     }
   ]
 ]

--- a/test/command/suite/tokenizers/trigram/force_prefix/single_token/unmatured_two_characters.expected
+++ b/test/command/suite/tokenizers/trigram/force_prefix/single_token/unmatured_two_characters.expected
@@ -1,2 +1,2 @@
 tokenize TokenTrigram "だよ" NormalizerAuto --mode GET
-[[0,0.0,0.0],[{"value":"だよ","position":0,"force_prefix":false}]]
+[[0,0.0,0.0],[{"value":"だよ","position":0,"force_prefix":true}]]


### PR DESCRIPTION
現在、GroongaではTokenBigramで最後のトークン(TOKEN_LAST)が1文字トークン(UNMATURED)の場合、強制前方一致フラグtoken_cursor->force_prefixが設定されることにより、1文字トークンで検索される場合でも勝手にうまくヒットするようになっています。

* TokenBigramの例
 -  クエリ：で -> [で]  
 -  本文：文章です -> [文章/章で/です/す]
     -  "で" というトークンは存在しないため前方一致が必要

しかし、TokenTrigramにすると2文字トークンは最後のトークンでないため(以下の例では最後のトークンは章）、強制前方一致フラグが設定されず、2文字トークンを含むとうまくヒットしなくなります。

* TokenTrigramの例
 - クエリ：文章 -> [文章/章]
 - 本文：文章です -> [文章で/章です/です/す]  
   - "文章" というトークンは存在しないため前方一致が必要

そこで、UNMATUREDトークンの場合、TOKEN_LASTではなくトークンの最後の文字がクエリの末尾であることを示すTOKEN_REACH_ENDの場合に強制前方一致フラグを設定するようにしてやれば、TokenTrigramの場合に2文字トークンが含まれても勝手にうまくヒットするようになると思います。

よければご検討ください。

