### PR TITLE
Fixed issue #241. Defined grn_rc_to_string()

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -125,6 +125,8 @@ typedef enum {
   GRN_SCORER_ERROR = -76
 } grn_rc;
 
+GRN_API const char *grn_rc_to_string(grn_rc rc);
+
 GRN_API grn_rc grn_init(void);
 GRN_API grn_rc grn_fin(void);
 

--- a/lib/operator.c
+++ b/lib/operator.c
@@ -124,6 +124,105 @@ grn_operator_to_string(grn_operator op)
   }
 }
 
+static const char *rc_names[] = {
+  "success",
+  "end of data",
+  "unknown error",
+  "operation not permitted",
+  "no such file or directory",
+  "no such process",
+  "interrupted function call",
+  "input output error",
+  "no such device or address",
+  "arg list too long",
+  "exec format error",
+  "bad file descriptor",
+  "no child processes",
+  "resource temporarily unavailable",
+  "not enough space",
+  "permission denied",
+  "bad address",
+  "resource busy",
+  "file exists",
+  "improper link",
+  "no such device",
+  "not a directory",
+  "is a directory",
+  "invalid argument",
+  "too many open files in system",
+  "too many open files",
+  "inappropriate i o control operation",
+  "file too large",
+  "no space left on device",
+  "invalid seek",
+  "read only file system",
+  "too many links",
+  "broken pipe",
+  "domain error",
+  "result too large",
+  "resource deadlock avoided",
+  "no memory available",
+  "filename too long",
+  "no locks available",
+  "function not implemented",
+  "directory not empty",
+  "illegal byte sequence",
+  "socket not initialized",
+  "operation would block",
+  "address is not available",
+  "network is down",
+  "no buffer",
+  "socket is already connected",
+  "socket is not connected",
+  "socket is already shutdowned",
+  "operation timeout",
+  "connection refused",
+  "range error",
+  "tokenizer error",
+  "file corrupt",
+  "invalid format",
+  "object corrupt",
+  "too many symbolic links",
+  "not socket",
+  "operation not supported",
+  "address is in use",
+  "zlib error",
+  "lz4 error",
+  "stack over flow",
+  "syntax error",
+  "retry max",
+  "incompatible file format",
+  "update not allowed",
+  "too small offset",
+  "too large offset",
+  "too small limit",
+  "cas error",
+  "unsupported command version",
+  "normalizer error",
+  "token filter error",
+  "command error",
+  "plugin error",
+  "scorer error",
+};
+
+#define GRN_RC_SUCCESS_CODE_LAST GRN_END_OF_DATA
+#define GRN_RC_ERROR_CODE_LAST   GRN_SCORER_ERROR
+
+const char *
+grn_rc_to_string(grn_rc rc)
+{
+  if (rc >= GRN_RC_ERROR_CODE_LAST && rc < 0) {
+    // negative value range is ERROR code.
+    return rc_names[GRN_RC_SUCCESS_CODE_LAST + (-rc)];
+  } else if (rc >= 0 && GRN_RC_SUCCESS_CODE_LAST >= rc) {
+    // positive valus range is SUCCESS code.
+    return rc_names[rc];
+  } else {
+    // another value range is undefined success/error code.
+    return "unknown";
+  }
+}
+
 #define DO_EQ_SUB do {\
   switch (y->header.domain) {\
   case GRN_DB_INT8 :\


### PR DESCRIPTION
I added grn_rc_to_string(). This function convert the grn_rc enum value to string.
Conduct a test of grn_rc_to_string() is following procedure.

 * test script
```
$ cat test_grn_rc_to_string.gdb 
set height 0

break main
run

echo val=0 is pass a test.\n

# Test SUCCESS code (positive value range).
call strcmp(grn_rc_to_string(0), "success")
call strcmp(grn_rc_to_string(1), "end of data")
call strcmp(grn_rc_to_string(2), "unknown")

# Test ERROR code (negative value range).
call strcmp(grn_rc_to_string(-1),  "unknown error")
call strcmp(grn_rc_to_string(-2),  "operation not permitted")
call strcmp(grn_rc_to_string(-75), "plugin error")
call strcmp(grn_rc_to_string(-76), "scorer error")
call strcmp(grn_rc_to_string(-77), "unknown")

quit
```

 * test result
```
$ gdb --silent -x ./test_grn_rc_to_string.gdb ./groonga/bin/groonga
Reading symbols from ./groonga/bin/groonga...done.
Breakpoint 1 at 0x403a30: file groonga.c, line 2658.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Breakpoint 1, main (argc=1, argv=0x7fffffffe678) at groonga.c:2658
2658	{
val=0 is pass a test.
$1 = 0
$2 = 0
$3 = 0
$4 = 0
$5 = 0
$6 = 0
$7 = 0
$8 = 0
A debugging session is active.

	Inferior 1 [process 26746] will be killed.

Quit anyway? (y or n) [answered Y; input not from terminal]
```
