### PR TITLE
use standard uint32_t instead of non-standard __uint32_t

### DIFF
--- a/lib/com.c
+++ b/lib/com.c
@@ -348,7 +348,7 @@ grn_com_event_add(grn_ctx *ctx, grn_com_event *ev, grn_sock fd, int events, grn_
     struct epoll_event e;
     memset(&e, 0, sizeof(struct epoll_event));
     e.data.fd = (fd);
-    e.events = (__uint32_t) events;
+    e.events = (uint32_t) events;
     if (epoll_ctl(ev->epfd, EPOLL_CTL_ADD, (fd), &e) == -1) {
       SERR("epoll_ctl");
       return ctx->rc;
@@ -396,7 +396,7 @@ grn_com_event_mod(grn_ctx *ctx, grn_com_event *ev, grn_sock fd, int events, grn_
       struct epoll_event e;
       memset(&e, 0, sizeof(struct epoll_event));
       e.data.fd = (fd);
-      e.events = (__uint32_t) events;
+      e.events = (uint32_t) events;
       if (epoll_ctl(ev->epfd, EPOLL_CTL_MOD, (fd), &e) == -1) {
         SERR("epoll_ctl");
         return ctx->rc;


### PR DESCRIPTION
this fixes the following build error with musl libc:
    lib/com.c: In function 'grn_com_event_add':
    lib/com.c:351:17: error: '__uint32_t' undeclared
    (first use in this function)
         e.events = (__uint32_t) events;
                     ^

fixes #375