### PR TITLE
drilldown: support specifying grouped table

### DIFF
--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -242,6 +242,8 @@ typedef struct {
   grn_table_group_flags calc_types;
   const char *calc_target_name;
   unsigned int calc_target_name_len;
+  const char *table_name;
+  unsigned int table_name_len;
 } drilldown_info;
 
 static grn_table_group_flags
@@ -294,7 +296,8 @@ drilldown_info_fill(grn_ctx *ctx,
                     grn_obj *offset,
                     grn_obj *limit,
                     grn_obj *calc_types,
-                    grn_obj *calc_target)
+                    grn_obj *calc_target,
+                    grn_obj *table)
 {
   if (keys) {
     drilldown->keys = GRN_TEXT_VALUE(keys);
@@ -353,6 +356,14 @@ drilldown_info_fill(grn_ctx *ctx,
   } else {
     drilldown->calc_target_name = NULL;
     drilldown->calc_target_name_len = 0;
+  }
+
+  if (table && GRN_TEXT_LEN(table)) {
+    drilldown->table_name = GRN_TEXT_VALUE(table);
+    drilldown->table_name_len = GRN_TEXT_LEN(table);
+  } else {
+    drilldown->table_name = NULL;
+    drilldown->table_name_len = 0;
   }
 }
 
@@ -435,6 +446,82 @@ grn_select_drilldown(grn_ctx *ctx, grn_obj *table,
   }
 }
 
+typedef enum {
+  NONE = 0,
+  JUST,
+  VISITED
+} drilldown_info_status;
+
+static grn_bool
+drilldown_info_visit(grn_ctx *ctx, grn_obj *labels,
+                     unsigned short *visits,
+                     drilldown_info *drilldowns,
+                     grn_id to, grn_obj *ids)
+{
+  switch (visits[to - 1]) {
+  case JUST:
+    return GRN_TRUE;
+  case VISITED:
+    return GRN_FALSE;
+  default:
+    visits[to - 1] = JUST;
+    {
+      drilldown_info *drilldown = &(drilldowns[to - 1]);
+      if (drilldown->table_name) {
+        grn_id id;
+        id = grn_table_get(ctx, labels,
+                           drilldown->table_name, drilldown->table_name_len);
+        if (id) {
+          if (drilldown_info_visit(ctx, labels, visits, drilldowns, id, ids)) {
+            return GRN_TRUE;
+          }
+        }
+      }
+    }
+    visits[to - 1] = VISITED;
+    grn_uvector_add_element(ctx, ids, to - 1, 0);
+    return GRN_FALSE;
+  }
+}
+
+static grn_bool
+drilldown_info_tsort(grn_ctx *ctx, grn_obj *labels,
+                     unsigned short *visits,
+                     drilldown_info *drilldowns, unsigned int n_drilldowns,
+                     grn_obj *ids)
+{
+  unsigned int i;
+  for (i = 0; i < n_drilldowns; i++) {
+    drilldown_info *drilldown = &(drilldowns[i]);
+    grn_id id;
+    id = grn_table_get(ctx, labels,
+                       drilldown->label, drilldown->label_len);
+    if (id) {
+      if (drilldown_info_visit(ctx, labels, visits, drilldowns, id, ids)) {
+        return GRN_FALSE;
+      }
+    }
+  }
+  return GRN_TRUE;
+}
+
+static void
+drilldown_info_tsort_init(grn_ctx *ctx, grn_obj *labels,
+                          unsigned short *visits,
+                          drilldown_info *drilldowns, unsigned int n_drilldowns)
+{
+  unsigned int i;
+  for (i = 0; i < n_drilldowns; i++) {
+    drilldown_info *drilldown = &(drilldowns[i]);
+    int added;
+    grn_id id;
+    id = grn_table_add(ctx, labels, drilldown->label, drilldown->label_len, &added);
+    if (added) {
+      visits[id - 1] = NONE;
+    }
+  }
+}
+
 static void
 grn_select_drilldowns(grn_ctx *ctx, grn_obj *table,
                       drilldown_info *drilldowns, unsigned int n_drilldowns,
@@ -442,46 +529,76 @@ grn_select_drilldowns(grn_ctx *ctx, grn_obj *table,
 {
   unsigned int i;
   grn_table_group_result *results;
+  grn_obj *labels = NULL;
+  grn_obj tsorted_ids;
+  unsigned short *visits;
+
+  labels = grn_table_create(ctx, NULL, 0, NULL,
+                            GRN_OBJ_TABLE_HASH_KEY,
+                            grn_ctx_at(ctx, GRN_DB_SHORT_TEXT),
+                            NULL);
+  if (!labels) {
+    return;
+  }
+  visits = GRN_PLUGIN_MALLOC(ctx, n_drilldowns * sizeof(unsigned short));
+
+  drilldown_info_tsort_init(ctx, labels, visits, drilldowns, n_drilldowns);
+  GRN_UINT32_INIT(&tsorted_ids, GRN_OBJ_VECTOR);
+  if (!drilldown_info_tsort(ctx, labels, visits,
+                            drilldowns, n_drilldowns, &tsorted_ids)) {
+    /* cyclic */
+    goto exit;
+  }
 
   results = GRN_PLUGIN_MALLOC(ctx, n_drilldowns * sizeof(grn_table_group_result));
 
   /* TODO: Remove invalid key drilldowns from the count. */
   for (i = 0; i < n_drilldowns; i++) {
-    drilldown_info *drilldown = &(drilldowns[i]);
     grn_table_sort_key *keys = NULL;
     unsigned int n_keys;
+    grn_obj *target_table = table;
+    unsigned int j = GRN_UINT32_VALUE_AT(&tsorted_ids, i);
+    drilldown_info *drilldown = &(drilldowns[j]);
 
-    results[i].table = NULL;
-    results[i].limit = 1;
-    results[i].flags = GRN_TABLE_GROUP_CALC_COUNT;
-    results[i].op = 0;
-    results[i].max_n_subrecs = 0;
-    results[i].calc_target = NULL;
+    results[j].table = NULL;
+    results[j].limit = 1;
+    results[j].flags = GRN_TABLE_GROUP_CALC_COUNT;
+    results[j].op = 0;
+    results[j].max_n_subrecs = 0;
+    results[j].calc_target = NULL;
+
+    if (drilldown->table_name) {
+      grn_id id;
+      id = grn_table_get(ctx, labels,
+                        drilldown->table_name, drilldown->table_name_len);
+      if (id) {
+        target_table = results[id - 1].table;
+      }
+    }
 
     keys = grn_table_sort_key_from_str(ctx,
                                        drilldown->keys,
                                        drilldown->keys_len,
-                                       table, &n_keys);
+                                       target_table, &n_keys);
     if (!keys) {
       continue;
     }
 
-    results[i].key_begin = 0;
-    results[i].key_end = n_keys - 1;
+    results[j].key_begin = 0;
+    results[j].key_end = n_keys - 1;
     if (n_keys > 1) {
-      results[i].max_n_subrecs = 1;
+      results[j].max_n_subrecs = 1;
     }
     if (drilldown->calc_target_name) {
-      results[i].calc_target = grn_obj_column(ctx, table,
+      results[j].calc_target = grn_obj_column(ctx, target_table,
                                               drilldown->calc_target_name,
                                               drilldown->calc_target_name_len);
     }
-    if (results[i].calc_target) {
-      results[i].flags |= drilldown->calc_types;
+    if (results[j].calc_target) {
+      results[j].flags |= drilldown->calc_types;
     }
 
-    grn_table_group(ctx, table, keys, n_keys, &(results[i]), 1);
-
+    grn_table_group(ctx, target_table, keys, n_keys, &(results[j]), 1);
     grn_table_sort_key_close(ctx, keys, n_keys);
   }
 
@@ -546,6 +663,11 @@ grn_select_drilldowns(grn_ctx *ctx, grn_obj *table,
   }
   GRN_OUTPUT_MAP_CLOSE();
   GRN_PLUGIN_FREE(ctx, results);
+
+exit: 
+  GRN_PLUGIN_FREE(ctx, visits);
+  GRN_OBJ_FIN(ctx, &tsorted_ids);
+  grn_obj_unlink(ctx, labels);
 }
 
 static grn_rc
@@ -1058,7 +1180,8 @@ command_select(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
                         grn_plugin_proc_get_var(ctx, user_data,
                                                 "drilldown_calc_types", -1),
                         grn_plugin_proc_get_var(ctx, user_data,
-                                                "drilldown_calc_target", -1));
+                                                "drilldown_calc_target", -1),
+                        NULL);
     n_drilldowns++;
   } else {
     unsigned int i;
@@ -1076,6 +1199,7 @@ command_select(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
       grn_obj *limit;
       grn_obj *calc_types;
       grn_obj *calc_target;
+      grn_obj *table;
 
       label_len = grn_vector_get_element(ctx, &drilldown_labels, i,
                                          &label, NULL, NULL);
@@ -1096,12 +1220,13 @@ command_select(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
       GET_VAR(limit);
       GET_VAR(calc_types);
       GET_VAR(calc_target);
+      GET_VAR(table);
 
 #undef GET_VAR
 
       drilldown_info_fill(ctx, drilldown,
                           keys, sortby, output_columns, offset, limit,
-                          calc_types, calc_target);
+                          calc_types, calc_target, table);
     }
   }
   if (grn_select(ctx,

--- a/test/command/suite/select/drilldown/labeled/table/cyclic.expected
+++ b/test/command/suite/select/drilldown/labeled/table/cyclic.expected
@@ -1,0 +1,82 @@
+table_create Categories TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Categories sub_category COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags category COLUMN_SCALAR Categories
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+[[0,0.0,0.0],3]
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+[[0,0.0,0.0],2]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag].output_columns _key,_nsubrecs,category   --drilldown[category].table sub_category   --drilldown[category].keys _key   --drilldown[category].output_columns _key,_nsubrecs   --drilldown[sub_category].table category   --drilldown[sub_category].keys sub_category   --drilldown[sub_category].output_columns _key,_nsubrecs
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/table/cyclic.test
+++ b/test/command/suite/select/drilldown/labeled/table/cyclic.test
@@ -1,0 +1,39 @@
+table_create Categories TABLE_PAT_KEY ShortText
+column_create Categories sub_category COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags category COLUMN_SCALAR Categories
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag].output_columns _key,_nsubrecs,category \
+  --drilldown[category].table sub_category \
+  --drilldown[category].keys _key \
+  --drilldown[category].output_columns _key,_nsubrecs \
+  --drilldown[sub_category].table category \
+  --drilldown[sub_category].keys sub_category \
+  --drilldown[sub_category].output_columns _key,_nsubrecs

--- a/test/command/suite/select/drilldown/labeled/table/empty.expected
+++ b/test/command/suite/select/drilldown/labeled/table/empty.expected
@@ -1,0 +1,108 @@
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags category COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+[[0,0.0,0.0],3]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag].output_columns _key,_nsubrecs,category   --drilldown[category].table   --drilldown[category].keys category   --drilldown[category].output_columns _key,_nsubrecs
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "category",
+            "ShortText"
+          ]
+        ],
+        [
+          "Groonga",
+          2,
+          "C/C++"
+        ],
+        [
+          "Mroonga",
+          1,
+          "C/C++"
+        ],
+        [
+          "Rroonga",
+          1,
+          "Ruby"
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/table/empty.test
+++ b/test/command/suite/select/drilldown/labeled/table/empty.test
@@ -1,0 +1,27 @@
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags category COLUMN_SCALAR ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag].output_columns _key,_nsubrecs,category \
+  --drilldown[category].table \
+  --drilldown[category].keys category \
+  --drilldown[category].output_columns _key,_nsubrecs

--- a/test/command/suite/select/drilldown/labeled/table/one.expected
+++ b/test/command/suite/select/drilldown/labeled/table/one.expected
@@ -1,0 +1,131 @@
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags category COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+[[0,0.0,0.0],3]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag].output_columns _key,_nsubrecs,category   --drilldown[category].table tag   --drilldown[category].keys category   --drilldown[category].output_columns _key,_nsubrecs
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "category",
+            "ShortText"
+          ]
+        ],
+        [
+          "Groonga",
+          2,
+          "C/C++"
+        ],
+        [
+          "Mroonga",
+          1,
+          "C/C++"
+        ],
+        [
+          "Rroonga",
+          1,
+          "Ruby"
+        ]
+      ],
+      "category": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "C/C++",
+          2
+        ],
+        [
+          "Ruby",
+          1
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/table/one.test
+++ b/test/command/suite/select/drilldown/labeled/table/one.test
@@ -1,0 +1,27 @@
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags category COLUMN_SCALAR ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag].output_columns _key,_nsubrecs,category \
+  --drilldown[category].table tag \
+  --drilldown[category].keys category \
+  --drilldown[category].output_columns _key,_nsubrecs

--- a/test/command/suite/select/drilldown/labeled/table/two.expected
+++ b/test/command/suite/select/drilldown/labeled/table/two.expected
@@ -1,0 +1,166 @@
+table_create Categories TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Categories sub_category COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags category COLUMN_SCALAR Categories
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+[[0,0.0,0.0],3]
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+[[0,0.0,0.0],2]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag].output_columns _key,_nsubrecs,category   --drilldown[category].table tag   --drilldown[category].keys category   --drilldown[category].output_columns _key,_nsubrecs,sub_category   --drilldown[sub_category].table category   --drilldown[sub_category].keys sub_category   --drilldown[sub_category].output_columns _key,_nsubrecs
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "category",
+            "Categories"
+          ]
+        ],
+        [
+          "Groonga",
+          2,
+          "C/C++"
+        ],
+        [
+          "Mroonga",
+          1,
+          "C/C++"
+        ],
+        [
+          "Rroonga",
+          1,
+          "Ruby"
+        ]
+      ],
+      "category": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "sub_category",
+            "ShortText"
+          ]
+        ],
+        [
+          "C/C++",
+          2,
+          "Programming language"
+        ],
+        [
+          "Ruby",
+          1,
+          "Programming language"
+        ]
+      ],
+      "sub_category": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Programming language",
+          2
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/table/two.test
+++ b/test/command/suite/select/drilldown/labeled/table/two.test
@@ -1,0 +1,39 @@
+table_create Categories TABLE_PAT_KEY ShortText
+column_create Categories sub_category COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags category COLUMN_SCALAR Categories
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag].output_columns _key,_nsubrecs,category \
+  --drilldown[category].table tag \
+  --drilldown[category].keys category \
+  --drilldown[category].output_columns _key,_nsubrecs,sub_category \
+  --drilldown[sub_category].table category \
+  --drilldown[sub_category].keys sub_category \
+  --drilldown[sub_category].output_columns _key,_nsubrecs

--- a/test/command/suite/select/drilldown/labeled/table/unordered.expected
+++ b/test/command/suite/select/drilldown/labeled/table/unordered.expected
@@ -1,0 +1,166 @@
+table_create Categories TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Categories sub_category COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags category COLUMN_SCALAR Categories
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+[[0,0.0,0.0],3]
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+[[0,0.0,0.0],2]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag].output_columns _key,_nsubrecs,category   --drilldown[sub_category].table category   --drilldown[sub_category].keys sub_category   --drilldown[sub_category].output_columns _key,_nsubrecs   --drilldown[category].table tag   --drilldown[category].keys category   --drilldown[category].output_columns _key,_nsubrecs,sub_category
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "category",
+            "Categories"
+          ]
+        ],
+        [
+          "Groonga",
+          2,
+          "C/C++"
+        ],
+        [
+          "Mroonga",
+          1,
+          "C/C++"
+        ],
+        [
+          "Rroonga",
+          1,
+          "Ruby"
+        ]
+      ],
+      "sub_category": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Programming language",
+          2
+        ]
+      ],
+      "category": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "sub_category",
+            "ShortText"
+          ]
+        ],
+        [
+          "C/C++",
+          2,
+          "Programming language"
+        ],
+        [
+          "Ruby",
+          1,
+          "Programming language"
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/table/unordered.test
+++ b/test/command/suite/select/drilldown/labeled/table/unordered.test
@@ -1,0 +1,39 @@
+table_create Categories TABLE_PAT_KEY ShortText
+column_create Categories sub_category COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags category COLUMN_SCALAR Categories
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+load --table Tags
+[
+{"_key": "Groonga", "category": "C/C++"},
+{"_key": "Mroonga", "category": "C/C++"},
+{"_key": "Rroonga", "category": "Ruby"}
+]
+
+load --table Categories
+[
+{"_key": "C/C++", "sub_category": "Programming language"},
+{"_key": "Ruby", "sub_category": "Programming language"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag].output_columns _key,_nsubrecs,category \
+  --drilldown[sub_category].table category \
+  --drilldown[sub_category].keys sub_category \
+  --drilldown[sub_category].output_columns _key,_nsubrecs \
+  --drilldown[category].table tag \
+  --drilldown[category].keys category \
+  --drilldown[category].output_columns _key,_nsubrecs,sub_category


### PR DESCRIPTION
[groonga-dev 3903](https://osdn.jp/projects/groonga/lists/archive/dev/2016-February/003903.html)　のうち、まず、

> --drilldown[...].tableで他の--drilldown[...]の「...」に指定
> したドリルダウン結果を指定できることと

を実装してみました。よければご検討ください。

CI環境でテストが落ちているので調査しています。

```bash
select Memos   \
 --drilldown[tag].keys tag  \
 --drilldown[tag].output_columns _key,_nsubrecs,category  \
 --drilldown[category].table tag \
 --drilldown[category].keys category \
 --drilldown[category].output_columns _key,_nsubrecs,sub_category \
 --drilldown[sub_category].table category \
 --drilldown[sub_category].keys sub_category \
 --drilldown[sub_category].output_columns _key,_nsubrecs
[
   ...
    {
      "tag": [
        [3],
        [
          ["_key", "ShortText"],
          ["_nsubrecs", "Int32"],
          ["category","Categories"]
        ],
        [
          "Groonga",
          2,
          "C/C++"
        ],
        [
          "Mroonga",
          1,
          "C/C++"
        ],
        [
          "Rroonga",
          1,
          "Ruby"
        ]
      ],
      "category": [
        [2],
        [
          ["_key","ShortText"],
          ["_nsubrecs","Int32"],
          ["sub_category","ShortText"]
        ],
        [
          "C/C++",
          2,
          "Programming language"
        ],
        [
          "Ruby",
          1,
          "Programming language"
        ]
      ],
      "sub_category": [
        [1],
        [
          [ "_key","ShortText"],
          ["_nsubrecs","Int32"]
        ],
        [
          "Programming language",
          2
        ]
      ]
    }
  ]
]
```