### PR TITLE
log: fix a crash bug reported in #503

### DIFF
--- a/lib/ctx.c
+++ b/lib/ctx.c
@@ -78,6 +78,7 @@
 grn_ctx grn_gctx = GRN_CTX_INITIALIZER(GRN_ENC_DEFAULT);
 int grn_pagesize;
 grn_critical_section grn_glock;
+grn_critical_section grn_glock_backtrace;
 uint32_t grn_gtick;
 int grn_lock_timeout = GRN_LOCK_TIMEOUT;
 
@@ -933,6 +934,7 @@ grn_init(void)
   grn_logger_init();
   grn_query_logger_init();
   CRITICAL_SECTION_INIT(grn_glock);
+  CRITICAL_SECTION_INIT(grn_glock_backtrace);
   grn_gtick = 0;
   ctx->next = ctx;
   ctx->prev = ctx;
@@ -1057,6 +1059,7 @@ fail_ctx_init_internal:
   GRN_LOG(ctx, GRN_LOG_NOTICE, "grn_init: <%s>: failed", grn_get_version());
   grn_query_logger_fin(ctx);
   grn_logger_fin(ctx);
+  CRITICAL_SECTION_FIN(grn_glock_backtrace);
   CRITICAL_SECTION_FIN(grn_glock);
   grn_fin_external_libraries();
   return rc;
@@ -1151,6 +1154,7 @@ grn_fin(void)
   grn_com_fin();
   GRN_LOG(ctx, GRN_LOG_NOTICE, "grn_fin (%d)", alloc_count);
   grn_logger_fin(ctx);
+  CRITICAL_SECTION_FIN(grn_glock_backtrace);
   CRITICAL_SECTION_FIN(grn_glock);
   grn_fin_external_libraries();
   return GRN_SUCCESS;

--- a/lib/grn_ctx.h
+++ b/lib/grn_ctx.h
@@ -98,6 +98,9 @@ GRN_API void grn_ctx_impl_set_current_error_message(grn_ctx *ctx);
 #define LOGTRACE(ctx,lvl) do {\
   int i;\
   char **p;\
+  if (ctx == &grn_gctx) {\
+    CRITICAL_SECTION_ENTER(grn_glock_backtrace);\
+  }\
   BACKTRACE(ctx);\
   p = backtrace_symbols((ctx)->trace, (ctx)->ntrace);\
   if (!p) {\
@@ -107,6 +110,9 @@ GRN_API void grn_ctx_impl_set_current_error_message(grn_ctx *ctx);
       GRN_LOG((ctx), lvl, "%s", p[i]);\
     }\
     free(p);\
+  }\
+  if (ctx == &grn_gctx) {\
+    CRITICAL_SECTION_LEAVE(grn_glock_backtrace);\
   }\
 } while (0)
 #else  /* HAVE_BACKTRACE */
@@ -501,6 +507,7 @@ void grn_assert(grn_ctx *ctx, int cond, const char* file, int line, const char* 
 GRN_VAR grn_ctx grn_gctx;
 extern int grn_pagesize;
 extern grn_critical_section grn_glock;
+extern grn_critical_section grn_glock_backtrace;
 extern uint32_t grn_gtick;
 extern int grn_lock_timeout;
 


### PR DESCRIPTION
Use a critical section object to make backtracing with grn_gctx thread-safe.

Note that the purpose of this commit is to avoid a crash.
Error codes and messages may be broken.