### PR TITLE
plugin functions/char: add char_length()

### DIFF
--- a/plugins/functions/CMakeLists.txt
+++ b/plugins/functions/CMakeLists.txt
@@ -38,3 +38,23 @@ else()
   install(TARGETS vector_functions DESTINATION "${GRN_FUNCTIONS_PLUGIN_DIR}")
 endif()
 target_link_libraries(vector_functions libgroonga)
+
+read_file_list(${CMAKE_CURRENT_SOURCE_DIR}/string_sources.am
+  VECTOR_SOURCES)
+set_source_files_properties(${VECTOR_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS}")
+if(GRN_EMBED)
+  add_library(string_functions STATIC ${VECTOR_SOURCES})
+  set_target_properties(
+    string_functions
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON)
+else()
+  add_library(string_functions MODULE ${VECTOR_SOURCES})
+  set_target_properties(string_functions PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "string")
+  install(TARGETS string_functions DESTINATION "${GRN_FUNCTIONS_PLUGIN_DIR}")
+endif()
+target_link_libraries(string_functions libgroonga)

--- a/plugins/functions/Makefile.am
+++ b/plugins/functions/Makefile.am
@@ -15,6 +15,7 @@ LIBS =						\
 	$(top_builddir)/lib/libgroonga.la
 
 function_plugins_LTLIBRARIES =
-function_plugins_LTLIBRARIES += vector.la
+function_plugins_LTLIBRARIES += vector.la string.la
 
 include vector_sources.am
+include string_sources.am

--- a/plugins/functions/string.c
+++ b/plugins/functions/string.c
@@ -1,0 +1,98 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2016 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef GRN_EMBEDDED
+#  define GRN_PLUGIN_FUNCTION_TAG functions_string
+#endif
+
+#include <groonga/plugin.h>
+
+static grn_obj *
+func_string_length(grn_ctx *ctx, int n_args, grn_obj **args,
+                   grn_user_data *user_data)
+{
+  grn_obj *target;
+  unsigned int length = 0;
+  grn_obj *grn_length;
+
+  if (n_args != 1) {
+    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+                     "string_length(): wrong number of arguments (%d for 1)",
+                     n_args);
+    return NULL;
+  }
+
+  target = args[0];
+  switch (target->header.type) {
+  case GRN_BULK :
+    {
+      const char *s = GRN_TEXT_VALUE(target);
+      const char *e = GRN_TEXT_VALUE(target) + GRN_TEXT_LEN(target);
+      const char *p;
+      unsigned int cl = 0;
+      for (p = s; p < e && (cl = grn_charlen(ctx, p, e)); p += cl, length++);
+    }
+    break;
+  default :
+    {
+      grn_obj inspected;
+
+      GRN_TEXT_INIT(&inspected, 0);
+      grn_inspect(ctx, target, &inspected);
+      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+                       "string_length(): target object must be bulk: <%.*s>",
+                       (int)GRN_TEXT_LEN(&inspected),
+                       GRN_TEXT_VALUE(&inspected));
+      GRN_OBJ_FIN(ctx, &inspected);
+      return NULL;
+    }
+    break;
+  }
+
+  grn_length = grn_plugin_proc_alloc(ctx, user_data, GRN_DB_UINT32, 0);
+  if (!grn_length) {
+    return NULL;
+  }
+
+  GRN_UINT32_SET(ctx, grn_length, length);
+
+  return grn_length;
+}
+
+grn_rc
+GRN_PLUGIN_INIT(grn_ctx *ctx)
+{
+  return ctx->rc;
+}
+
+grn_rc
+GRN_PLUGIN_REGISTER(grn_ctx *ctx)
+{
+  grn_rc rc = GRN_SUCCESS;
+
+  grn_proc_create(ctx, "string_length", -1, GRN_PROC_FUNCTION, func_string_length,
+                  NULL, NULL, 0, NULL);
+
+  return rc;
+}
+
+grn_rc
+GRN_PLUGIN_FIN(grn_ctx *ctx)
+{
+  return GRN_SUCCESS;
+}

--- a/plugins/functions/string_sources.am
+++ b/plugins/functions/string_sources.am
@@ -1,0 +1,2 @@
+string_la_SOURCES =				\
+	string.c

--- a/test/command/suite/select/function/string/string_length/en.expected
+++ b/test/command/suite/select/function/string/string_length/en.expected
@@ -1,0 +1,43 @@
+plugin_register functions/string
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga"},
+{"_key": "Rroonga"}
+]
+[[0,0.0,0.0],2]
+select Memos   --output_columns '_key, string_length(_key)'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "string_length",
+          "Object"
+        ]
+      ],
+      [
+        "Groonga",
+        7
+      ],
+      [
+        "Rroonga",
+        7
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/string/string_length/en.test
+++ b/test/command/suite/select/function/string/string_length/en.test
@@ -1,0 +1,13 @@
+plugin_register functions/string
+
+table_create Memos TABLE_HASH_KEY ShortText
+
+load --table Memos
+[
+{"_key": "Groonga"},
+{"_key": "Rroonga"}
+]
+
+select Memos \
+  --output_columns '_key, string_length(_key)' \
+  --command_version 2

--- a/test/command/suite/select/function/string/string_length/ja.expected
+++ b/test/command/suite/select/function/string/string_length/ja.expected
@@ -1,0 +1,43 @@
+plugin_register functions/string
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "ぐるんが"},
+{"_key": "るるんが"}
+]
+[[0,0.0,0.0],2]
+select Memos   --output_columns '_key, string_length(_key)'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "string_length",
+          "Object"
+        ]
+      ],
+      [
+        "ぐるんが",
+        4
+      ],
+      [
+        "るるんが",
+        4
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/string/string_length/ja.test
+++ b/test/command/suite/select/function/string/string_length/ja.test
@@ -1,0 +1,13 @@
+plugin_register functions/string
+
+table_create Memos TABLE_HASH_KEY ShortText
+
+load --table Memos
+[
+{"_key": "ぐるんが"},
+{"_key": "るるんが"}
+]
+
+select Memos \
+  --output_columns '_key, string_length(_key)' \
+  --command_version 2


### PR DESCRIPTION
I want to filter with charctor length as following.

```
select Users --filter 'char_length(name) == 2' --output_columns 'name' --command_version 2
```