### PR TITLE
Add missing extern to variable in header

### DIFF
--- a/lib/grn_report.h
+++ b/lib/grn_report.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-const grn_log_level GRN_REPORT_INDEX_LOG_LEVEL;
+extern const grn_log_level GRN_REPORT_INDEX_LOG_LEVEL;
 
 void grn_report_index(grn_ctx *ctx,
                       const char *action,


### PR DESCRIPTION
This missing extern causes following error in OSX:

```log
...
2403 warnings generated.
  CXXLD    libgroonga.la
duplicate symbol _GRN_REPORT_INDEX_LOG_LEVEL in:
    .libs/db.o
    .libs/expr.o
duplicate symbol _GRN_REPORT_INDEX_LOG_LEVEL in:
    .libs/db.o
    .libs/report.o
ld: 2 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[4]: *** [libgroonga.la] Error 1
make[3]: *** [all-recursive] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```