### PR TITLE
Don't override error

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -269,8 +269,8 @@ grn_db_open(grn_ctx *ctx, const char *path)
       default :
         s->keys = NULL;
         if (ctx->rc == GRN_SUCCESS) {
-        ERR(GRN_INVALID_ARGUMENT,
-            "[db][open] invalid keys table's type: %#x", type);
+          ERR(GRN_INVALID_ARGUMENT,
+              "[db][open] invalid keys table's type: %#x", type);
         }
         break;
       }

--- a/lib/db.c
+++ b/lib/db.c
@@ -268,8 +268,10 @@ grn_db_open(grn_ctx *ctx, const char *path)
         break;
       default :
         s->keys = NULL;
+        if (ctx->rc == GRN_SUCCESS) {
         ERR(GRN_INVALID_ARGUMENT,
             "[db][open] invalid keys table's type: %#x", type);
+        }
         break;
       }
       if (s->keys) {


### PR DESCRIPTION
In Rroonga, a test is failing:

```
=========================================================================================================
Failure: test_new(DatabaseTest)
/home/myokoym/work/groonga/rroonga/test/test-database.rb:73:in `test_new'
     70:   end
     71: 
     72:   def test_new
  => 73:     assert_raise(Groonga::NoSuchFileOrDirectory) do
     74:       new_context = Groonga::Context.new
     75:       Groonga::Database.new(@database_path.to_s, :context => new_context)
     76:     end

<Groonga::NoSuchFileOrDirectory> expected but was
<Groonga::InvalidArgument(<invalid argument: [db][open] invalid keys table's type: 0: #<Groonga::Database>
db.c:272: grn_db_open()>)>

diff:
? Groonga::N                                       oSuchFi               leO              r       Dir    ectory
?          InvalidArgument(<invalid argument: [db][ pen]  nvalid keys tab  's type: 0: #<G oonga:: atabas >    
+ db.c:272: grn_db_open()>)
=========================================================================================================
```

In this case, an error already occurred in ` grn_io_detect_type()`.
We shouldn't override the error.