### PR TITLE
suppress warning message for fuzzy search etc

### DIFF
--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -325,12 +325,16 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
       hash = GRN_PTR_VALUE(hash_args_ptr);
       if (hash->header.type != GRN_TABLE_HASH_KEY) {
         GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
-                         "fuzzy_search(): 3rd argument must be object literal: <%.*s>",
+                         "fuzzy_search(): "
+                         "3rd argument must be object literal: <%.*s>",
                          (int)GRN_TEXT_LEN(args[3]), GRN_TEXT_VALUE(args[3]));
         goto exit;
       }
 
-      if (!(cursor = grn_hash_cursor_open(ctx, (grn_hash *)hash, NULL, 0, NULL, 0, 0, -1, 0))) {
+      cursor = grn_hash_cursor_open(ctx, (grn_hash *)hash,
+                                    NULL, 0, NULL, 0,
+                                    0, -1, 0);
+      if (!cursor) {
         GRN_PLUGIN_ERROR(ctx, GRN_NO_MEMORY_AVAILABLE,
                          "fuzzy_search(): couldn't open cursor");
         goto exit;

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -296,7 +296,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
   grn_obj *target = NULL;
   grn_obj *obj;
   grn_obj *query;
-  grn_obj *hash_args_ptr;
+  grn_obj *option_ptr;
   uint32_t max_distance = 1;
   uint32_t prefix_length = 0;
   uint32_t prefix_match_size = 0;
@@ -319,11 +319,11 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
     void *key;
     grn_obj *value;
     int key_size;
-    hash_args_ptr = args[3];
-    if (hash_args_ptr->header.type == GRN_PTR) {
-      grn_obj *hash;
-      hash = GRN_PTR_VALUE(hash_args_ptr);
-      if (hash->header.type != GRN_TABLE_HASH_KEY) {
+    option_ptr = args[3];
+    if (option_ptr->header.type == GRN_PTR) {
+      grn_obj *option;
+      option = GRN_PTR_VALUE(option_ptr);
+      if (option->header.type != GRN_TABLE_HASH_KEY) {
         GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
                          "fuzzy_search(): "
                          "3rd argument must be object literal: <%.*s>",
@@ -331,7 +331,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
         goto exit;
       }
 
-      cursor = grn_hash_cursor_open(ctx, (grn_hash *)hash,
+      cursor = grn_hash_cursor_open(ctx, (grn_hash *)option,
                                     NULL, 0, NULL, 0,
                                     0, -1, 0);
       if (!cursor) {

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -318,7 +318,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
     grn_hash_cursor *cursor;
     void *key;
     grn_obj *value;
-    int key_size, value_size;
+    int key_size;
     hash_args_ptr = args[3];
     if (hash_args_ptr->header.type == GRN_PTR) {
       grn_obj *hash;
@@ -340,7 +340,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
         goto exit;
       }
       while (grn_hash_cursor_next(ctx, cursor) != GRN_ID_NIL) {
-        value_size = grn_hash_cursor_get_key_value(ctx, cursor, &key, &key_size, (void **)&value);
+        grn_hash_cursor_get_key_value(ctx, cursor, &key, &key_size, (void **)&value);
 
         if (key_size == 12 && !memcmp(key, "max_distance", 12)) {
           max_distance = GRN_UINT32_VALUE(value);

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -353,7 +353,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
             flags |= GRN_TABLE_FUZZY_SEARCH_WITH_TRANSPOSITION;
           }
         } else {
-          GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT, "invalid option name: %.*s",
+          GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT, "invalid option name: <%.*s>",
                            key_size, (char *)key);
           grn_hash_cursor_close(ctx, cursor);
           goto exit;

--- a/lib/proc/proc_highlight.c
+++ b/lib/proc/proc_highlight.c
@@ -298,7 +298,7 @@ func_highlight(grn_ctx *ctx, int nargs, grn_obj **args,
             default_close_tag = GRN_TEXT_VALUE(value);
             default_close_tag_length = GRN_TEXT_LEN(value);
           } else {
-            GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT, "invalid option name: %.*s",
+            GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT, "invalid option name: <%.*s>",
                              key_size, (char *)key);
             grn_hash_cursor_close(ctx, cursor);
             goto exit;


### PR DESCRIPTION
他の環境でビルドしてきづきました。

```
proc_fuzzy_search.c:327:21: warning: 'hash' may be used uninitialized in this function [-Wmaybe-uninitialized]
```
warningの抑止とスタイルなど非常にこまごました修正です。
