### PR TITLE
Support columns for temporary table

### DIFF
--- a/lib/grn_ctx_impl.h
+++ b/lib/grn_ctx_impl.h
@@ -171,6 +171,7 @@ struct _grn_ctx_impl {
 
   grn_obj *db;
   grn_array *values;        /* temporary objects */
+  grn_pat *temporary_columns;
   grn_hash *ios;        /* IOs */
   grn_obj *outbuf;
   void (*output)(grn_ctx *, int, void *);

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -111,6 +111,7 @@ struct _grn_type {
 #define GRN_TABLE_SORT_GEO            (0x02<<0)
 
 #define GRN_OBJ_TMP_OBJECT 0x80000000
+#define GRN_OBJ_TMP_COLUMN 0x40000000
 
 #define GRN_DB_OBJP(obj) \
   (obj &&\


### PR DESCRIPTION
Use cases:

  * Named output columns in select like "AS" in SQL
    * Creating a column to temporary table and assigning return value
      of function to the column:

          select --filter all_records() \
                 --column[snippet].type ShortText \
                 --column[snippet].value 'snippet_html(body)' \
                 --output_columns _id,snippet

  * Drilldown by computed value
    * Select -> Create temporary column -> Compute value -> Drilldown:

          select --filter all_records() \
                 --column[year].type UInt8 \
                 --column[year].value 'time_to_year(updated_at)' \
                 --drilldown year