### PR TITLE
sphinx: support only HTML output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,16 +74,6 @@ CMakeFiles
 /doc/locale/*/*-stamp
 /doc/locale/*/doctrees/
 /doc/locale/*/html/
-/doc/locale/*/dirhtml/
-/doc/locale/*/htmlhelp/
-/doc/locale/*/json/
-/doc/locale/*/latex/
-/doc/locale/*/qthelp/
-/doc/locale/*/rdoc/
-/doc/locale/*/man/
-/doc/locale/*/pickle/
-/doc/locale/*/textile/
-/doc/locale/*/pdf/
 /doc/locale/*/LC_MESSAGES/*.mo
 /doc/locale/*/LC_MESSAGES/*.pot
 /doc/locale/*/LC_MESSAGES/*.edit

--- a/build/makefiles/gettext.am
+++ b/build/makefiles/gettext.am
@@ -59,8 +59,6 @@ build:
 endif
 
 html: build
-man: build
-pdf: build
 
 gettext:
 	rm *.pot || true

--- a/build/makefiles/sphinx-build.am
+++ b/build/makefiles/sphinx-build.am
@@ -2,13 +2,10 @@
 DOCTREES_BASE = doctrees
 
 SPHINXOPTS    =
-PAPER         =
 
 # Internal variables.
 SOURCE_DIR      = $(abs_top_srcdir)/doc/source
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = $(PAPEROPT_$(PAPER)) -E $(SPHINXOPTS) $(SOURCE_DIR)
+ALLSPHINXOPTS   = -E $(SPHINXOPTS) $(SOURCE_DIR)
 
 SPHINX_BUILD_COMMAND =						\
 	DOCUMENT_VERSION="$(DOCUMENT_VERSION)"			\

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -24,7 +24,7 @@ update-files: $(BUILT_SOURCES)
 	cd locale/en && $(MAKE) clean html
 	cd $(srcdir); ./update-files.sh > files.am
 
-man pdf clean-html update-po:
+clean-html update-po:
 	for dir in $(SUBDIRS); do		\
 	  (cd $${dir} && $(MAKE) $@);		\
 	done

--- a/doc/locale/Makefile.am
+++ b/doc/locale/Makefile.am
@@ -24,7 +24,7 @@ add:
               a \ \ doc\/locale\/$(LOCALE)\/LC_MESSAGES\/Makefile"	\
 	  $(top_srcdir)/configure.ac
 
-man pdf clean-html init update-po:
+clean-html init update-po:
 	for dir in $(SUBDIRS); do		\
 	  (cd $${dir} && $(MAKE) $@);		\
 	done


### PR DESCRIPTION
少し前の 6f8eb65ff290e80b02f1541e04ab1f1208a3f10d と 2e91a753e48ed4e8de524eb4e535bbd502801125 の関連です。

この部分も多分不要じゃないかと思うので、気づいたついでに上げておきます。