### PR TITLE
doc ja: fix a typo

### DIFF
--- a/doc/source/contribution/development/release.rst
+++ b/doc/source/contribution/development/release.rst
@@ -421,7 +421,7 @@ grntestを実行するためにはGroongaのテストデータとgrntestのソ�
 grntestの実行方法
 ~~~~~~~~~~~~~~~~~
 
-grntestではGroongaコマンドを明示的にしていすることができます。
+grntestではGroongaコマンドを明示的に指定することができます。
 後述のパッケージごとのgrntestによる動作確認では以下のようにして実行します。::
 
     % GROONGA=(groongaのパス指定) test/function/run-test.sh


### PR DESCRIPTION
明示的に**してい**する ->
明示的に**指定**する