### PR TITLE
Snippet full

### DIFF
--- a/lib/grn_proc.h
+++ b/lib/grn_proc.h
@@ -44,6 +44,7 @@ void grn_proc_init_lock_release(grn_ctx *ctx);
 void grn_proc_init_object_exist(grn_ctx *ctx);
 void grn_proc_init_object_remove(grn_ctx *ctx);
 void grn_proc_init_schema(grn_ctx *ctx);
+void grn_proc_init_snippet_full(grn_ctx *ctx);
 void grn_proc_init_snippet_html(grn_ctx *ctx);
 void grn_proc_init_table_create(grn_ctx *ctx);
 void grn_proc_init_table_list(grn_ctx *ctx);

--- a/lib/grn_proc.h
+++ b/lib/grn_proc.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define GRN_SELECT_INTERNAL_VAR_CONDITION     "$condition"
+
 void grn_proc_init_from_env(void);
 
 GRN_VAR const char *grn_document_root;
@@ -42,6 +44,7 @@ void grn_proc_init_lock_release(grn_ctx *ctx);
 void grn_proc_init_object_exist(grn_ctx *ctx);
 void grn_proc_init_object_remove(grn_ctx *ctx);
 void grn_proc_init_schema(grn_ctx *ctx);
+void grn_proc_init_snippet_html(grn_ctx *ctx);
 void grn_proc_init_table_create(grn_ctx *ctx);
 void grn_proc_init_table_list(grn_ctx *ctx);
 void grn_proc_init_table_remove(grn_ctx *ctx);

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -6659,4 +6659,6 @@ grn_db_init_builtin_query(grn_ctx *ctx)
   grn_proc_init_fuzzy_search(ctx);
 
   grn_proc_init_object_remove(ctx);
+
+  grn_proc_init_snippet_full(ctx);
 }

--- a/lib/proc/proc_snippet.c
+++ b/lib/proc/proc_snippet.c
@@ -1,0 +1,152 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2009-2016 Brazil
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "../grn_proc.h"
+#include "../grn_expr.h"
+
+#include <groonga/plugin.h>
+#include <string.h>
+
+#define GRN_FUNC_SNIPPET_HTML_CACHE_NAME      "$snippet_html"
+
+static grn_obj *
+snippet_exec(grn_ctx *ctx, grn_obj *snip, grn_obj *text,
+             grn_user_data *user_data,
+             const char *prefix, int prefix_length,
+             const char *suffix, int suffix_length)
+{
+  grn_rc rc;
+  unsigned int i, n_results, max_tagged_length;
+  grn_obj snippet_buffer;
+  grn_obj *snippets;
+
+  if (GRN_TEXT_LEN(text) == 0) {
+    return NULL;
+  }
+
+  rc = grn_snip_exec(ctx, snip,
+                     GRN_TEXT_VALUE(text), GRN_TEXT_LEN(text),
+                     &n_results, &max_tagged_length);
+  if (rc != GRN_SUCCESS) {
+    return NULL;
+  }
+
+  if (n_results == 0) {
+    return grn_plugin_proc_alloc(ctx, user_data, GRN_DB_VOID, 0);
+  }
+
+  snippets = grn_plugin_proc_alloc(ctx, user_data, GRN_DB_SHORT_TEXT, GRN_OBJ_VECTOR);
+  if (!snippets) {
+    return NULL;
+  }
+
+  GRN_TEXT_INIT(&snippet_buffer, 0);
+  grn_bulk_space(ctx, &snippet_buffer, prefix_length + max_tagged_length + suffix_length);
+  for (i = 0; i < n_results; i++) {
+    unsigned int snippet_length;
+
+    GRN_BULK_REWIND(&snippet_buffer);
+    if (prefix_length) {
+      GRN_TEXT_PUT(ctx, &snippet_buffer, prefix, prefix_length);
+    }
+    rc = grn_snip_get_result(ctx, snip, i,
+                             GRN_TEXT_VALUE(&snippet_buffer) + prefix_length,
+                             &snippet_length);
+    if (rc == GRN_SUCCESS) {
+      grn_vector_add_element(ctx, snippets,
+                             strncat(GRN_TEXT_VALUE(&snippet_buffer), suffix, suffix_length),
+                             prefix_length + snippet_length + suffix_length,
+                             0, GRN_DB_SHORT_TEXT);
+    }
+  }
+  GRN_OBJ_FIN(ctx, &snippet_buffer);
+
+  return snippets;
+}
+
+static grn_obj *
+func_snippet_html(grn_ctx *ctx, int nargs, grn_obj **args,
+                  grn_user_data *user_data)
+{
+  grn_obj *snippets = NULL;
+
+  /* TODO: support parameters */
+  if (nargs == 1) {
+    grn_obj *text = args[0];
+    grn_obj *expression = NULL;
+    grn_obj *condition_ptr = NULL;
+    grn_obj *condition = NULL;
+    grn_obj *snip = NULL;
+    int flags = GRN_SNIP_SKIP_LEADING_SPACES;
+    unsigned int width = 200;
+    unsigned int max_n_results = 3;
+    const char *open_tag = "<span class=\"keyword\">";
+    const char *close_tag = "</span>";
+    grn_snip_mapping *mapping = GRN_SNIP_MAPPING_HTML_ESCAPE;
+
+    grn_proc_get_info(ctx, user_data, NULL, NULL, &expression);
+    condition_ptr = grn_expr_get_var(ctx, expression,
+                                     GRN_SELECT_INTERNAL_VAR_CONDITION,
+                                     strlen(GRN_SELECT_INTERNAL_VAR_CONDITION));
+    if (condition_ptr) {
+      condition = GRN_PTR_VALUE(condition_ptr);
+    }
+
+    if (condition) {
+      grn_obj *snip_ptr;
+      snip_ptr = grn_expr_get_var(ctx, expression,
+                                  GRN_FUNC_SNIPPET_HTML_CACHE_NAME,
+                                  strlen(GRN_FUNC_SNIPPET_HTML_CACHE_NAME));
+      if (snip_ptr) {
+        snip = GRN_PTR_VALUE(snip_ptr);
+      } else {
+        snip_ptr =
+          grn_expr_get_or_add_var(ctx, expression,
+                                  GRN_FUNC_SNIPPET_HTML_CACHE_NAME,
+                                  strlen(GRN_FUNC_SNIPPET_HTML_CACHE_NAME));
+        GRN_OBJ_FIN(ctx, snip_ptr);
+        GRN_PTR_INIT(snip_ptr, GRN_OBJ_OWN, GRN_DB_OBJECT);
+
+        snip = grn_snip_open(ctx, flags, width, max_n_results,
+                             open_tag, strlen(open_tag),
+                             close_tag, strlen(close_tag),
+                             mapping);
+        if (snip) {
+          grn_snip_set_normalizer(ctx, snip, GRN_NORMALIZER_AUTO);
+          grn_expr_snip_add_conditions(ctx, condition, snip,
+                                       0, NULL, NULL, NULL, NULL);
+          GRN_PTR_SET(ctx, snip_ptr, snip);
+        }
+      }
+    }
+
+    if (snip) {
+      snippets = snippet_exec(ctx, snip, text, user_data, NULL, 0, NULL, 0);
+    }
+  }
+
+  if (!snippets) {
+    snippets = grn_plugin_proc_alloc(ctx, user_data, GRN_DB_VOID, 0);
+  }
+
+  return snippets;
+}
+
+void
+grn_proc_init_snippet_html(grn_ctx *ctx)
+{
+  grn_proc_create(ctx, "snippet_html", -1, GRN_PROC_FUNCTION,
+                  func_snippet_html, NULL, NULL, 0, NULL);
+}

--- a/lib/proc/sources.am
+++ b/lib/proc/sources.am
@@ -5,4 +5,5 @@ libgrnproc_la_SOURCES =				\
 	proc_lock.c				\
 	proc_object.c				\
 	proc_schema.c				\
+	proc_snippet.c				\
 	proc_table.c

--- a/test/command/suite/select/function/snippet_full/cache.expected
+++ b/test/command/suite/select/function/snippet_full/cache.expected
@@ -1,0 +1,41 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "<p>mroonga and MySQL</p>"},
+{"content": "<p>pgroonga and PostgreSQL</p>"}
+]
+[[0,0.0,0.0],2]
+select Entries   --output_columns '   snippet_full(content, {},   "SQL", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "<p>mroonga and My<span class=\"keyword\">SQL</span></p>"
+        ]
+      ],
+      [
+        [
+          "<p>pgroonga and Postgre<span class=\"keyword\">SQL</span></p>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/cache.test
+++ b/test/command/suite/select/function/snippet_full/cache.test
@@ -1,0 +1,15 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "<p>mroonga and MySQL</p>"},
+{"content": "<p>pgroonga and PostgreSQL</p>"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {}, \
+  "SQL", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/default.expected
+++ b/test/command/suite/select/function/snippet_full/default.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {},   "Groonga", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "<p><span class=\"keyword\">groonga</span> and MySQL</p>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/default.test
+++ b/test/command/suite/select/function/snippet_full/default.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {}, \
+  "Groonga", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/default_tag.expected
+++ b/test/command/suite/select/function/snippet_full/default_tag.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"default_open_tag": "<span>", "default_close_tag": "</span>"},   "Groonga", "MySQL"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "<p><span>groonga</span> and <span>MySQL</span></p>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/default_tag.test
+++ b/test/command/suite/select/function/snippet_full/default_tag.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"default_open_tag": "<span>", "default_close_tag": "</span>"}, \
+  "Groonga", "MySQL" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/html_escape.expected
+++ b/test/command/suite/select/function/snippet_full/html_escape.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"html_escape": true},   "groonga", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "&lt;p&gt;<span class=\"keyword\">groonga</span> and MySQL&lt;/p&gt;"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/html_escape.test
+++ b/test/command/suite/select/function/snippet_full/html_escape.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "<p>groonga and MySQL</p>"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"html_escape": true}, \
+  "groonga", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/leading_space.expected
+++ b/test/command/suite/select/function/snippet_full/leading_space.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"skip_leading_spaces": false},   "MySQL", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "groonga and<span class=\"keyword\"> MySQL</span>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/leading_space.test
+++ b/test/command/suite/select/function/snippet_full/leading_space.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"skip_leading_spaces": false}, \
+  "MySQL", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/max_results.expected
+++ b/test/command/suite/select/function/snippet_full/max_results.expected
@@ -1,0 +1,36 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"width": 10, "max_n_results": 2},   "SQL", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "d My<span class=\"keyword\">SQL</span> an",
+          "Posrgre<span class=\"keyword\">SQL</span>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/max_results.test
+++ b/test/command/suite/select/function/snippet_full/max_results.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"width": 10, "max_n_results": 2}, \
+  "SQL", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/normalizer.expected
+++ b/test/command/suite/select/function/snippet_full/normalizer.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"normalizer": "NormalizerAuto"},   "sql", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "groonga and My<span class=\"keyword\">SQL</span> and Posrgre<span class=\"keyword\">SQL</span>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/normalizer.test
+++ b/test/command/suite/select/function/snippet_full/normalizer.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"normalizer": "NormalizerAuto"}, \
+  "sql", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/prefix.expected
+++ b/test/command/suite/select/function/snippet_full/prefix.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"prefix": "..."},   "SQL", "<span class=\\"w1\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "...groonga and My<span class=\"w1\">SQL</span> and Posrgre<span class=\"w1\">SQL</span>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/prefix.test
+++ b/test/command/suite/select/function/snippet_full/prefix.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"prefix": "..."}, \
+  "SQL", "<span class=\\"w1\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/suffix.expected
+++ b/test/command/suite/select/function/snippet_full/suffix.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"suffix": "..."},   "SQL", "<span class=\\"keyword\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "groonga and My<span class=\"keyword\">SQL</span> and Posrgre<span class=\"keyword\">SQL</span>..."
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/suffix.test
+++ b/test/command/suite/select/function/snippet_full/suffix.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"suffix": "..."}, \
+  "SQL", "<span class=\\"keyword\\">", "</span>" \
+  )' \
+  --command_version 2

--- a/test/command/suite/select/function/snippet_full/twice_keyword.expected
+++ b/test/command/suite/select/function/snippet_full/twice_keyword.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content, {"prefix": "..."},   "SQL", "<span class=\\"keyword1\\">", "</span>",   "groonga", "<span class=\\"keyword2\\">", "</span>"   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "...<span class=\"keyword2\">groonga</span> and My<span class=\"keyword1\">SQL</span> and Posrgre<span class=\"keyword1\">SQL</span>"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/twice_keyword.test
+++ b/test/command/suite/select/function/snippet_full/twice_keyword.test
@@ -1,0 +1,15 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "groonga and MySQL and PosrgreSQL"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, {"prefix": "..."}, \
+  "SQL", "<span class=\\"keyword1\\">", "</span>", \
+  "groonga", "<span class=\\"keyword2\\">", "</span>" \
+  )' \
+  --command_version 2


### PR DESCRIPTION
object literal形式のオプションを使ってフルスペックのsnippet_full関数を実装しました。

snippet_htmlでconditionからキーワードを引っ張る場合、filterのキーワードもすべてひっぱちゃうので、queryだけのものをスニペットしたいときなどに有用です。

default_open_tagとdefault_close_tagオプションがある場合は、後ろにN個のキーワード並べます。
```
snippet_full(string_or_column, {option}, [keyword1,keyword2...] )
```
default_open_tagとdefault_close_tagオプションがない場合は、後ろにキーワードと開始タグと終了タグの３つセットで並べます。
```
snippet_full(string_or_column, {option},
 [keyword1,open_tag1, close_tag1, keyword2, open_tag2, close_tag2...] )
```
* option

| property            | description                                                | default        |
|---------------------|------------------------------------------------------------|----------------|
| width               | スニペットサイズ                                       | 200            |
| skip_leading_spaces | 先頭のスペースを除去するか。<br>NormalizerAutoの場合やったほうがいい |      true      |
| html_escape         | HTMLエスケープするかどうか                                 | false          |
| prefix              | スニペットの先頭に付加する文字列(e.g. "...")               | NULL           |
| suffix              | スニペットの末尾に付加する文字列(e.g. "...")               | NULL           |
| normalizer          | ノーマライザー                                             | NormalizerAuto |
| default_open_tag    | キーワードの開始タグ                                       | NULL           |
| default_close_tag   | キーワードの終了タグ                                       | NULL           |

よければ、ご検討ください。