### PR TITLE
grn_table_fuzzy_search() support operator

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -2923,18 +2923,25 @@ grn_table_fuzzy_search(grn_ctx *ctx, grn_obj *table, const void *key, uint32_t k
   case GRN_TABLE_PAT_KEY :
     {
       grn_pat *pat = (grn_pat *)table;
-      grn_obj *hash;
-      hash = grn_table_create(ctx, NULL, 0, NULL,
-                              GRN_OBJ_TABLE_HASH_KEY|GRN_OBJ_WITH_SUBREC,
-                              table, NULL);
-      WITH_NORMALIZE(pat, key, key_size, {
-        rc = grn_pat_fuzzy_search(ctx, pat, key, key_size,
-                                  args, (grn_hash *)hash);
-      });
-      if (rc == GRN_SUCCESS) {
-        rc = grn_table_setoperation(ctx, res, hash, res, op);
+      if (!grn_table_size(ctx, res) && op == GRN_OP_OR) {
+        WITH_NORMALIZE(pat, key, key_size, {
+          rc = grn_pat_fuzzy_search(ctx, pat, key, key_size,
+                                    args, (grn_hash *)res);
+        });
+      } else {
+        grn_obj *hash;
+        hash = grn_table_create(ctx, NULL, 0, NULL,
+                                GRN_OBJ_TABLE_HASH_KEY|GRN_OBJ_WITH_SUBREC,
+                                table, NULL);
+        WITH_NORMALIZE(pat, key, key_size, {
+          rc = grn_pat_fuzzy_search(ctx, pat, key, key_size,
+                                    args, (grn_hash *)hash);
+        });
+        if (rc == GRN_SUCCESS) {
+          rc = grn_table_setoperation(ctx, res, hash, res, op);
+        }
+        grn_obj_unlink(ctx, hash);
       }
-      grn_obj_unlink(ctx, hash);
     }
     break;
   default :

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -85,7 +85,7 @@ grn_rc grn_table_search(grn_ctx *ctx, grn_obj *table,
 
 grn_rc grn_table_fuzzy_search(grn_ctx *ctx, grn_obj *table,
                               const void *key, uint32_t key_size,
-                              grn_fuzzy_search_optarg *args, grn_obj *res);
+                              grn_fuzzy_search_optarg *args, grn_obj *res, grn_operator op);
 
 grn_id grn_table_next(grn_ctx *ctx, grn_obj *table, grn_id id);
 

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -5612,7 +5612,7 @@ token_info_open(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii,
         GRN_OBJ_TABLE_HASH_KEY|GRN_OBJ_WITH_SUBREC,
         grn_ctx_at(ctx, GRN_DB_UINT32), NULL))) {
       grn_table_fuzzy_search(ctx, lexicon, key, key_size,
-                             args, (grn_obj *)h);
+                             args, (grn_obj *)h, GRN_OP_OR);
       if (GRN_HASH_SIZE(h)) {
         if ((ti->cursors = cursor_heap_open(ctx, GRN_HASH_SIZE(h)))) {
           grn_rset_recinfo *ri;

--- a/test/command/suite/select/function/fuzzy_search/pat/and.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/and.expected
@@ -1,0 +1,11 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Tom"},
+{"_key": "Tomy"},
+{"_key": "Ken"}
+]
+[[0,0.0,0.0],3]
+select Users --filter '_key @^ "T" && fuzzy_search(_key, "To", 1)'   --output_columns '_key, _score'   --match_escalation_threshold -1
+[[0,0.0,0.0],[[[1],[["_key","ShortText"],["_score","Int32"]],["Tom",2]]]]

--- a/test/command/suite/select/function/fuzzy_search/pat/and.test
+++ b/test/command/suite/select/function/fuzzy_search/pat/and.test
@@ -1,0 +1,12 @@
+table_create Users TABLE_PAT_KEY ShortText
+
+load --table Users
+[
+{"_key": "Tom"},
+{"_key": "Tomy"},
+{"_key": "Ken"}
+]
+
+select Users --filter '_key @^ "T" && fuzzy_search(_key, "To", 1)' \
+  --output_columns '_key, _score' \
+  --match_escalation_threshold -1

--- a/test/command/suite/select/function/fuzzy_search/pat/or.expected
+++ b/test/command/suite/select/function/fuzzy_search/pat/or.expected
@@ -1,0 +1,46 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Tom"},
+{"_key": "Tomy"},
+{"_key": "Ken"}
+]
+[[0,0.0,0.0],3]
+select Users --filter '_key @^ "T" || fuzzy_search(_key, "Ke", 1)'   --output_columns '_key, _score'   --match_escalation_threshold -1
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Tomy",
+        1
+      ],
+      [
+        "Tom",
+        1
+      ],
+      [
+        "Ken",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/fuzzy_search/pat/or.test
+++ b/test/command/suite/select/function/fuzzy_search/pat/or.test
@@ -1,0 +1,12 @@
+table_create Users TABLE_PAT_KEY ShortText
+
+load --table Users
+[
+{"_key": "Tom"},
+{"_key": "Tomy"},
+{"_key": "Ken"}
+]
+
+select Users --filter '_key @^ "T" || fuzzy_search(_key, "Ke", 1)' \
+  --output_columns '_key, _score' \
+  --match_escalation_threshold -1


### PR DESCRIPTION
TABLE_PATの_keyを直接指定したときのオペレータが反映できていませんでした。

インデックスでキーの列挙だけで使われるときにも、pat_fuzzy_searchとsetoperationで２回ループになって無駄になりそうなので、結果テーブルが0件、且つ、OP_ORのときはsetoperationをしないようにしています。

よければ、ご検討ください。