### PR TITLE
Fix autogen.sh extream slow.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1459,8 +1459,7 @@ AC_ARG_WITH(groonga-org-path,
 AC_SUBST(GROONGA_ORG_PATH)
 
 # groonga-httpd
-m4_define([nginx_version], m4_include(nginx_version))
-NGINX_VERSION=nginx_version
+NGINX_VERSION=m4_include([nginx_version])
 AC_SUBST(NGINX_VERSION)
 
 # groonga-httpd binary path


### PR DESCRIPTION
This configure.ac is extreme slow on libtool-2.4.6.

From libtool mailing list.

You can workaround/fix this by:
-m4_define([nginx_version], m4_include(nginx_version))
-NGINX_VERSION=nginx_version
+NGINX_VERSION=m4_include([nginx_version])

See also.
http://lists.gnu.org/archive/html/libtool/2015-09/msg00004.html