### PR TITLE
db: fix memory leak in grn_table_group_single_key_records

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -3745,6 +3745,7 @@ grn_table_group_single_key_records(grn_ctx *ctx, grn_obj *table,
     }
     grn_table_cursor_close(ctx, tc);
   }
+  GRN_OBJ_FIN(ctx, &value_buffer);
   grn_obj_close(ctx, &bulk);
 }
 


### PR DESCRIPTION
grn_testでleakってでいなかったのでどっかで回収されているかもしれませんが、``grn_table_group_single_key_records()``ではcalc_targetのためにGRN_VOID_INITしたvalue_bufferをGRN_OBJ_FINしていないように見えました。（他は大丈夫）