### PR TITLE
pat_inspect_node: output all available nodes

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2670,7 +2670,7 @@ grn_pat_inspect_node(grn_ctx *ctx, grn_pat *pat, grn_id id, int check,
     GRN_TEXT_PUTS(ctx, buf, "\n");
     grn_pat_inspect_node(ctx, pat, node->lr[1], c, key_buf,
                          indent + 2, "R:", buf);
-  } else {
+  } else if (id) {
     int key_size;
     uint8_t *key;
 

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2664,6 +2664,13 @@ grn_pat_inspect_node(grn_ctx *ctx, grn_pat *pat, grn_id id, int check,
   grn_text_lltoa(ctx, buf, id);
 
   if (c > check) {
+    GRN_TEXT_PUTS(ctx, buf, "\n");
+    grn_pat_inspect_node(ctx, pat, node->lr[0], c, key_buf,
+                         indent + 2, "L:", buf);
+    GRN_TEXT_PUTS(ctx, buf, "\n");
+    grn_pat_inspect_node(ctx, pat, node->lr[1], c, key_buf,
+                         indent + 2, "R:", buf);
+  } else {
     int key_size;
     uint8_t *key;
 
@@ -2690,15 +2697,6 @@ grn_pat_inspect_node(grn_ctx *ctx, grn_pat *pat, grn_id id, int check,
       }
     }
     GRN_TEXT_PUTS(ctx, buf, "]");
-  }
-
-  if (c > check) {
-    GRN_TEXT_PUTS(ctx, buf, "\n");
-    grn_pat_inspect_node(ctx, pat, node->lr[0], c, key_buf,
-                         indent + 2, "L:", buf);
-    GRN_TEXT_PUTS(ctx, buf, "\n");
-    grn_pat_inspect_node(ctx, pat, node->lr[1], c, key_buf,
-                         indent + 2, "R:", buf);
   }
 }
 


### PR DESCRIPTION
I'm not sure but it seems ``grn_pat_inspect_node`` doesn't output all available nodes.

For example, In the following code, doesn't output "c" node.

```c
#include <stdio.h>
#include <string.h>
#include <groonga.h>

int
main(int argc, char **argv)
{
  grn_ctx ctx;
  grn_obj *db, *table;
  grn_id id;
  grn_obj *result;
  const char *path = "test.grn";

  grn_init();
  grn_ctx_init(&ctx, 0);
  db = grn_db_open(&ctx, path);
  if (!db) { db = grn_db_create(&ctx, path, NULL); }

  table = grn_table_create(&ctx, NULL, 0,
                           NULL,
                           GRN_OBJ_TABLE_PAT_KEY,
                           grn_ctx_at(&ctx, GRN_DB_SHORT_TEXT), NULL);

  grn_table_add(&ctx, table, "b", strlen("b"), NULL);
  grn_table_add(&ctx, table, "c", strlen("c"), NULL);
  grn_table_add(&ctx, table, "ca", strlen("ca"), NULL);
  grn_p(&ctx, table);
/*
before
#<table:pat (nil) key:ShortText value:(nil) size:3 columns:[] default_tokenizer:(nil) normalizer:(nil) keys:["b", "c", "ca"] subrec:none nodes:{
1("b"){0,7,0}[01100010]
  L:1
  R:3("ca"){0,7,1}[01100011 01100001]
    L:2
    R:3
}>
Not found "c"

after
#<table:pat (nil) key:ShortText value:(nil) size:3 columns:[] default_tokenizer:(nil) normalizer:(nil) keys:["b", "c", "ca"] subrec:none nodes:{
1
  L:1("b"){0,7,0}[01100010]
  R:3
    L:2("c"){0,7,0}[01100011]
    R:3("ca"){0,7,1}[01100011 01100001]
}>
*/
  {
    grn_table_cursor *tc;
    if ((tc = grn_table_cursor_open(&ctx, table, "c", strlen("c"), NULL, 0, 0, -1, GRN_CURSOR_PREFIX))) {
      grn_id id;
      while ((id = grn_table_cursor_next(&ctx, tc))) {
        grn_p(&ctx, tc);
      }
    }
    grn_table_cursor_close(&ctx, tc);
  }
  grn_obj_close(&ctx, db);
  grn_ctx_fin(&ctx);
  grn_fin();

  return 0;
}
```