### PR TITLE
Change how to calculate score of fuzzy_search

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1517,7 +1517,7 @@ grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
     if (DB_OBJ(h)->header.flags & GRN_OBJ_WITH_SUBREC) {
       grn_rset_recinfo *ri;
       if (grn_hash_add(ctx, h, &(heap->nodes[i].id), sizeof(grn_id), (void **)&ri, NULL)) {
-        ri->score = heap->nodes[i].distance;
+        ri->score = max_distance - heap->nodes[i].distance + 1;
       }
     } else {
       grn_hash_add(ctx, h, &(heap->nodes[i].id), sizeof(grn_id), NULL, NULL);

--- a/test/command/suite/select/function/fuzzy_search/index/index.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/index.expected
@@ -37,7 +37,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _
       ],
       [
         "Tom",
-        1
+        2
       ],
       [
         "Tomy",

--- a/test/command/suite/select/function/fuzzy_search/index/index_column.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/index_column.expected
@@ -37,7 +37,7 @@ select Users --filter 'fuzzy_search(Tags.tag, "Tom", 1)'   --output_columns 'nam
       ],
       [
         "Tom",
-        1
+        2
       ],
       [
         "Tomy",

--- a/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.expected
@@ -37,7 +37,7 @@ select Users --filter 'fuzzy_search(name, "Tom Yamad", 1)'   --output_columns 'n
       ],
       [
         "Tom Yamada",
-        1
+        2
       ],
       [
         "Tomy Yamada",

--- a/test/command/suite/select/function/fuzzy_search/pat/max_distance.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/max_distance.expected
@@ -37,11 +37,11 @@ select Tags --filter 'fuzzy_search(_key, "To", 2)'   --output_columns '_key, _sc
       ],
       [
         "Tom",
-        1
+        2
       ],
       [
         "Tomy",
-        2
+        1
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/pat/max_expansion.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/max_expansion.expected
@@ -14,4 +14,4 @@ load --table Users
 ]
 [[0,0.0,0.0],3]
 select Tags --filter 'fuzzy_search(_key, "To", 2, 0, 1)'   --output_columns '_key, _score'   --match_escalation_threshold -1
-[[0,0.0,0.0],[[[1],[["_key","ShortText"],["_score","Int32"]],["Tom",1]]]]
+[[0,0.0,0.0],[[[1],[["_key","ShortText"],["_score","Int32"]],["Tom",2]]]]

--- a/test/command/suite/select/function/fuzzy_search/pat/pat.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/pat.expected
@@ -37,7 +37,7 @@ select Tags --filter 'fuzzy_search(_key, "Tom", 1)'   --output_columns '_key, _s
       ],
       [
         "Tom",
-        0
+        2
       ],
       [
         "Tomy",

--- a/test/command/suite/select/function/fuzzy_search/pat/prefix_length.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/prefix_length.expected
@@ -37,11 +37,11 @@ select Tags --filter 'fuzzy_search(_key, "To", 5, 1)'   --output_columns '_key, 
       ],
       [
         "Tom",
-        1
+        5
       ],
       [
         "Tomy",
-        2
+        4
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/pat/prefix_length_ja.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/prefix_length_ja.expected
@@ -37,11 +37,11 @@ select Tags --filter 'fuzzy_search(_key, "とむ", 5, 1)'   --output_columns '_k
       ],
       [
         "とむ",
-        0
+        6
       ],
       [
         "とみー",
-        2
+        4
       ]
     ]
   ]


### PR DESCRIPTION
[[groonga-dev,03916]](https://osdn.jp/projects/groonga/lists/archive/dev/2016-February/003919.html)

２．編集距離に応じてトークンの重み付けをする。
の方の実装です。

編集距離を他のマッチスコアとなじませるためにmax_distance - edit_distance + 1としてみました。
同じ文字列(編集距離が0)がmax_distance + 1になります。
遠くなるほどスコアが下がり、最も遠いのが1です。

よければ、ご検討ください。

もし、１．の方が望ましければ閉じてください。