### PR TITLE
hash: support 4GiB over total key size

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -335,6 +335,8 @@ typedef uint16_t grn_obj_flags;
 #define GRN_OBJ_UNIT_USERDEF_SECTION   (0x07<<8)
 #define GRN_OBJ_UNIT_USERDEF_POSITION  (0x08<<8)
 
+#define GRN_OBJ_KEY_LARGE              (0x01<<12)
+
 #define GRN_OBJ_NO_SUBREC              (0x00<<13)
 #define GRN_OBJ_WITH_SUBREC            (0x01<<13)
 

--- a/lib/db.c
+++ b/lib/db.c
@@ -933,6 +933,17 @@ grn_table_create_validate(grn_ctx *ctx, const char *name, unsigned int name_size
     return ctx->rc;
   }
 
+  if ((flags & GRN_OBJ_KEY_LARGE) &&
+      table_type != GRN_OBJ_TABLE_HASH_KEY) {
+    ERR(GRN_INVALID_ARGUMENT,
+        "[table][create] "
+        "large key support is available only for TABLE_HASH_KEY key table: "
+        "<%.*s>(%s)",
+        name_size, name,
+        table_type_name);
+    return ctx->rc;
+  }
+
   return ctx->rc;
 }
 

--- a/lib/dump.c
+++ b/lib/dump.c
@@ -39,6 +39,9 @@ grn_dump_table_create_flags(grn_ctx *ctx,
     GRN_TEXT_PUTS(ctx, buffer, "TABLE_NO_KEY");
     break;
   }
+  if (flags & GRN_OBJ_KEY_LARGE) {
+    GRN_TEXT_PUTS(ctx, buffer, "|KEY_LARGE");
+  }
   if (flags & GRN_OBJ_KEY_WITH_SIS) {
     GRN_TEXT_PUTS(ctx, buffer, "|KEY_WITH_SIS");
   }

--- a/lib/grn_hash.h
+++ b/lib/grn_hash.h
@@ -254,7 +254,7 @@ struct _grn_hash {
   uint32_t value_size;\
   grn_id tokenizer;\
   uint32_t curr_rec;\
-  int32_t curr_key;\
+  uint32_t curr_key;\
   uint32_t idx_offset;\
   uint32_t entry_size;\
   uint32_t max_offset;\
@@ -263,7 +263,8 @@ struct _grn_hash {
   uint32_t lock;\
   grn_id normalizer;\
   uint32_t truncated;\
-  uint32_t reserved[14]
+  uint64_t curr_key_large;\
+  uint32_t reserved[12]
 
 struct _grn_hash_header_common {
   GRN_HASH_HEADER_COMMON_FIELDS;
@@ -364,6 +365,8 @@ grn_id grn_hash_at(grn_ctx *ctx, grn_hash *hash, grn_id id);
 grn_id grn_array_at(grn_ctx *ctx, grn_array *array, grn_id id);
 
 void grn_hash_check(grn_ctx *ctx, grn_hash *hash);
+
+grn_bool grn_hash_is_large_total_key_size(grn_ctx *ctx, grn_hash *hash);
 
 uint64_t grn_hash_total_key_size(grn_ctx *ctx, grn_hash *hash);
 uint64_t grn_hash_max_total_key_size(grn_ctx *ctx, grn_hash *hash);

--- a/lib/proc/proc_table.c
+++ b/lib/proc/proc_table.c
@@ -52,6 +52,9 @@ command_table_create_parse_flags(grn_ctx *ctx,
     } else if (!memcmp(nptr, "KEY_WITH_SIS", 12)) {
       flags |= GRN_OBJ_KEY_WITH_SIS;
       nptr += 12;
+    } else if (!memcmp(nptr, "KEY_LARGE", 9)) {
+      flags |= GRN_OBJ_KEY_LARGE;
+      nptr += 9;
     } else {
       GRN_PLUGIN_ERROR(ctx,
                        GRN_INVALID_ARGUMENT,

--- a/test/command/suite/dump/schema/table/hash/key_large_flag.expected
+++ b/test/command/suite/dump/schema/table/hash/key_large_flag.expected
@@ -1,0 +1,4 @@
+table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText

--- a/test/command/suite/dump/schema/table/hash/key_large_flag.test
+++ b/test/command/suite/dump/schema/table/hash/key_large_flag.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText
+
+dump

--- a/test/command/suite/table_create/key_large/hash_key.expected
+++ b/test/command/suite/table_create/key_large/hash_key.expected
@@ -1,0 +1,46 @@
+table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Alice"},
+{"_key": "Bob"},
+{"_key": "Charlie"}
+]
+[[0,0.0,0.0],3]
+select Users
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "Alice"
+      ],
+      [
+        2,
+        "Bob"
+      ],
+      [
+        3,
+        "Charlie"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/table_create/key_large/hash_key.test
+++ b/test/command/suite/table_create/key_large/hash_key.test
@@ -1,0 +1,10 @@
+table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText
+
+load --table Users
+[
+{"_key": "Alice"},
+{"_key": "Bob"},
+{"_key": "Charlie"}
+]
+
+select Users

--- a/test/command/suite/table_create/key_large/patricia_trie.expected
+++ b/test/command/suite/table_create/key_large/patricia_trie.expected
@@ -1,0 +1,13 @@
+table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[table][create] large key support is available only for TABLE_HASH_KEY key table: <Users>(TABLE_PAT_KEY)"
+  ],
+  false
+]
+#|e| [table][create] large key support is available only for TABLE_HASH_KEY key table: <Users>(TABLE_PAT_KEY)

--- a/test/command/suite/table_create/key_large/patricia_trie.test
+++ b/test/command/suite/table_create/key_large/patricia_trie.test
@@ -1,0 +1,1 @@
+table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText


### PR DESCRIPTION
If you add KEY_LARGE flag to table:

    table_create Users TABLE_HASH_KEY|KEY_LARGE ShortText

you can put many keys to the table. By default, 4GiB is the max total
key size. With KEY_LARGE flag, 1TiB is the max total key size. Because
4KiB * (2 ** 28 - 1) < 1TiB. ((2 ** 28 - 1) is the max number of records
in a table.)

It doesn't break backward compatibility. You can use the existing
database without dump and restore.