### PR TITLE
Add build and install information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ See doc/source/ directory or http://groonga.org/docs/.
   * Path: vendor/nginx-${VERSION}
   * License: BSD license. See vendor/nginx-${VERSION}/LICENSE for details.
 
+## Build and Install
+
+ $ ./autogen.sh
+ $ ./configure
+ $ make
+ $ sudo make install
+
 ## Authors
 
 ### Primary authors

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ See doc/source/ directory or http://groonga.org/docs/.
 
 ## Build and Install
 
+```
  $ ./autogen.sh
  $ ./configure
  $ make
  $ sudo make install
+```
 
 ## Authors
 


### PR DESCRIPTION
There is no information regarding build and install in README.md
It should have such information.

For examples, the documentation does not have information  cloning from github.
http://groonga.org/docs/install/mac_os_x.html
A developer does not have information how to generate configure file. If README.md has such information, he/she can build it.