### PR TITLE
travis: use latest pkg-config on Travis CI's OS X instances

### DIFF
--- a/tools/travis-install.sh
+++ b/tools/travis-install.sh
@@ -16,13 +16,12 @@ case "${TRAVIS_OS_NAME}" in
     ;;
   osx)
     brew update > /dev/null
-    brew unlink pkg-config
+    brew outdated pkg-config || brew upgrade pkg-config
     brew install \
          msgpack \
          libevent \
          mecab \
          mecab-ipadic \
-         pkg-config \
          pcre \
          cutter
     ;;

--- a/tools/travis-install.sh
+++ b/tools/travis-install.sh
@@ -16,6 +16,7 @@ case "${TRAVIS_OS_NAME}" in
     ;;
   osx)
     brew update > /dev/null
+    brew unlink pkg-config
     brew install \
          msgpack \
          libevent \


### PR DESCRIPTION
pkg-config 0.29 was merged in Homebrew 4 days ago.
This causes test failure on Travis CI's OSX instances.

When pkg-config 0.28 is installed on OS X with Homebrew
and then installing pkg-config 0.29:

NG:

``` bash
$ brew install pkg-config
```

OK:

```bash
$ brew unlink pkg-config
$ brew install pkg-config
```

or users can install pkg-config with `brew upgrade pkg-config`.

Above commands are tested on my MacBook '12 El Capitan.