### PR TITLE
doc: replace deprecated option (KEY_NORMALIZE)

### DIFF
--- a/doc/source/example/reference/commands/select/query_expander_substitution_table.log
+++ b/doc/source/example/reference/commands/select/query_expander_substitution_table.log
@@ -1,6 +1,6 @@
 Execution example::
 
-  table_create Thesaurus TABLE_PAT_KEY|KEY_NORMALIZE ShortText
+  table_create Thesaurus TABLE_PAT_KEY ShortText --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Thesaurus synonym COLUMN_VECTOR ShortText
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/example/reference/commands/select/usage_setup.log
+++ b/doc/source/example/reference/commands/select/usage_setup.log
@@ -8,7 +8,7 @@ Execution example::
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Entries tag COLUMN_SCALAR ShortText
   # [[0, 1337566253.89858, 0.000355720520019531], true]
-  table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Terms entries_key_index COLUMN_INDEX|WITH_POSITION Entries _key
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/example/reference/functions/query/usage_setup_schema.log
+++ b/doc/source/example/reference/functions/query/usage_setup_schema.log
@@ -4,7 +4,7 @@ Execution example::
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Documents content COLUMN_SCALAR Text
   # [[0, 1337566253.89858, 0.000355720520019531], true]
-  table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Terms documents_content_index COLUMN_INDEX|WITH_POSITION Documents content
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/example/reference/functions/snippet_html/usage_setup.log
+++ b/doc/source/example/reference/functions/snippet_html/usage_setup.log
@@ -4,7 +4,7 @@ Execution example::
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Documents content COLUMN_SCALAR Text
   # [[0, 1337566253.89858, 0.000355720520019531], true]
-  table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Terms documents_content_index COLUMN_INDEX|WITH_POSITION Documents content
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/example/reference/grn_expr/query_syntax/setup.log
+++ b/doc/source/example/reference/grn_expr/query_syntax/setup.log
@@ -6,7 +6,7 @@ Execution example::
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Entries n_likes COLUMN_SCALAR UInt32
   # [[0, 1337566253.89858, 0.000355720520019531], true]
-  table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Terms entries_key_index COLUMN_INDEX|WITH_POSITION Entries _key
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/example/reference/grn_expr/script_syntax/simple_term_extract_operator.log
+++ b/doc/source/example/reference/grn_expr/script_syntax/simple_term_extract_operator.log
@@ -1,6 +1,6 @@
 Execution example::
 
-  table_create Words TABLE_PAT_KEY|KEY_NORMALIZE ShortText
+  table_create Words TABLE_PAT_KEY ShortText --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   load --table Words
   [
@@ -13,24 +13,24 @@ Execution example::
   select Words --filter '_key *T "Groonga is the successor project to Senna."' --output_columns _key
   # [
   #   [
-  #     0, 
-  #     1337566253.89858, 
+  #     0,
+  #     1337566253.89858,
   #     0.000355720520019531
-  #   ], 
+  #   ],
   #   [
   #     [
   #       [
   #         2
-  #       ], 
+  #       ],
   #       [
   #         [
-  #           "_key", 
+  #           "_key",
   #           "ShortText"
   #         ]
-  #       ], 
+  #       ],
   #       [
   #         "groonga"
-  #       ], 
+  #       ],
   #       [
   #         "senna"
   #       ]

--- a/doc/source/example/reference/indexing-schema.log
+++ b/doc/source/example/reference/indexing-schema.log
@@ -4,5 +4,5 @@ Execution example::
   # [[0, 1337566253.89858, 0.000355720520019531], true]
   column_create Tweets content COLUMN_SCALAR ShortText
   # [[0, 1337566253.89858, 0.000355720520019531], true]
-  table_create Lexicon TABLE_HASH_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Lexicon TABLE_HASH_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
   # [[0, 1337566253.89858, 0.000355720520019531], true]

--- a/doc/source/troubleshooting/different_results_with_the_same_keyword.rst
+++ b/doc/source/troubleshooting/different_results_with_the_same_keyword.rst
@@ -17,7 +17,7 @@ DDLは以下の通りです。BlogsテーブルのbodyカラムをTokenMecabト�
   table_create Blogs TABLE_NO_KEY
   column_create Blogs body COLUMN_SCALAR ShortText
   column_create Blogs updated_at COLUMN_SCALAR Time
-  table_create Terms TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenMecab
+  table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenMecab  --normalizer NormalizerAuto
   column_create Terms blog_body COLUMN_INDEX|WITH_POSITION Blogs body
 
 テスト用のデータは1件だけ投入します。::
@@ -85,7 +85,7 @@ TokenMecabトークナイザーは事前に準備した辞書を用いてトー�
 
 ここでも、前述の例を使って具体例を示します。まず、TokenBigramを用いた索引を追加します。::
 
-  table_create Bigram TABLE_PAT_KEY|KEY_NORMALIZE ShortText --default_tokenizer TokenBigram
+  table_create Bigram TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram  --normalizer NormalizerAuto
   column_create Bigram blog_body COLUMN_INDEX|WITH_POSITION Blogs body
 
 この状態でも以前はマッチしなかったレコードがヒットするようになります。::


### PR DESCRIPTION
これで一通りKEY_NORMALIZEは潰せたような..

ところで、
[7.3.44.4.5. default_tokenizer](http://groonga.org/ja/docs/reference/commands/table_create.html#key-type)

``デフォルト値はありません。``とありますが、

doc/source/example/reference/commands/select/query_expander_substitution_table.log
には、

```
table_create Thesaurus TABLE_PAT_KEY|KEY_NORMALIZE ShortText
```

とトークナイザを指定していないものがありますね。
次のように書き換えて問題なさそうだったのでdefault_tokenizerは未指定です。

```
table_create Thesaurus TABLE_PAT_KEY ShortText --normalizer NormalizerAuto
```

補足(2015/08/26 19:16)

次のどちらかが良いように思います。

* default_tokenizerは必ず指定する。(デフォルト値はありません。が正しい場合)
* 未指定の場合、XXになると表現を変える(デフォルト値がある場合)
 