### PR TITLE
drilldown: support group by all records

### DIFF
--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -635,7 +635,7 @@ grn_select_drilldowns_execute(grn_ctx *ctx,
                                        drilldown->keys_len,
                                        target_table, &n_keys);
 
-    if (!keys && !drilldown->table_name) {
+    if (!keys && !drilldown->calc_target_name) {
       GRN_PLUGIN_CLEAR_ERROR(ctx);
       continue;
     }
@@ -1158,12 +1158,10 @@ proc_select_find_all_drilldown_labels(grn_ctx *ctx, grn_user_data *user_data,
   grn_table_cursor *cursor;
   cursor = grn_table_cursor_open(ctx, vars, NULL, 0, NULL, 0, 0, -1, 0);
   if (cursor) {
+#define N_SUFFIXES 3
     const char *prefix = "drilldown[";
     int prefix_len = strlen(prefix);
-    const char *suffix_key = "].keys";
-    int suffix_key_len = strlen(suffix_key);
-    const char *suffix_table = "].table";
-    int suffix_table_len = strlen(suffix_table);
+    const char *suffixes[N_SUFFIXES] = {"].keys", "].table", "].calc_target"};
     int suffix_len;
     while (grn_table_cursor_next(ctx, cursor)) {
       void *key;
@@ -1174,14 +1172,14 @@ proc_select_find_all_drilldown_labels(grn_ctx *ctx, grn_user_data *user_data,
       suffix_len = 0;
       if (name_len >= prefix_len &&
           strncmp(prefix, name, prefix_len) == 0) {
-        if (name_len >= (prefix_len + 1 + suffix_key_len) &&
-            strncmp(suffix_key, name + name_len - suffix_key_len,
-                    suffix_key_len) == 0) {
-          suffix_len = suffix_key_len;
-        } else if (name_len >= (prefix_len + 1 + suffix_table_len) &&
-                   strncmp(suffix_table, name + name_len - suffix_table_len,
-                   suffix_table_len) == 0) {
-          suffix_len = suffix_table_len;
+        int i;
+        for (i = 0; i < N_SUFFIXES; i++) {
+          int len = strlen(suffixes[i]);
+          if (name_len >= (prefix_len + 1 + len) &&
+              strncmp(suffixes[i], name + name_len - len, len) == 0) {
+            suffix_len = len;
+            break;
+          }
         }
         if (suffix_len > 0) {
           grn_table_add(ctx, labels,
@@ -1190,6 +1188,7 @@ proc_select_find_all_drilldown_labels(grn_ctx *ctx, grn_user_data *user_data,
                         NULL);
         }
       }
+#undef N_SUFFIXES
     }
     grn_table_cursor_close(ctx, cursor);
   }

--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -1336,44 +1336,44 @@ command_select(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
       i = 0;
       n_drilldowns = grn_table_size(ctx, drilldown_labels);
       while (grn_table_cursor_next(ctx, cursor)) {
-      drilldown_info *drilldown = &(drilldowns[i]);
-      const char *label;
-      int label_len;
-      char key_name[GRN_TABLE_MAX_KEY_SIZE];
-      grn_obj *keys;
-      grn_obj *sortby;
-      grn_obj *output_columns;
-      grn_obj *offset;
-      grn_obj *limit;
-      grn_obj *calc_types;
-      grn_obj *calc_target;
-      grn_obj *table;
+        drilldown_info *drilldown = &(drilldowns[i]);
+        const char *label;
+        int label_len;
+        char key_name[GRN_TABLE_MAX_KEY_SIZE];
+        grn_obj *keys;
+        grn_obj *sortby;
+        grn_obj *output_columns;
+        grn_obj *offset;
+        grn_obj *limit;
+        grn_obj *calc_types;
+        grn_obj *calc_target;
+        grn_obj *table;
 
-      label_len = grn_table_cursor_get_key(ctx, cursor, (void **)&label);
-      drilldown->label = label;
-      drilldown->label_len = label_len;
+        label_len = grn_table_cursor_get_key(ctx, cursor, (void **)&label);
+        drilldown->label = label;
+        drilldown->label_len = label_len;
 
 #define GET_VAR(name)\
-      grn_snprintf(key_name,                                            \
-                   GRN_TABLE_MAX_KEY_SIZE,                              \
-                   GRN_TABLE_MAX_KEY_SIZE,                              \
-                   "drilldown[%.*s]." # name, label_len, label);        \
-      name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
+        grn_snprintf(key_name,                                            \
+                     GRN_TABLE_MAX_KEY_SIZE,                              \
+                     GRN_TABLE_MAX_KEY_SIZE,                              \
+                     "drilldown[%.*s]." # name, label_len, label);        \
+        name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
 
-      GET_VAR(keys);
-      GET_VAR(sortby);
-      GET_VAR(output_columns);
-      GET_VAR(offset);
-      GET_VAR(limit);
-      GET_VAR(calc_types);
-      GET_VAR(calc_target);
-      GET_VAR(table);
+        GET_VAR(keys);
+        GET_VAR(sortby);
+        GET_VAR(output_columns);
+        GET_VAR(offset);
+        GET_VAR(limit);
+        GET_VAR(calc_types);
+        GET_VAR(calc_target);
+        GET_VAR(table);
 
 #undef GET_VAR
 
-      drilldown_info_fill(ctx, drilldown,
-                          keys, sortby, output_columns, offset, limit,
-                          calc_types, calc_target, table);
+        drilldown_info_fill(ctx, drilldown,
+                            keys, sortby, output_columns, offset, limit,
+                            calc_types, calc_target, table);
         i++;
       }
       grn_table_cursor_close(ctx, cursor);

--- a/test/command/suite/select/drilldown/labeled/all_records/no_table.expected
+++ b/test/command/suite/select/drilldown/labeled/all_records/no_table.expected
@@ -1,0 +1,82 @@
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos value COLUMN_SCALAR Int64
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "value": 10},
+{"_key": "Mroonga is fast!", "value": 2},
+{"_key": "Groonga sticker!", "value": 3},
+{"_key": "Rroonga is fast!", "value": 4}
+]
+[[0,0.0,0.0],4]
+select Memos   --drilldown[sum].calc_types SUM   --drilldown[sum].calc_target value   --drilldown[sum].output_columns _key,_sum
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "value",
+          "Int64"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        10
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        2
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        3
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        4
+      ]
+    ],
+    {
+      "sum": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_sum",
+            "Int64"
+          ]
+        ],
+        [
+          "all_records",
+          19
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/all_records/no_table.test
+++ b/test/command/suite/select/drilldown/labeled/all_records/no_table.test
@@ -1,0 +1,15 @@
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos value COLUMN_SCALAR Int64
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "value": 10},
+{"_key": "Mroonga is fast!", "value": 2},
+{"_key": "Groonga sticker!", "value": 3},
+{"_key": "Rroonga is fast!", "value": 4}
+]
+
+select Memos \
+  --drilldown[sum].calc_types SUM \
+  --drilldown[sum].calc_target value \
+  --drilldown[sum].output_columns _key,_sum

--- a/test/command/suite/select/drilldown/labeled/all_records/sum.expected
+++ b/test/command/suite/select/drilldown/labeled/all_records/sum.expected
@@ -1,0 +1,111 @@
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --drilldown[tag].keys tag   --drilldown[tag_sum].table tag   --drilldown[tag_sum].calc_types SUM   --drilldown[tag_sum].calc_target _nsubrecs   --drilldown[tag_sum].output_columns _key,_sum
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ],
+      [
+        1,
+        "Groonga is fast!",
+        "Groonga"
+      ],
+      [
+        2,
+        "Mroonga is fast!",
+        "Mroonga"
+      ],
+      [
+        3,
+        "Groonga sticker!",
+        "Groonga"
+      ],
+      [
+        4,
+        "Rroonga is fast!",
+        "Rroonga"
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Groonga",
+          2
+        ],
+        [
+          "Mroonga",
+          1
+        ],
+        [
+          "Rroonga",
+          1
+        ]
+      ],
+      "tag_sum": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_sum",
+            "Int64"
+          ]
+        ],
+        [
+          "all_records",
+          4
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/all_records/sum.test
+++ b/test/command/suite/select/drilldown/labeled/all_records/sum.test
@@ -1,0 +1,19 @@
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "tag": "Rroonga"}
+]
+
+select Memos \
+  --drilldown[tag].keys tag \
+  --drilldown[tag_sum].table tag \
+  --drilldown[tag_sum].calc_types SUM \
+  --drilldown[tag_sum].calc_target _nsubrecs \
+  --drilldown[tag_sum].output_columns _key,_sum


### PR DESCRIPTION
[groonga-dev 3903](https://osdn.jp/projects/groonga/lists/archive/dev/2016-February/003903.html)　の、

> --drilldown[...].keysを省略できること

を実装してみました。
モチベーションは、円グラフを書くためにベクターカラムのドリルダウン結果の_nsubrecsの合計値を取得したいことです。

キー数が0、calc_targetがあって、かつ、n_resultsが1の場合、"all_records"というキー名ですべてのレコードをgroupするモードを```grn_table_group()```APIに追加しました。

よければご検討ください。
```bash
select Memos  \
  --drilldown[tag].keys tag \
  --drilldown[tag_sum].table tag \
  --drilldown[tag_sum].calc_types SUM \
  --drilldown[tag_sum].calc_target _nsubrecs \
  --drilldown[tag_sum].output_columns _key,_sum
[
   ...
    {
      "tag": [
        [3],
        [
          ["_key", "ShortText"],
          ["_nsubrecs","Int32"]
        ],
        [
          "Groonga",
          2
        ],
        [
          "Mroonga",
          1
        ],
        [
          "Rroonga",
          1
        ]
      ],
      "tag_sum": [
        [1],
        [
          [ "_key","ShortText"],
          [ "_sum","Int64"]
        ],
        [
          "all_records",
          4
        ]
      ]
    }
  ]
]
```