### PR TITLE
snippet_full: allow doesn't use any normalizer

### DIFF
--- a/lib/proc/proc_snippet.c
+++ b/lib/proc/proc_snippet.c
@@ -265,9 +265,9 @@ func_snippet_full(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_d
       if (snip) {
         grn_rc rc;
         unsigned int i;
-        if (!normalizer_name_length) {
+        if (!normalizer_name) {
           grn_snip_set_normalizer(ctx, snip, GRN_NORMALIZER_AUTO);
-        } else {
+        } else if (normalizer_name_length) {
           grn_obj *normalizer;
           normalizer = grn_ctx_get(ctx, normalizer_name, normalizer_name_length);
           if (!grn_obj_is_normalizer_proc(ctx, normalizer)) {

--- a/test/command/suite/select/function/snippet_full/no_normalizer.expected
+++ b/test/command/suite/select/function/snippet_full/no_normalizer.expected
@@ -1,0 +1,35 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "MySQL is a kind of sql database server"}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet_full(content,   "sql", "<span class=\\"keyword\\">", "</span>",   {"normalizer": ""}   )'   --command_version 2
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet_full",
+          "null"
+        ]
+      ],
+      [
+        [
+          "MySQL is a kind of <span class=\"keyword\">sql</span> database server"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet_full/no_normalizer.test
+++ b/test/command/suite/select/function/snippet_full/no_normalizer.test
@@ -1,0 +1,15 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "MySQL is a kind of sql database server"}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet_full(content, \
+  "sql", "<span class=\\"keyword\\">", "</span>", \
+  {"normalizer": ""} \
+  )' \
+  --command_version 2


### PR DESCRIPTION
snippet関数でデフォルトはNormalizerAutoとしたのですが、```{"normalizer": ""}```でNormalizerを使用しないこともできるようにしたいと思いました。

