### PR TITLE
doc ja: write output_columns '*' description

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference.po
+++ b/doc/locale/ja/LC_MESSAGES/reference.po
@@ -8301,7 +8301,7 @@ msgstr ""
 msgid ""
 "``*`` is a special value. It means that all columns that are not :doc:`/"
 "reference/columns/pseudo`."
-msgstr ""
+msgstr "``*``は特別な値で:doc:`reference/columns/pseudo` 擬似カラム以外の全てのカラムという意味です。"
 
 msgid "Here is a ``*`` usage example."
 msgstr "以下は ``*`` の使用例です。"


### PR DESCRIPTION
一部英語のままなので修正です。

作成した修正は、「擬似カラム 擬似カラム以外のすべてと表示されてしまう気がします。
適宜修正をお願いします。