### PR TITLE
Order of drilldown labels

### DIFF
--- a/test/command/suite/select/drilldown/labeled/multiple_labels.expected
+++ b/test/command/suite/select/drilldown/labeled/multiple_labels.expected
@@ -1,0 +1,119 @@
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --drilldown[tag2].keys tag   --drilldown[tag1].keys tag
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag2": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Groonga",
+          2
+        ],
+        [
+          "Mroonga",
+          1
+        ],
+        [
+          "Rroonga",
+          1
+        ]
+      ],
+      "tag1": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Groonga",
+          2
+        ],
+        [
+          "Mroonga",
+          1
+        ],
+        [
+          "Rroonga",
+          1
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/multiple_labels.test
+++ b/test/command/suite/select/drilldown/labeled/multiple_labels.test
@@ -1,0 +1,16 @@
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+select Memos \
+  --drilldown[tag2].keys tag \
+  --drilldown[tag1].keys tag


### PR DESCRIPTION
これはPRというか質問なのですが、ラベル付きドリルダウンの場合、CI環境のcmakeとauto toolsの場合で、ラベルの出力順序が異なるようです。
* auto tools
https://travis-ci.org/groonga/groonga/jobs/122000281

* cmake
https://travis-ci.org/groonga/groonga/jobs/122000284

たぶん、cmakeは指定した順序のままラベルが出力され、auto toolsの場合は、アルファベット順になっているように見えます。

これは仕様動作ですか？

CIでの動作を見るためにproc_select_find_all_drilldown_labelsのgrn_table_cursor_openにGRN_CUSOR_BY_IDを試しにつけてみています。