### PR TITLE
pat: Add grn_pat_fuzzy_search()

### DIFF
--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -110,7 +110,8 @@ void grn_pat_cache_disable(grn_ctx *ctx, grn_pat *pat);
 #define WITH_TRANSPOSITION                  (0x01)
 
 GRN_API grn_rc grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
-                                    const void *key, unsigned int key_size, unsigned int max_size,
+                                    const void *key, unsigned int key_size,
+                                    unsigned int prefix_match_size,
                                     unsigned int max_distance, int flags, grn_hash *h);
 
 #ifdef __cplusplus

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -107,7 +107,7 @@ void grn_pat_cursor_inspect(grn_ctx *ctx, grn_pat_cursor *c, grn_obj *buf);
 grn_rc grn_pat_cache_enable(grn_ctx *ctx, grn_pat *pat, uint32_t cache_size);
 void grn_pat_cache_disable(grn_ctx *ctx, grn_pat *pat);
 
-#define WITH_TRANSPOSITION                  (0x01)
+#define GRN_PAT_FUZZY_WITH_TRANSPOSITION                  (0x01)
 
 GRN_API grn_rc grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
                                     const void *key, unsigned int key_size,

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -109,7 +109,7 @@ void grn_pat_cache_disable(grn_ctx *ctx, grn_pat *pat);
 
 #define WITH_TRANSPOSITION                  (0x01)
 
-GRN_API grn_rc grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
+GRN_API grn_rc grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
                                     const void *key, unsigned int key_size, unsigned int max_size,
                                     unsigned int max_distance, int flags, grn_hash *h);
 

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -107,6 +107,12 @@ void grn_pat_cursor_inspect(grn_ctx *ctx, grn_pat_cursor *c, grn_obj *buf);
 grn_rc grn_pat_cache_enable(grn_ctx *ctx, grn_pat *pat, uint32_t cache_size);
 void grn_pat_cache_disable(grn_ctx *ctx, grn_pat *pat);
 
+#define WITH_TRANSPOSITION                  (0x01)
+
+GRN_API grn_rc grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
+                                    const void *key, unsigned int key_size, unsigned int max_size,
+                                    unsigned int max_distance, int flags, grn_hash *h);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1423,6 +1423,9 @@ grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
   }
   for (lx = 0; s < e && (len = grn_charlen(ctx, s, e)); s += len, lx++);
   dists = GRN_MALLOC((lx + 1) * (lx + max_distance + 1) * sizeof(uint16_t));
+  if (!dists) {
+    return GRN_NO_MEMORY_AVAILABLE;
+  }
 
   for (x = 0; x <= lx; x++) { DIST(x, 0) = x; }
   for (y = 0; y <= lx + max_distance ; y++) { DIST(0, y) = y; }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1261,7 +1261,7 @@ calc_edit_distance_by_offset(grn_ctx *ctx,
         b = DIST(x, y - 1) + 1;
         c = DIST(x - 1, y - 1) + 1;
         DIST(x, y) = ((a < b) ? ((a < c) ? a : c) : ((b < c) ? b : c));
-        if (flags == WITH_TRANSPOSITION
+        if (flags == GRN_PAT_FUZZY_WITH_TRANSPOSITION
             && x > 1 && y > 1
             && cx == cy
             && memcmp(px, py - cy, cx) == 0

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1224,6 +1224,222 @@ grn_pat_lcp_search(grn_ctx *ctx, grn_pat *pat, const void *key, uint32_t key_siz
   return r2;
 }
 
+#define DIST(ox,oy) (dists[((lx + 1) * (oy)) + (ox)])
+
+inline static uint16_t
+calc_edit_distance_by_offset(grn_ctx *ctx,
+                             const char *sx, const char *ex,
+                             const char *sy, const char *ey,
+                             uint16_t *dists, uint32_t lx,
+                             uint32_t offset, uint32_t max_distance,
+                             grn_bool *can_transition, int flags)
+{
+  uint32_t cx, cy, x = 1, y = 1;
+  const char *px, *py;
+
+  /* Skip already calculated rows */
+  for (py = sy, y = 1; py < ey && (cy = grn_charlen(ctx, py, ey)); py += cy, y++) {
+    if (py - sy >= offset) {
+      break;
+    }
+  }
+  for (; py < ey && (cy = grn_charlen(ctx, py, ey)); py += cy, y++) {
+    /* children nodes will be no longer smaller than max distance
+     * with only insertion costs.
+     * This is end of row on allocated memory. */
+    if (y > lx + max_distance) {
+      *can_transition = GRN_FALSE;
+      return max_distance + 1;
+    }
+
+    for (px = sx, x = 1; px < ex && (cx = grn_charlen(ctx, px, ex)); px += cx, x++) {
+      if (cx == cy && !memcmp(px, py, cx)) {
+        DIST(x, y) = DIST(x - 1, y - 1);
+      } else {
+        uint32_t a, b, c;
+        a = DIST(x - 1, y) + 1;
+        b = DIST(x, y - 1) + 1;
+        c = DIST(x - 1, y - 1) + 1;
+        DIST(x, y) = ((a < b) ? ((a < c) ? a : c) : ((b < c) ? b : c));
+        if (flags == WITH_TRANSPOSITION
+            && x > 1 && y > 1
+            && cx == cy
+            && memcmp(px, py - cy, cx) == 0
+            && memcmp(px - cx, py, cx) == 0) {
+          uint32_t t = DIST(x - 2, y - 2) + 1;
+          DIST(x, y) = ((DIST(x, y) < t) ? DIST(x, y) : t);
+        }
+      }
+    }
+  }
+  if (lx) {
+    /* If there is no cell which is smaller than equal to max distance on end of row,
+     * children nodes will be no longer smaller than max distance */
+    *can_transition = GRN_FALSE;
+    for (x = 1; x <= lx; x++) {
+      if (DIST(x, y - 1) <= max_distance) {
+        *can_transition = GRN_TRUE;
+        break;
+      }
+    }
+  }
+  return DIST(lx, y - 1);
+}
+
+typedef struct {
+  const char *key;
+  int key_length;
+  grn_bool can_transition;
+} fussy_node;
+
+inline static void
+_grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
+                      const char *key, uint32_t key_size,
+                      uint16_t *dists, uint32_t lx,
+                      int last_check, fussy_node *last_node,
+                      uint32_t max_distance, int flags, grn_hash *h)
+{
+  pat_node *node = NULL;
+  int check, len;
+  const char *k;
+  uint32_t offset = 0;
+
+  PAT_AT(pat, id, node);
+  if (!node) {
+    return;
+  }
+  check = PAT_CHK(node);
+  len = PAT_LEN(node);
+  k = pat_node_get_key(ctx, pat, node);
+
+  if (check > last_check) {
+    if (len >= last_node->key_length &&
+        !memcmp(k, last_node->key, last_node->key_length)) {
+      if (last_node->can_transition == GRN_FALSE) {
+        return;
+      }
+    }
+    _grn_pat_fussy_search(ctx, pat, node->lr[0],
+                          key, key_size, dists, lx,
+                          check, last_node,
+                          max_distance, flags, h);
+
+    _grn_pat_fussy_search(ctx, pat, node->lr[1],
+                          key, key_size, dists, lx,
+                          check, last_node,
+                          max_distance, flags, h);
+  } else {
+    if (id) {
+      /* Set already calculated common prefix length */
+      if (len >= last_node->key_length &&
+          !memcmp(k, last_node->key, last_node->key_length)) {
+        if (last_node->can_transition == GRN_FALSE) {
+          return;
+        }
+        offset = last_node->key_length;
+      } else {
+        if (last_node->can_transition == GRN_FALSE) {
+          last_node->can_transition = GRN_TRUE;
+        }
+        if (last_node->key_length) {
+          const char *kp = k;
+          const char *ke = k + len;
+          const char *p = last_node->key;
+          const char *e = last_node->key + last_node->key_length;
+          int lp;
+          for (;p < e && kp < ke && (lp = grn_charlen(ctx, p, e));
+               p += lp, kp += lp) {
+            if (p + lp <= e && kp + lp <= ke && memcmp(p, kp, lp)) {
+              break;
+            }
+          }
+          offset = kp - k;
+        }
+      }
+      if (len - offset) {
+        uint16_t distance = 0;
+        distance =
+          calc_edit_distance_by_offset(ctx,
+                                       key, key + key_size,
+                                       k, k + len,
+                                       dists, lx,
+                                       offset, max_distance,
+                                       &(last_node->can_transition), flags);
+        if (distance <= max_distance) {
+          if (DB_OBJ(h)->header.flags & GRN_OBJ_WITH_SUBREC) {
+            grn_rset_recinfo *ri;
+            if (grn_hash_add(ctx, h, &id, sizeof(grn_id), (void **)&ri, NULL)) {
+              ri->score = distance;
+            }
+          } else {
+            grn_hash_add(ctx, h, &id, sizeof(grn_id), NULL, NULL);
+          }
+        }
+      }
+      last_node->key = k;
+      last_node->key_length = len;
+    }
+  }
+  return;
+}
+
+grn_rc
+grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
+                     const void *key, uint32_t key_size, uint32_t max_size,
+                     uint32_t max_distance, int flags, grn_hash *h)
+{
+  pat_node *node;
+  grn_id id;
+  uint16_t *dists;
+  uint32_t lx, len, x, y;
+  const char *s = key;
+  const char *e = (const char *)key + key_size;
+  fussy_node last_node;
+  PAT_AT(pat, GRN_ID_NIL, node);
+  id = node->lr[1];
+
+  if (key_size > GRN_TABLE_MAX_KEY_SIZE ||
+      max_distance > GRN_TABLE_MAX_KEY_SIZE ||
+      max_size > key_size) {
+    return GRN_INVALID_ARGUMENT;
+  }
+  if (grn_pat_error_if_truncated(ctx, pat) != GRN_SUCCESS) {
+    return GRN_ID_NIL;
+  }
+  if (max_size) {
+    grn_pat_cursor *cur;
+    if ((cur = grn_pat_cursor_open(ctx, pat, key, max_size,
+                                   NULL, 0, 0, -1, GRN_CURSOR_PREFIX))) {
+      grn_id tid;
+      tid = grn_pat_cursor_next(ctx, cur);
+      grn_pat_cursor_close(ctx, cur);
+      if (tid) {
+        id = tid;
+      } else {
+        return GRN_END_OF_DATA;
+      }
+    }
+  }
+  for (lx = 0; s < e && (len = grn_charlen(ctx, s, e)); s += len, lx++);
+  dists = GRN_MALLOC((lx + 1) * (lx + max_distance + 1) * sizeof(uint16_t));
+
+  for (x = 0; x <= lx; x++) { DIST(x, 0) = x; }
+  for (y = 0; y <= lx + max_distance ; y++) { DIST(0, y) = y; }
+
+  last_node.key = NULL;
+  last_node.key_length = 0;
+  last_node.can_transition = GRN_TRUE;
+  _grn_pat_fussy_search(ctx, pat, id,
+                        key, key_size, dists, lx,
+                        -1, &last_node, max_distance, flags, h);
+  GRN_FREE(dists);
+  if (grn_hash_size(ctx, h)) {
+    return GRN_SUCCESS;
+  } else {
+    return GRN_END_OF_DATA;
+  }
+}
+
 inline static grn_rc
 _grn_pat_del(grn_ctx *ctx, grn_pat *pat, const char *key, uint32_t key_size, int shared,
              grn_table_delete_optarg *optarg)

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1396,17 +1396,19 @@ grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
   const char *s = key;
   const char *e = (const char *)key + key_size;
   fuzzy_node last_node;
-  PAT_AT(pat, GRN_ID_NIL, node);
-  id = node->lr[1];
-
+  grn_rc rc = grn_pat_error_if_truncated(ctx, pat);
+  if (rc != GRN_SUCCESS) {
+    return rc;
+  }
   if (key_size > GRN_TABLE_MAX_KEY_SIZE ||
       max_distance > GRN_TABLE_MAX_KEY_SIZE ||
       prefix_match_size > key_size) {
     return GRN_INVALID_ARGUMENT;
   }
-  if (grn_pat_error_if_truncated(ctx, pat) != GRN_SUCCESS) {
-    return GRN_ID_NIL;
-  }
+
+  PAT_AT(pat, GRN_ID_NIL, node);
+  id = node->lr[1];
+
   if (prefix_match_size) {
     grn_pat_cursor *cur;
     if ((cur = grn_pat_cursor_open(ctx, pat, key, prefix_match_size,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1423,7 +1423,9 @@ grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
       }
     }
   }
-  for (lx = 0; s < e && (len = grn_charlen(ctx, s, e)); s += len, lx++);
+  for (lx = 0; s < e && (len = grn_charlen(ctx, s, e)); s += len) {
+    lx++;
+  }
   dists = GRN_MALLOC((lx + 1) * (lx + max_distance + 1) * sizeof(uint16_t));
   if (!dists) {
     return GRN_NO_MEMORY_AVAILABLE;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1290,13 +1290,13 @@ typedef struct {
   const char *key;
   int key_length;
   grn_bool can_transition;
-} fussy_node;
+} fuzzy_node;
 
 inline static void
-_grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
+_grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
                       const char *key, uint32_t key_size,
                       uint16_t *dists, uint32_t lx,
-                      int last_check, fussy_node *last_node,
+                      int last_check, fuzzy_node *last_node,
                       uint32_t max_distance, int flags, grn_hash *h)
 {
   pat_node *node = NULL;
@@ -1319,12 +1319,12 @@ _grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
         return;
       }
     }
-    _grn_pat_fussy_search(ctx, pat, node->lr[0],
+    _grn_pat_fuzzy_search(ctx, pat, node->lr[0],
                           key, key_size, dists, lx,
                           check, last_node,
                           max_distance, flags, h);
 
-    _grn_pat_fussy_search(ctx, pat, node->lr[1],
+    _grn_pat_fuzzy_search(ctx, pat, node->lr[1],
                           key, key_size, dists, lx,
                           check, last_node,
                           max_distance, flags, h);
@@ -1384,7 +1384,7 @@ _grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
 }
 
 grn_rc
-grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
+grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
                      const void *key, uint32_t key_size, uint32_t max_size,
                      uint32_t max_distance, int flags, grn_hash *h)
 {
@@ -1394,7 +1394,7 @@ grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
   uint32_t lx, len, x, y;
   const char *s = key;
   const char *e = (const char *)key + key_size;
-  fussy_node last_node;
+  fuzzy_node last_node;
   PAT_AT(pat, GRN_ID_NIL, node);
   id = node->lr[1];
 
@@ -1429,7 +1429,7 @@ grn_pat_fussy_search(grn_ctx *ctx, grn_pat *pat,
   last_node.key = NULL;
   last_node.key_length = 0;
   last_node.can_transition = GRN_TRUE;
-  _grn_pat_fussy_search(ctx, pat, id,
+  _grn_pat_fuzzy_search(ctx, pat, id,
                         key, key_size, dists, lx,
                         -1, &last_node, max_distance, flags, h);
   GRN_FREE(dists);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1234,7 +1234,7 @@ calc_edit_distance_by_offset(grn_ctx *ctx,
                              uint32_t offset, uint32_t max_distance,
                              grn_bool *can_transition, int flags)
 {
-  uint32_t cx, cy, x = 1, y = 1;
+  uint32_t cx, cy, x, y;
   const char *px, *py;
 
   /* Skip already calculated rows */
@@ -1357,7 +1357,7 @@ _grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
         }
       }
       if (len - offset) {
-        uint16_t distance = 0;
+        uint16_t distance;
         distance =
           calc_edit_distance_by_offset(ctx,
                                        key, key + key_size,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1385,7 +1385,8 @@ _grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat, grn_id id,
 
 grn_rc
 grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
-                     const void *key, uint32_t key_size, uint32_t max_size,
+                     const void *key, uint32_t key_size,
+                     uint32_t prefix_match_size,
                      uint32_t max_distance, int flags, grn_hash *h)
 {
   pat_node *node;
@@ -1400,15 +1401,15 @@ grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
 
   if (key_size > GRN_TABLE_MAX_KEY_SIZE ||
       max_distance > GRN_TABLE_MAX_KEY_SIZE ||
-      max_size > key_size) {
+      prefix_match_size > key_size) {
     return GRN_INVALID_ARGUMENT;
   }
   if (grn_pat_error_if_truncated(ctx, pat) != GRN_SUCCESS) {
     return GRN_ID_NIL;
   }
-  if (max_size) {
+  if (prefix_match_size) {
     grn_pat_cursor *cur;
-    if ((cur = grn_pat_cursor_open(ctx, pat, key, max_size,
+    if ((cur = grn_pat_cursor_open(ctx, pat, key, prefix_match_size,
                                    NULL, 0, 0, -1, GRN_CURSOR_PREFIX))) {
       grn_id tid;
       tid = grn_pat_cursor_next(ctx, cur);

--- a/test/unit/core/test-patricia-trie-search.c
+++ b/test/unit/core/test-patricia-trie-search.c
@@ -24,8 +24,8 @@ void data_prefix_search(void);
 void test_prefix_search(gconstpointer data);
 void data_suffix_search(void);
 void test_suffix_search(gconstpointer data);
-void data_fussy_search(void);
-void test_fussy_search(gconstpointer data);
+void data_fuzzy_search(void);
+void test_fuzzy_search(gconstpointer data);
 
 static GList *keys;
 
@@ -389,7 +389,7 @@ test_suffix_search(gconstpointer data)
 }
 
 void
-data_fussy_search(void)
+data_fuzzy_search(void)
 {
   cut_add_data("nonexistence",
                xfix_test_data_new(GRN_END_OF_DATA, NULL, "cccc", NULL, NULL),
@@ -417,7 +417,7 @@ data_fussy_search(void)
 }
 
 void
-test_fussy_search(gconstpointer data)
+test_fuzzy_search(gconstpointer data)
 {
   const grn_trie_test_data *test_data = data;
   const gchar key1[]  = "あ";
@@ -440,11 +440,11 @@ test_fussy_search(gconstpointer data)
 
   cut_assert_create_hash();
   grn_test_assert_equal_rc(test_data->expected_rc,
-                           grn_pat_fussy_search(context, trie,
-                                                 test_data->search_key,
-                                                 strlen(test_data->search_key),
-                                                 0, 1, 1,
-                                                 hash));
+                           grn_pat_fuzzy_search(context, trie,
+                                                test_data->search_key,
+                                                strlen(test_data->search_key),
+                                                0, 1, 1,
+                                                hash));
   gcut_assert_equal_list_string(test_data->expected_strings,
                                 retrieve_all_keys());
 }

--- a/test/unit/core/test-patricia-trie-search.c
+++ b/test/unit/core/test-patricia-trie-search.c
@@ -24,6 +24,8 @@ void data_prefix_search(void);
 void test_prefix_search(gconstpointer data);
 void data_suffix_search(void);
 void test_suffix_search(gconstpointer data);
+void data_fussy_search(void);
+void test_fussy_search(gconstpointer data);
 
 static GList *keys;
 
@@ -381,6 +383,67 @@ test_suffix_search(gconstpointer data)
                            grn_pat_suffix_search(context, trie,
                                                  test_data->search_key,
                                                  strlen(test_data->search_key),
+                                                 hash));
+  gcut_assert_equal_list_string(test_data->expected_strings,
+                                retrieve_all_keys());
+}
+
+void
+data_fussy_search(void)
+{
+  cut_add_data("nonexistence",
+               xfix_test_data_new(GRN_END_OF_DATA, NULL, "cccc", NULL, NULL),
+               xfix_test_data_free,
+               "insertion",
+               xfix_test_data_new(GRN_SUCCESS,
+                                  gcut_list_string_new("ああ", "あ", NULL),
+               "あ", NULL, NULL),
+               xfix_test_data_free,
+               "deletion",
+               xfix_test_data_new(GRN_SUCCESS,
+                                  gcut_list_string_new("bbbbb", NULL),
+               "bbbbbb", NULL, NULL),
+               xfix_test_data_free,
+               "substitution",
+               xfix_test_data_new(GRN_SUCCESS,
+                                  gcut_list_string_new("cdefg", NULL),
+               "cdefh", NULL, NULL),
+               xfix_test_data_free,
+               "transposition",
+               xfix_test_data_new(GRN_SUCCESS,
+                                  gcut_list_string_new("cdefg", NULL),
+               "cdegf", NULL, NULL),
+               xfix_test_data_free);
+}
+
+void
+test_fussy_search(gconstpointer data)
+{
+  const grn_trie_test_data *test_data = data;
+  const gchar key1[]  = "あ";
+  const gchar key2[]  = "ああ";
+  const gchar key3[]  = "あああ";
+  const gchar key4[]  = "bbbb";
+  const gchar key5[]  = "bbbbb";
+  const gchar key6[]  = "cdefg";
+
+  trie_test_data_set_parameters(test_data);
+
+  cut_assert_create_trie();
+
+  cut_assert_lookup_add(key1);
+  cut_assert_lookup_add(key2);
+  cut_assert_lookup_add(key3);
+  cut_assert_lookup_add(key4);
+  cut_assert_lookup_add(key5);
+  cut_assert_lookup_add(key6);
+
+  cut_assert_create_hash();
+  grn_test_assert_equal_rc(test_data->expected_rc,
+                           grn_pat_fussy_search(context, trie,
+                                                 test_data->search_key,
+                                                 strlen(test_data->search_key),
+                                                 0, 1, 1,
                                                  hash));
   gcut_assert_equal_list_string(test_data->expected_strings,
                                 retrieve_all_keys());


### PR DESCRIPTION
パトリシアトライを使って**キー**の高速なあいまい検索を実装してみました。
これを取り込んでもよさそうでしたら、grn_obj_searchで転置索引に対してfuzzy_searchを使えるようにして、selector関数を作りたいと思っています。

以下の検証プログラムでwikipediaタイトル1万件のgrn_pat_fuzzyの結果がレコードごとに編集距離を求めた場合の結果と数が同じになることを確認しています。

https://gist.github.com/naoa/934da65118b7bbc99178

よければご検討をお願いします。

### API
```c
grn_rc grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
                            const void *key, unsigned int key_size, unsigned int max_size,
                            unsigned int max_distance, int flags, grn_hash *h);
```
keyとの編集距離がmax_distance以下であるキーのIDをhashにセットする。

max_distance: 取得対象とする最大の編集距離。この値が小さいほど多くの処理をスキップできて高速。
max_size: 前方一致検索する文字数。
flags: WITH_TRANSPOSITIONをつけると、並び替えのコストが1になる

### 高速化のポイント

高速化の主要なポイントは以下の２つです。

1. できるだけ同じ接頭辞の部分の計算結果を使い回す
2. 求めたい最大編集距離のパラメータを渡すことにより、最大編集距離以下にならないことが確定した時点でその子ノードの探索、編集距離演算をスキップする

#### 共通接頭辞の演算結果使い回し

動的計画法では、２つの文字列をマトリックスのx軸とy軸にマッピングし、行ごとに左隣、上、左斜めの最小値を計算していって最後に最も右下の値をとりだすことにより、編集距離を計算できます。

入力keyがdateでパトリシアトライのキーがdataだとすると以下のようにして1が求められます。

|||d|a|t|e|
|---|---|---|---|---|---|
||0|1|2|3|4|
|**d**|1|0|1|2|3|
|**a**|2|1|0|1|2|
|**t**|3|2|1|0|1|
|**a**|4|3|2|1|**1**|

パトリシアトライでは辞書順にキーを取り出すことができます。dataの次がdatabだったすると以下のようにして2が求められます。

|||d|a|t|e|
|---|---|---|---|---|---|
||0|1|2|3|4|
|**d**|1|0|1|2|3|
|**a**|2|1|0|1|2|
|**t**|3|2|1|0|1|
|**a**|4|3|2|1|1|
|**b**|5|4|3|2|**2**|

ここで、dataまでの1~4行は上の表と同じでまったく変更が必要ありません。そのため、この途中の行の計算結果を使い回すことができます。
これで5行の計算から1行の計算だけに抑えることができます。

#### 最大編集距離以上になる子ノードの枝刈り
パトリシアトライでは共通の接頭辞でまとめられており、子ノードは概ね親ノードの編集距離以上になります(正確にいうと以下のように親ノードの最終行の最小値以上)。

動的計画法では1行ごとに左隣、上、斜めだけしか見てないということから、子ノードの編集距離が親ノードの最終行の最小値未満になることはありません。そこで、求めたい最大編集距離のパラメータを渡すことにより、子ノードの探索をがっつりとやめることができます。

例えば、最大編集距離1が与えられた場合、上記のようにdatabで最終行の最小値は2ですので、次にどんな文字が来ようと、編集距離は1にはなり得ません。

さらにdatabaやdatabaseという子ノードがあっても、これらの探索、編集距離の演算をスキップすることができます。

これらにより、特にmax_distanceが十分に小さい範囲ではとても高速に編集距離が近いキーが列挙できます。

#### 実験結果

日本語wikipediaのタイトル30万件と実際に使っている英語DBの全文検索用の語彙表でキー数が1785万件(これは多すぎでもうちょっと丁寧にトークンをフィルターすべきな気がしますが）でmax_distanceと文字数を変化させた実行時間を以下に示します。
それぞれ100件の実行時間の平均値で単位は秒(sec)です。

比較対象として、レコードごとに動的計画法で同じものを求めた結果(edit max_d=1)を示しています。

* CPU
Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz

##### 日本語wikipediaタイトル キー数30万件

![image 1](https://cloud.githubusercontent.com/assets/5455147/12703558/6d13785a-c889-11e5-923d-7ced30278e1b.png)

|n_chars|pat max_d=1|pat max_d=2|pat max_d=3|pat max_d=5|pat max_d=10|edit max_d=1|
|---|---|---|---|---|---|---|
|1|0.0372|0.066|0.0818|0.117|0.1312|0.1691|
|5|0.0801|0.1269|0.1703|0.2084|0.2328|0.52|
|10|0.1282|0.2465|0.2705|0.3091|0.381|0.9158|
|20|0.2055|0.3312|0.4291|0.5307|0.5319|1.6355|
|30|0.3007|0.4634|0.5278|0.6064|0.6419|2.3025|


##### English lexicon キー数1785万件

![image 2](https://cloud.githubusercontent.com/assets/5455147/12703561/792806e2-c889-11e5-912e-0363be6bcbab.png)


|n_chars|pat max_d=1|pat max_d=2|pat max_d=3|pat max_d=5|pat max_d=10|edit max_d=1|
|---|---|---|---|---|---|---|
|1|0.012|0.028|0.233|2.099|6.334|13.712|
|5|0.007|0.103|0.782|3.62|11.075|44.911|
|10|0.021|0.171|1.168|6.293|16.482|80.639|
|20|0.01|0.149|1.701|10.762|32.621|152.047|
|30|0.019|0.23|2.674|15.95|53.588|223.545|


max_distanceが1や2では、枝刈りがかなり効いて文字数やキー数が増えても実行時間が大きく増えないことがわかります。

日本語の方がキー数が大分すくないのにmax_distance=1や2のときに時間がかかっているのは、日本語の方が文字種が多いからだと思われます。英語だとアルファベットと記号、数字ぐらいしか使われていません。

max_distanceが大きく、キー数が増えすぎると結構遅くなってしまうので、最初にprefixで絞れるオプションも入れています。max_sizeを1だけでもいれるとキー数1785万件、文字数10、max_distanceが5で1.5sec(max_size=0の場合、11sec)ぐらいで求めることができました。

#### 参考

http://stevehanov.ca/blog/index.php?id=114
https://murilo.wordpress.com/2011/02/01/fast-and-easy-levenshtein-distance-using-a-trie-in-c/