### PR TITLE
column_remove: show more detail in error message

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1437,10 +1437,13 @@ proc_column_remove(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_
     if (col) {
       grn_obj_remove(ctx, col);
     } else {
-      ERR(GRN_INVALID_ARGUMENT, "column not found.");
+      ERR(GRN_INVALID_ARGUMENT, "[column][remove] column isn't found: <%.*s.%.*s>",
+          (int)GRN_TEXT_LEN(VAR(0)), GRN_TEXT_VALUE(VAR(0)),
+          (int)GRN_TEXT_LEN(VAR(1)), GRN_TEXT_VALUE(VAR(1)));
     }
   } else {
-    ERR(GRN_INVALID_ARGUMENT, "table not found.");
+    ERR(GRN_INVALID_ARGUMENT, "[column][remove] table isn't found: <%.*s>",
+        (int)GRN_TEXT_LEN(VAR(0)), GRN_TEXT_VALUE(VAR(0)));
   }
   GRN_OUTPUT_BOOL(!ctx->rc);
   return NULL;

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1439,7 +1439,7 @@ proc_column_remove(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_
     } else {
       ERR(GRN_INVALID_ARGUMENT, "[column][remove] column isn't found: <%.*s.%.*s>",
           (int)GRN_TEXT_LEN(VAR(0)), GRN_TEXT_VALUE(VAR(0)),
-          (int)GRN_TEXT_LEN(VAR(1)), GRN_TEXT_VALUE(VAR(1)));
+          colname_len, colname);
     }
   } else {
     ERR(GRN_INVALID_ARGUMENT, "[column][remove] table isn't found: <%.*s>",

--- a/test/command/suite/column_remove/nonexistent.expected
+++ b/test/command/suite/column_remove/nonexistent.expected
@@ -1,0 +1,8 @@
+column_remove Users name
+[[[-22,0.0,0.0],"[column][remove] table isn't found: <Users>"],false]
+#|e| [column][remove] table isn't found: <Users>
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_remove Users name
+[[[-22,0.0,0.0],"[column][remove] column isn't found: <Users.name>"],false]
+#|e| [column][remove] column isn't found: <Users.name>

--- a/test/command/suite/column_remove/nonexistent.test
+++ b/test/command/suite/column_remove/nonexistent.test
@@ -1,0 +1,4 @@
+column_remove Users name
+
+table_create Users TABLE_PAT_KEY ShortText
+column_remove Users name


### PR DESCRIPTION
I improved error messages in `column_remove` command. I referred to [`column_rename`](https://github.com/groonga/groonga/blob/master/lib/proc.c#L1480) command.