### PR TITLE
Fix fuzzy weight

### DIFF
--- a/test/command/suite/select/function/fuzzy_search/index/index.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/index.expected
@@ -10,9 +10,10 @@ load --table Users
 [
 {"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Ken"},
+{"name": "Tom"}
 ]
-[[0,0.0,0.0],3]
+[[0,0.0,0.0],4]
 select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _score'   --match_escalation_threshold -1
 [
   [
@@ -23,7 +24,7 @@ select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _
   [
     [
       [
-        2
+        3
       ],
       [
         [
@@ -42,6 +43,10 @@ select Users --filter 'fuzzy_search(name, "Tom", 1)'   --output_columns 'name, _
       [
         "Tomy",
         1
+      ],
+      [
+        "Tom",
+        2
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/index/index.test
+++ b/test/command/suite/select/function/fuzzy_search/index/index.test
@@ -8,7 +8,8 @@ load --table Users
 [
 {"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Ken"},
+{"name": "Tom"}
 ]
 
 select Users --filter 'fuzzy_search(name, "Tom", 1)' \

--- a/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.expected
@@ -10,9 +10,10 @@ load --table Users
 [
 {"name": "Tom Yamada"},
 {"name": "Tomy Yamada"},
-{"name": "Ken Yamada"}
+{"name": "Ken Yamada"},
+{"name": "Tom Yamad"}
 ]
-[[0,0.0,0.0],3]
+[[0,0.0,0.0],4]
 select Users --filter 'fuzzy_search(name, "Tom Yamad", 1)'   --output_columns 'name, _score'   --match_escalation_threshold -1
 [
   [
@@ -23,7 +24,7 @@ select Users --filter 'fuzzy_search(name, "Tom Yamad", 1)'   --output_columns 'n
   [
     [
       [
-        2
+        3
       ],
       [
         [
@@ -42,6 +43,10 @@ select Users --filter 'fuzzy_search(name, "Tom Yamad", 1)'   --output_columns 'n
       [
         "Tomy Yamada",
         1
+      ],
+      [
+        "Tom Yamad",
+        3
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.test
+++ b/test/command/suite/select/function/fuzzy_search/index/index_with_tokenizer.test
@@ -8,7 +8,8 @@ load --table Users
 [
 {"name": "Tom Yamada"},
 {"name": "Tomy Yamada"},
-{"name": "Ken Yamada"}
+{"name": "Ken Yamada"},
+{"name": "Tom Yamad"}
 ]
 
 select Users --filter 'fuzzy_search(name, "Tom Yamad", 1)' \

--- a/test/command/suite/select/function/fuzzy_search/index/vector.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/vector.expected
@@ -1,0 +1,70 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags tag COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": ["Tom", "Tomy"]},
+{"name": ["Tomy", "Tom"]},
+{"name": ["Tomy", "Ken"]},
+{"name": ["Tom", "Ken"]},
+{"name": ["Ken"]}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'fuzzy_search(name, "Tom", 2)'   --output_columns 'name, _score'   --match_escalation_threshold -1
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "name",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        [
+          "Tom",
+          "Tomy"
+        ],
+        2
+      ],
+      [
+        [
+          "Tomy",
+          "Tom"
+        ],
+        3
+      ],
+      [
+        [
+          "Tomy",
+          "Ken"
+        ],
+        2
+      ],
+      [
+        [
+          "Tom",
+          "Ken"
+        ],
+        3
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/fuzzy_search/index/vector.test
+++ b/test/command/suite/select/function/fuzzy_search/index/vector.test
@@ -1,0 +1,18 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_VECTOR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags tag COLUMN_INDEX Users name
+
+load --table Users
+[
+{"name": ["Tom", "Tomy"]},
+{"name": ["Tomy", "Tom"]},
+{"name": ["Tomy", "Ken"]},
+{"name": ["Tom", "Ken"]},
+{"name": ["Ken"]}
+]
+
+select Users --filter 'fuzzy_search(name, "Tom", 2)' \
+  --output_columns 'name, _score' \
+  --match_escalation_threshold -1


### PR DESCRIPTION
すいません。トークンごとに重みを設定するためにpostingの重みを使うと、全レコードのpostingに重みを設定する必要があって現実的ではありませんでした。。

そこで、grn_ii_cursorに新しくweightのメンバーを追加してtokenごとに同じ重みを適用できるようにしました。（このぐらいしか思いつきませんでした。。）
今後の拡張として、通常の全文検索でもlexiconに重みカラムを置いておいてそれを適用するようなこともできるかもしれません。

この実装方法はいかがでしょうか？
APIが変わってしまいますが、ii_cursor_openに引数weightを増やして設定するほうが自然かもしれません。

既存への影響を考えてこれは受け入れられず、fuzzyではトークンごとの重みを適用しないでも構いません。

その場合はこちら。(revert版 距離は関係なくマッチすれば1)
https://github.com/naoa/groonga/tree/revert-fuzzy-weight

よければ、ご検討ください。