### PR TITLE
debian: Use network-online.target to wait configured network strictly

### DIFF
--- a/packages/debian/groonga-httpd.service
+++ b/packages/debian/groonga-httpd.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Groonga HTTP Server
-After=network.target
+Wants=network-online.target
 Conflicts=groonga.service
 
 [Service]

--- a/packages/debian/groonga-httpd.service
+++ b/packages/debian/groonga-httpd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Groonga HTTP Server
 Wants=network-online.target
+After=network-online.target
 Conflicts=groonga.service
 
 [Service]

--- a/packages/debian/groonga-server-gqtp.service
+++ b/packages/debian/groonga-server-gqtp.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Groonga GQTP Server
-After=network.target
+Wants=network-online.target
 
 [Service]
 Type=forking

--- a/packages/debian/groonga-server-gqtp.service
+++ b/packages/debian/groonga-server-gqtp.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Groonga GQTP Server
 Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
I think that using `Wants=network-online.target` is more suitable for Groonga's server functionality.

Because systemd's manpage says:

    network-online.target is a target that actively waits until the nework is "up", 
    where the definition of "up" is defined by the network management software. 
    Usually it indicates a configured, routable IP address of some kind.

ref: http://www.freedesktop.org/software/systemd/man/systemd.special.html#network-online.target