### PR TITLE
Remove resolved todo

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -270,23 +270,3 @@ man_pages = [
     ('index', 'groonga', unicode(_('Groonga documentation'), "utf-8"),
      [u'Groonga Project'], 1)
 ]
-
-# -- Options for Gettext --------------------------------------------------
-# This feature requires Sphinx 1.3 or later.
-gettext_uuid = False
-
-# Workaround for slow gettext builder.
-# TODO: REMOVE ME when issue#1426 is fixed
-# See also: https://bitbucket.org/birkenfeld/sphinx/issue/1426/gettext-builder-is-very-slow-during-read
-def setup(app):
-  # disable versioning for speed
-  from sphinx.builders.gettext import I18nBuilder
-  I18nBuilder.versioning_method = 'none'
-
-  def doctree_read(app, doctree):
-    if not isinstance(app.builder, I18nBuilder):
-        return
-    from docutils import nodes
-    from sphinx.versioning import add_uids
-    list(add_uids(doctree, nodes.TextElement))
-  app.connect('doctree-read', doctree_read)


### PR DESCRIPTION
#367 

CLEANED!! :sparkles: 

```
$ make -C doc html
(snip)
copying static files... done
copying extra files... done
dumping search index in Japanese (code: ja) ... done
dumping object inventory... done
build succeeded, 2 warnings.
(snip)
```
2 warnings mean ...

```
groonga/doc/source/reference/cast.rst:: WARNING: document isn't included in any toctree
groonga/doc/source/reference/scoring_note.rst:: WARNING: document isn't included in any toctree
```

Now I ignore. :confused: 