### PR TITLE
Fix fuzzy search

### DIFF
--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -293,7 +293,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
 
   if ((nargs - 1) < 2) {
     GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
-                     "fuzzy_serach(): wrong number of arguments (%d ...)",
+                     "fuzzy_search(): wrong number of arguments (%d ...)",
                      nargs - 1);
     rc = ctx->rc;
     goto exit;

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -398,7 +398,6 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
                      GRN_TEXT_VALUE(&inspected));
     rc = ctx->rc;
     GRN_OBJ_FIN(ctx, &inspected);
-    goto exit;
   } else {
     grn_search_optarg options = {0};
     options.mode = GRN_OP_FUZZY;

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -332,6 +332,9 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
     if (lexicon->header.type != GRN_TABLE_PAT_KEY) {
       use_sequential_search = GRN_TRUE;
     }
+    if (lexicon) {
+      grn_obj_unlink(ctx, lexicon);
+    }
   } else {
     if (grn_obj_is_key_accessor(ctx, obj) &&
         table->header.type == GRN_TABLE_PAT_KEY) {

--- a/test/command/suite/select/function/fuzzy_search/index/hash.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/hash.expected
@@ -37,7 +37,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _
       ],
       [
         "Tom",
-        0
+        1
       ],
       [
         "Tomy",

--- a/test/command/suite/select/function/fuzzy_search/sequential/max_distance.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/max_distance.expected
@@ -37,7 +37,7 @@ select Users --filter 'fuzzy_search(name, "To", 2)'   --output_columns 'name, _s
       ],
       [
         "Tomy",
-        2
+        1
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/sequential/or.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/or.expected
@@ -9,7 +9,7 @@ load --table Users
 {"name": "Ken"}
 ]
 [[0,0.0,0.0],3]
-select Users --filter 'fuzzy_search(name, "To", 5, 1)'   --output_columns 'name, _score'   --match_escalation_threshold -1
+select Users --filter 'name @^ "T" || fuzzy_search(name, "Ke", 1)'   --output_columns 'name, _score'   --match_escalation_threshold -1
 [
   [
     0,
@@ -19,7 +19,7 @@ select Users --filter 'fuzzy_search(name, "To", 5, 1)'   --output_columns 'name,
   [
     [
       [
-        2
+        3
       ],
       [
         [
@@ -37,6 +37,10 @@ select Users --filter 'fuzzy_search(name, "To", 5, 1)'   --output_columns 'name,
       ],
       [
         "Tomy",
+        1
+      ],
+      [
+        "Ken",
         1
       ]
     ]

--- a/test/command/suite/select/function/fuzzy_search/sequential/or.test
+++ b/test/command/suite/select/function/fuzzy_search/sequential/or.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Ken"}
+]
+
+select Users --filter 'name @^ "T" || fuzzy_search(name, "Ke", 1)' \
+  --output_columns 'name, _score' \
+  --match_escalation_threshold -1

--- a/test/command/suite/select/function/fuzzy_search/sequential/prefix_length_ja.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/prefix_length_ja.expected
@@ -33,11 +33,11 @@ select Users --filter 'fuzzy_search(name, "とむ", 5, 1)'   --output_columns 'n
       ],
       [
         "とむ",
-        0
+        1
       ],
       [
         "とみー",
-        2
+        1
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/sequential/reference.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/reference.expected
@@ -12,4 +12,4 @@ load --table Users
 ]
 [[0,0.0,0.0],3]
 select Users --filter 'fuzzy_search(name, "Tom", 2)'   --output_columns 'name, _score'   --match_escalation_threshold -1
-[[0,0.0,0.0],[[[2],[["name","Tag"],["_score","Int32"]],["Tom",0],["Tomy",1]]]]
+[[0,0.0,0.0],[[[2],[["name","Tag"],["_score","Int32"]],["Tom",1],["Tomy",1]]]]

--- a/test/command/suite/select/function/fuzzy_search/sequential/reference_vector.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/reference_vector.expected
@@ -38,7 +38,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 2)'   --output_columns 'name, _
           "Tom",
           "Tomy"
         ],
-        0
+        1
       ],
       [
         [

--- a/test/command/suite/select/function/fuzzy_search/sequential/text.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/text.expected
@@ -33,7 +33,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _
       ],
       [
         "Tom",
-        0
+        1
       ],
       [
         "Tomy",

--- a/test/command/suite/select/function/fuzzy_search/sequential/vector.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/vector.expected
@@ -36,7 +36,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 2)'   --output_columns 'name, _
           "Tom",
           "Tomy"
         ],
-        0
+        1
       ],
       [
         [


### PR DESCRIPTION
fuzzy_searchのシーケンシャルサーチでgrn_ii_posting_add()を使うようにして、編集距離ではなくインデックスを使った場合と同様にマッチ数のスコアを使うようにしました。

現状、grn_patの_keyを指定したときだけ、スコアが編集距離になっています。
ちょっとややこしいかもしれませんが、編集距離を使いたいときもあると思うので、grn_patの_keyのときは編集距離でもいいかなと思っています。

もしくは編集距離だすときはオプションか別関数とかにしたほうが自然ですかね？

また、細々としたの修正しました。
