### PR TITLE
Fix binary operator expected.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -8,9 +8,9 @@ Darwin)
         if [ -d $homebrew_aclocal ]; then
           ACLOCAL_ARGS="$ACLOCAL_ARGS -I $homebrew_aclocal"
         fi
-        gettext_aclocal="$(echo /usr/local/Cellar/gettext/*/share/aclocal)"
-        if [ -d $gettext_aclocal ]; then
-          ACLOCAL_ARGS="$ACLOCAL_ARGS -I $gettext_aclocal"
+        gettext_aclocal="$(echo /usr/local/Cellar/gettext/*/share/aclocal | awk '{ print $NF }')"
+        if [ -d "$gettext_aclocal" ]; then
+          $ACLOCAL_ARGS="$ACLOCAL_ARGS -I $gettext_aclocal"
         fi
 	;;
 FreeBSD)

--- a/autogen.sh
+++ b/autogen.sh
@@ -10,7 +10,7 @@ Darwin)
         fi
         gettext_aclocal="$(echo /usr/local/Cellar/gettext/*/share/aclocal | awk '{ print $NF }')"
         if [ -d "$gettext_aclocal" ]; then
-          $ACLOCAL_ARGS="$ACLOCAL_ARGS -I $gettext_aclocal"
+          ACLOCAL_ARGS="$ACLOCAL_ARGS -I $gettext_aclocal"
         fi
 	;;
 FreeBSD)


### PR DESCRIPTION
Please review this patch.

If multiple gettext package installed,
Following statement does not work properly.

if [ -d $gettext_aclocal ]; then
  ACLOCAL_ARGS="$ACLOCAL_ARGS -I $gettext_aclocal"
fi

./autogen.sh: line 12: [: /usr/local/Cellar/gettext/0.19.4/share/aclocal: binary operator expected

echo /usr/local/Cellar/gettext/*/share/aclocal
/usr/local/Cellar/gettext/0.19.4/share/aclocal /usr/local/Cellar/gettext/0.19.5.1/share/aclocal