### PR TITLE
ii: skip overlapping tokens in consideration of frequency of token

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -6074,7 +6074,9 @@ token_candidate_score(grn_ctx *ctx, token_candidate_node *nodes, uint32_t candid
   for (i = 0; i <= last; i++) {
     if (candidate & (1 << i)) {
       token_candidate_node *node = nodes + i + offset;
-      score += max_estimated_size / node->estimated_size;
+      if (node->estimated_size > 0) {
+        score += max_estimated_size / node->estimated_size;
+      }
     }
   }
   return score;

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -74,6 +74,7 @@
 static grn_bool grn_ii_cursor_set_min_enable = GRN_FALSE;
 static double grn_ii_select_too_many_index_match_ratio = -1;
 static double grn_ii_estimate_size_for_query_reduce_ratio = 0.9;
+static grn_bool grn_ii_overlap_token_skip_enable = GRN_FALSE;
 
 void
 grn_ii_init_from_env(void)
@@ -109,6 +110,18 @@ grn_ii_init_from_env(void)
     if (grn_ii_estimate_size_for_query_reduce_ratio_env[0]) {
       grn_ii_estimate_size_for_query_reduce_ratio =
         atof(grn_ii_estimate_size_for_query_reduce_ratio_env);
+    }
+  }
+
+  {
+    char grn_ii_overlap_token_skip_enable_env[GRN_ENV_BUFFER_SIZE];
+    grn_getenv("GRN_II_OVERLAP_TOKEN_SKIP_ENABLE",
+               grn_ii_overlap_token_skip_enable_env,
+               GRN_ENV_BUFFER_SIZE);
+    if (grn_ii_overlap_token_skip_enable_env[0]) {
+      grn_ii_overlap_token_skip_enable = GRN_TRUE;
+    } else {
+      grn_ii_overlap_token_skip_enable = GRN_FALSE;
     }
   }
 }
@@ -5887,6 +5900,331 @@ token_compare(const void *a, const void *b)
   return t1->size - t2->size;
 }
 
+#define TOKEN_CANDIDATE_NODE_SIZE 32
+#define TOKEN_CANDIDATE_ADJACENT_MAX_SIZE 16
+#define TOKEN_CANDIDATE_QUEUE_SIZE 64
+#define TOKEN_CANDIDATE_SIZE 16
+
+typedef struct {
+  grn_id tid;
+  const unsigned char *token;
+  uint32_t token_size;
+  int32_t pos;
+  grn_token_cursor_status status;
+  int ef;
+  uint32_t estimated_size;
+  uint8_t adjacent[TOKEN_CANDIDATE_ADJACENT_MAX_SIZE]; /* Index of adjacent node from top */
+  uint8_t n_adjacent;
+} token_candidate_node;
+
+typedef struct {
+  uint32_t *candidates; /* Standing bits indicate index of token_candidate_node */
+  int top;
+  int rear;
+  int size;
+} token_candidate_queue;
+
+inline static void
+token_candidate_adjacent_set(grn_ctx *ctx, grn_token_cursor *token_cursor,
+                             token_candidate_node *top, token_candidate_node *curr)
+{
+  grn_bool exists_adjacent = GRN_FALSE;
+  token_candidate_node *adj;
+  for (adj = top; adj < curr; adj++) {
+    if (token_cursor->curr <= adj->token + adj->token_size) {
+      if (adj->n_adjacent < TOKEN_CANDIDATE_ADJACENT_MAX_SIZE) {
+        adj->adjacent[adj->n_adjacent] = curr - top;
+        adj->n_adjacent++;
+        exists_adjacent = GRN_TRUE;
+      }
+    }
+  }
+  if (!exists_adjacent) {
+    adj = curr - 1;
+    if (adj->n_adjacent < TOKEN_CANDIDATE_ADJACENT_MAX_SIZE) {
+      adj->adjacent[adj->n_adjacent] = curr - top;
+      adj->n_adjacent++;
+    }
+  }
+}
+
+inline static grn_rc
+token_candidate_init(grn_ctx *ctx, grn_ii *ii, grn_token_cursor *token_cursor,
+                     grn_id tid, int ef, token_candidate_node **nodes, int *n_nodes,
+                     uint32_t *max_estimated_size)
+{
+  grn_rc rc;
+  token_candidate_node *top, *curr;
+  int size = TOKEN_CANDIDATE_NODE_SIZE;
+
+  *nodes = GRN_MALLOC(TOKEN_CANDIDATE_NODE_SIZE * sizeof(token_candidate_node));
+  if (!*nodes) {
+    return GRN_NO_MEMORY_AVAILABLE;
+  }
+  top = *nodes;
+  curr = top;
+
+#define TOKEN_CANDIDATE_NODE_SET() { \
+  curr->tid = tid; \
+  curr->token = token_cursor->curr; \
+  curr->token_size = token_cursor->curr_size; \
+  curr->pos = token_cursor->pos; \
+  curr->status = token_cursor->status; \
+  curr->ef = ef; \
+  curr->estimated_size = grn_ii_estimate_size(ctx, ii, tid); \
+  curr->n_adjacent = 0; \
+}
+  TOKEN_CANDIDATE_NODE_SET();
+  GRN_LOG(ctx, GRN_LOG_DEBUG, "[ii][overlap_token_skip] tid=%u pos=%d estimated_size=%u",
+          curr->tid, curr->pos, curr->estimated_size);
+  *max_estimated_size = curr->estimated_size;
+  curr++;
+
+  while (token_cursor->status == GRN_TOKEN_CURSOR_DOING) {
+    if (curr - top >= size) {
+      if (!(*nodes = GRN_REALLOC(*nodes,
+          (curr - top + TOKEN_CANDIDATE_NODE_SIZE) * sizeof(token_candidate_node)))) {
+        return GRN_NO_MEMORY_AVAILABLE;
+      }
+      top = *nodes;
+      curr = top + size;
+      size += TOKEN_CANDIDATE_NODE_SIZE;
+    }
+    tid = grn_token_cursor_next(ctx, token_cursor);
+    if (token_cursor->status != GRN_TOKEN_CURSOR_DONE_SKIP) {
+      if (token_cursor->force_prefix) { ef |= EX_PREFIX; }
+      TOKEN_CANDIDATE_NODE_SET();
+      token_candidate_adjacent_set(ctx, token_cursor, top, curr);
+      if (curr->estimated_size > *max_estimated_size) {
+        *max_estimated_size = curr->estimated_size;
+      }
+      curr++;
+    }
+  }
+  *n_nodes = curr - top;
+  rc = GRN_SUCCESS;
+  return rc;
+#undef TOKEN_CANDIDATE_NODE_SET
+}
+
+inline static grn_rc
+token_candidate_queue_init(grn_ctx *ctx, token_candidate_queue *q)
+{
+  q->top = 0;
+  q->rear = 0;
+  q->size = TOKEN_CANDIDATE_QUEUE_SIZE;
+
+  q->candidates = GRN_MALLOC(TOKEN_CANDIDATE_QUEUE_SIZE * sizeof(uint32_t));
+  if (!q->candidates) {
+    q->size = 0;
+    return GRN_NO_MEMORY_AVAILABLE;
+  }
+  return GRN_SUCCESS;
+}
+
+inline static grn_rc
+token_candidate_enqueue(grn_ctx *ctx, token_candidate_queue *q, uint32_t candidate)
+{
+  if (q->rear >= q->size) {
+    if (!(q->candidates =
+        GRN_REALLOC(q->candidates,
+        (q->rear + TOKEN_CANDIDATE_QUEUE_SIZE) * sizeof(uint32_t)))) {
+      q->size = 0;
+      return GRN_NO_MEMORY_AVAILABLE;
+    }
+    q->size += TOKEN_CANDIDATE_QUEUE_SIZE;
+  }
+  *(q->candidates + q->rear) = candidate;
+  q->rear++;
+  return GRN_SUCCESS;
+}
+
+inline static grn_rc
+token_candidate_dequeue(grn_ctx *ctx, token_candidate_queue *q, uint32_t *candidate)
+{
+  if (q->top == q->rear) {
+    return GRN_END_OF_DATA;
+  }
+  *candidate = *(q->candidates + q->top);
+  q->top++;
+  return GRN_SUCCESS;
+}
+
+inline static void
+token_candidate_queue_fin(grn_ctx *ctx, token_candidate_queue *q)
+{
+  GRN_FREE(q->candidates);
+}
+
+inline static token_candidate_node*
+token_candidate_last_node(grn_ctx *ctx, token_candidate_node *nodes, uint32_t candidate, int offset)
+{
+  int i;
+  GRN_BIT_SCAN_REV(candidate, i);
+  return nodes + i + offset;
+}
+
+inline static uint64_t
+token_candidate_score(grn_ctx *ctx, token_candidate_node *nodes, uint32_t candidate,
+                      int offset, uint32_t max_estimated_size)
+{
+  int i, last;
+  uint64_t score = 0;
+  GRN_BIT_SCAN_REV(candidate, last);
+  for (i = 0; i <= last; i++) {
+    if (candidate & (1 << i)) {
+      token_candidate_node *node = nodes + i + offset;
+      score += max_estimated_size / node->estimated_size;
+    }
+  }
+  return score;
+}
+
+inline static grn_rc
+token_candidate_select(grn_ctx *ctx, token_candidate_node *nodes,
+                       int offset, int limit, int end,
+                       uint32_t *selected_candidate, uint32_t max_estimated_size)
+{
+  grn_rc rc;
+  token_candidate_queue q;
+  uint32_t candidate;
+  uint64_t max_score = 0;
+  int i, min_n_nodes = 0;
+
+  if (offset + limit > end) {
+    limit = end - offset;
+  }
+  rc = token_candidate_queue_init(ctx, &q);
+  if (rc != GRN_SUCCESS) {
+    return rc;
+  }
+  rc = token_candidate_enqueue(ctx, &q, 1);
+  if (rc != GRN_SUCCESS) {
+    goto exit;
+  }
+  while (token_candidate_dequeue(ctx, &q, &candidate) != GRN_END_OF_DATA) {
+    token_candidate_node *candidate_last_node =
+      token_candidate_last_node(ctx, nodes, candidate, offset);
+    for (i = 0; i < candidate_last_node->n_adjacent; i++) {
+      int adjacent, n_nodes = 0;
+      uint32_t new_candidate;
+      adjacent = candidate_last_node->adjacent[i] - offset;
+      if (adjacent > limit) {
+        break;
+      }
+      new_candidate = candidate | (1 << adjacent);
+      GET_NUM_BITS(new_candidate, n_nodes);
+      if (min_n_nodes > 0 && n_nodes > min_n_nodes + 1) {
+        goto exit;
+      }
+      rc = token_candidate_enqueue(ctx, &q, new_candidate);
+      if (rc != GRN_SUCCESS) {
+        goto exit;
+      }
+      if (adjacent == limit) {
+        if (min_n_nodes == 0) {
+          min_n_nodes = n_nodes;
+        }
+        if (n_nodes >= min_n_nodes && n_nodes <= min_n_nodes + 1) {
+          uint64_t score;
+          score = token_candidate_score(ctx, nodes, new_candidate, offset, max_estimated_size);
+          if (score > max_score) {
+            max_score = score;
+            *selected_candidate = new_candidate;
+          }
+        }
+      }
+    }
+  }
+  rc = GRN_SUCCESS;
+exit :
+  token_candidate_queue_fin(ctx, &q);
+  return rc;
+}
+
+inline static grn_rc
+token_candidate_build(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii,
+                      token_info **tis, uint32_t *n,
+                      token_candidate_node *nodes, uint32_t selected_candidate,
+                      int offset)
+{
+  grn_rc rc = GRN_END_OF_DATA;
+  token_info *ti;
+  const char *key;
+  uint32_t size;
+  int i, last = 0;
+  GRN_BIT_SCAN_REV(selected_candidate, last);
+  for (i = 1; i <= last; i++) {
+    if (selected_candidate & (1 << i)) {
+      token_candidate_node *node = nodes + i + offset;
+      switch (node->status) {
+      case GRN_TOKEN_CURSOR_DOING :
+        key = _grn_table_key(ctx, lexicon, node->tid, &size);
+        ti = token_info_open(ctx, lexicon, ii, key, size, node->pos,
+                             EX_NONE, NULL);
+        break;
+      case GRN_TOKEN_CURSOR_DONE :
+        if (node->tid) {
+          key = _grn_table_key(ctx, lexicon, node->tid, &size);
+          ti = token_info_open(ctx, lexicon, ii, key, size, node->pos,
+                               node->ef & EX_PREFIX, NULL);
+          break;
+        } /* else fallthru */
+      default :
+        ti = token_info_open(ctx, lexicon, ii, (char *)node->token,
+                             node->token_size, node->pos,
+                             node->ef & EX_PREFIX, NULL);
+        break;
+      }
+      if (!ti) {
+        goto exit;
+      }
+      tis[(*n)++] = ti;
+      GRN_LOG(ctx, GRN_LOG_DEBUG, "[ii][overlap_token_skip] tid=%u pos=%d estimated_size=%u",
+              node->tid, node->pos, node->estimated_size);
+    }
+  }
+  rc = GRN_SUCCESS;
+exit :
+  return rc;
+}
+
+inline static grn_rc
+token_info_build_skipping_overlap(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii,
+                                  token_info **tis, uint32_t *n,
+                                  grn_token_cursor *token_cursor,
+                                  grn_id tid, int ef)
+{
+  grn_rc rc;
+  token_candidate_node *nodes = NULL;
+  int n_nodes = 0, offset = 0, limit = TOKEN_CANDIDATE_SIZE - 1;
+  uint32_t max_estimated_size;
+
+  rc = token_candidate_init(ctx, ii, token_cursor, tid, ef, &nodes, &n_nodes, &max_estimated_size);
+  if (rc != GRN_SUCCESS) {
+    return rc;
+  }
+  while (offset < n_nodes - 1) {
+    uint32_t selected_candidate = 0;
+    rc = token_candidate_select(ctx, nodes, offset, limit, n_nodes - 1,
+                                &selected_candidate, max_estimated_size);
+    if (rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    rc = token_candidate_build(ctx, lexicon, ii, tis, n, nodes, selected_candidate, offset);
+    if (rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    offset += limit;
+  }
+  rc = GRN_SUCCESS;
+exit :
+  if (nodes) {
+    GRN_FREE(nodes);
+  }
+  return rc;
+}
+
 inline static grn_rc
 token_info_build(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii, const char *string, unsigned int string_len,
                  token_info **tis, uint32_t *n, grn_bool *only_skip_token,
@@ -5956,6 +6294,12 @@ token_info_build(grn_ctx *ctx, grn_obj *lexicon, grn_ii *ii, const char *string,
     }
     if (!ti) { goto exit ; }
     tis[(*n)++] = ti;
+
+    if (grn_ii_overlap_token_skip_enable) {
+      rc = token_info_build_skipping_overlap(ctx, lexicon, ii, tis, n, token_cursor, tid, ef);
+      goto exit;
+    }
+
     while (token_cursor->status == GRN_TOKEN_CURSOR_DOING) {
       tid = grn_token_cursor_next(ctx, token_cursor);
       if (token_cursor->force_prefix) { ef |= EX_PREFIX; }

--- a/lib/tokenizers.c
+++ b/lib/tokenizers.c
@@ -237,6 +237,8 @@ delimit_null_init(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_d
 
 /* ngram tokenizer */
 
+static grn_bool grn_ngram_tokenizer_remove_blank_disable = GRN_FALSE;
+
 typedef struct {
   grn_tokenizer_token token;
   grn_tokenizer_query *query;
@@ -268,6 +270,9 @@ ngram_init(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data, ui
   unsigned int normalized_length_in_bytes;
   grn_ngram_tokenizer *tokenizer;
 
+  if (grn_ngram_tokenizer_remove_blank_disable) {
+    normalize_flags &= ~GRN_STRING_REMOVE_BLANK;
+  }
   query = grn_tokenizer_query_open(ctx, nargs, args, normalize_flags);
   if (!query) {
     return NULL;
@@ -807,6 +812,17 @@ grn_db_init_builtin_tokenizers(grn_ctx *ctx)
   GRN_TEXT_INIT(&vars[0].value, 0);
   GRN_TEXT_INIT(&vars[1].value, 0);
   GRN_UINT32_INIT(&vars[2].value, 0);
+
+  {
+    char grn_ngram_tokenizer_remove_blank_disable_env[GRN_ENV_BUFFER_SIZE];
+
+    grn_getenv("GRN_NGRAM_TOKENIZER_REMOVE_BLANK_DISABLE",
+               grn_ngram_tokenizer_remove_blank_disable_env,
+               GRN_ENV_BUFFER_SIZE);
+    if (grn_ngram_tokenizer_remove_blank_disable_env[0]) {
+      grn_ngram_tokenizer_remove_blank_disable = GRN_TRUE;
+    }
+  }
 
   obj = DEF_TOKENIZER("TokenDelimit",
                       delimit_init, delimited_next, delimited_fin, vars);

--- a/test/command/suite/select/env/overlap_token_skip/long.expected
+++ b/test/command/suite/select/env/overlap_token_skip/long.expected
@@ -1,0 +1,228 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigramIgnoreBlankSplitSymbolAlpha   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "This is very very long sentence."}
+]
+[[0,0.0,0.0],1]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+table_tokenize Terms "This is very very long sentence." --index_column index
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "th",
+      "position": 0,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "hi",
+      "position": 1,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "is",
+      "position": 2,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "si",
+      "position": 3,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "is",
+      "position": 4,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "sv",
+      "position": 5,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "ve",
+      "position": 6,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "er",
+      "position": 7,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "ry",
+      "position": 8,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "yv",
+      "position": 9,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "ve",
+      "position": 10,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "er",
+      "position": 11,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "ry",
+      "position": 12,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "yl",
+      "position": 13,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "lo",
+      "position": 14,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "on",
+      "position": 15,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "ng",
+      "position": 16,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "gs",
+      "position": 17,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "se",
+      "position": 18,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "en",
+      "position": 19,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "nt",
+      "position": 20,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "te",
+      "position": 21,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "en",
+      "position": 22,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "nc",
+      "position": 23,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "ce",
+      "position": 24,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "e.",
+      "position": 25,
+      "force_prefix": false,
+      "estimated_size": 1
+    }
+  ]
+]
+log_level --level debug
+[[0,0.0,0.0],true]
+select Entries --filter 'body @ "This is very very long sentence."'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "body",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "This is very very long sentence."
+      ]
+    ]
+  ]
+]
+#|d| [ii][overlap_token_skip] tid=19 pos=0 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=7 pos=1 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=16 pos=3 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=17 pos=5 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=5 pos=7 estimated_size=3
+#|d| [ii][overlap_token_skip] tid=22 pos=9 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=5 pos=11 estimated_size=3
+#|d| [ii][overlap_token_skip] tid=21 pos=13 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=9 pos=14 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=13 pos=15 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=11 pos=16 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=15 pos=18 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=12 pos=20 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=18 pos=21 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=10 pos=23 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=3 pos=25 estimated_size=1
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/env/overlap_token_skip/long.test
+++ b/test/command/suite/select/env/overlap_token_skip/long.test
@@ -1,0 +1,23 @@
+#@omit "need enable `GRN_II_OVERLAP_TOKEN_SKIP_ENABLE` environment variable."
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigramIgnoreBlankSplitSymbolAlpha \
+  --normalizer NormalizerAuto
+
+load --table Entries
+[
+{"body": "This is very very long sentence."}
+]
+
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+
+table_tokenize Terms "This is very very long sentence." --index_column index
+
+log_level --level debug
+#@add-important-log-levels debug
+select Entries --filter 'body @ "This is very very long sentence."'
+#@remove-important-log-levels debug
+log_level --level notice

--- a/test/command/suite/select/env/overlap_token_skip/non_overlap.expected
+++ b/test/command/suite/select/env/overlap_token_skip/non_overlap.expected
@@ -1,0 +1,43 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "Hong Kong"}
+]
+[[0,0.0,0.0],1]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+table_tokenize Terms "Hong Kong" --index_column index
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "hong",
+      "position": 0,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "kong",
+      "position": 1,
+      "force_prefix": false,
+      "estimated_size": 1
+    }
+  ]
+]
+log_level --level debug
+[[0,0.0,0.0],true]
+select Entries --filter 'body @ "Hong Kong"'
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["body","ShortText"]],[1,"Hong Kong"]]]]
+#|d| [ii][overlap_token_skip] tid=1 pos=0 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=2 pos=1 estimated_size=1
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/env/overlap_token_skip/non_overlap.test
+++ b/test/command/suite/select/env/overlap_token_skip/non_overlap.test
@@ -1,0 +1,23 @@
+#@omit "need enable `GRN_II_OVERLAP_TOKEN_SKIP_ENABLE` environment variable."
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+
+load --table Entries
+[
+{"body": "Hong Kong"}
+]
+
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+
+table_tokenize Terms "Hong Kong" --index_column index
+
+log_level --level debug
+#@add-important-log-levels debug
+select Entries --filter 'body @ "Hong Kong"'
+#@remove-important-log-levels debug
+log_level --level notice

--- a/test/command/suite/select/env/overlap_token_skip/one.expected
+++ b/test/command/suite/select/env/overlap_token_skip/one.expected
@@ -1,0 +1,36 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "HongKong"}
+]
+[[0,0.0,0.0],1]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+table_tokenize Terms "HongKong" --index_column index
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "hongkong",
+      "position": 0,
+      "force_prefix": false,
+      "estimated_size": 1
+    }
+  ]
+]
+log_level --level debug
+[[0,0.0,0.0],true]
+select Entries --filter 'body @ "HongKong"'
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["body","ShortText"]],[1,"HongKong"]]]]
+#|d| [ii][overlap_token_skip] tid=1 pos=0 estimated_size=1
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/env/overlap_token_skip/one.test
+++ b/test/command/suite/select/env/overlap_token_skip/one.test
@@ -1,0 +1,23 @@
+#@omit "need enable `GRN_II_OVERLAP_TOKEN_SKIP_ENABLE` environment variable."
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+
+load --table Entries
+[
+{"body": "HongKong"}
+]
+
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+
+table_tokenize Terms "HongKong" --index_column index
+
+log_level --level debug
+#@add-important-log-levels debug
+select Entries --filter 'body @ "HongKong"'
+#@remove-important-log-levels debug
+log_level --level notice

--- a/test/command/suite/select/env/overlap_token_skip/short.expected
+++ b/test/command/suite/select/env/overlap_token_skip/short.expected
@@ -1,0 +1,76 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigramSplitSymbolAlpha   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "HongKong"}
+]
+[[0,0.0,0.0],1]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+table_tokenize Terms "HongKong" --index_column index
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "ho",
+      "position": 0,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "on",
+      "position": 1,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "ng",
+      "position": 2,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "gk",
+      "position": 3,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "ko",
+      "position": 4,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "on",
+      "position": 5,
+      "force_prefix": false,
+      "estimated_size": 3
+    },
+    {
+      "value": "ng",
+      "position": 6,
+      "force_prefix": false,
+      "estimated_size": 3
+    }
+  ]
+]
+log_level --level debug
+[[0,0.0,0.0],true]
+select Entries --filter 'body @ "HongKong"'
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["body","ShortText"]],[1,"HongKong"]]]]
+#|d| [ii][overlap_token_skip] tid=3 pos=0 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=6 pos=1 estimated_size=3
+#|d| [ii][overlap_token_skip] tid=2 pos=3 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=4 pos=4 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=5 pos=6 estimated_size=3
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/env/overlap_token_skip/short.test
+++ b/test/command/suite/select/env/overlap_token_skip/short.test
@@ -1,0 +1,23 @@
+#@omit "need enable `GRN_II_OVERLAP_TOKEN_SKIP_ENABLE` environment variable."
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigramSplitSymbolAlpha \
+  --normalizer NormalizerAuto
+
+load --table Entries
+[
+{"body": "HongKong"}
+]
+
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+
+table_tokenize Terms "HongKong" --index_column index
+
+log_level --level debug
+#@add-important-log-levels debug
+select Entries --filter 'body @ "HongKong"'
+#@remove-important-log-levels debug
+log_level --level notice

--- a/test/command/suite/select/env/overlap_token_skip/skip.expected
+++ b/test/command/suite/select/env/overlap_token_skip/skip.expected
@@ -1,0 +1,80 @@
+plugin_register token_filters/stop_word
+[[0,0.0,0.0],true]
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters TokenFilterStopWord
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "This is a pen"}
+]
+[[0,0.0,0.0],1]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+[[0,0.0,0.0],true]
+load --table Terms
+[
+{"_key": "is", "is_stop_word": true},
+{"_key": "a", "is_stop_word": true}
+]
+[[0,0.0,0.0],2]
+table_tokenize Terms "This is a pen" --index_column index
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "this",
+      "position": 0,
+      "force_prefix": false,
+      "estimated_size": 1
+    },
+    {
+      "value": "pen",
+      "position": 3,
+      "force_prefix": false,
+      "estimated_size": 1
+    }
+  ]
+]
+log_level --level debug
+[[0,0.0,0.0],true]
+select Entries --filter 'body @ "This is a pen"'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "body",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "This is a pen"
+      ]
+    ]
+  ]
+]
+#|d| [ii][overlap_token_skip] tid=4 pos=0 estimated_size=1
+#|d| [ii][overlap_token_skip] tid=3 pos=3 estimated_size=1
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/env/overlap_token_skip/skip.test
+++ b/test/command/suite/select/env/overlap_token_skip/skip.test
@@ -1,0 +1,32 @@
+#@omit "need enable `GRN_II_OVERLAP_TOKEN_SKIP_ENABLE` environment variable."
+plugin_register token_filters/stop_word
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto \
+  --token_filters TokenFilterStopWord
+
+load --table Entries
+[
+{"body": "This is a pen"}
+]
+
+column_create Terms index COLUMN_INDEX|WITH_POSITION Entries body
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+
+load --table Terms
+[
+{"_key": "is", "is_stop_word": true},
+{"_key": "a", "is_stop_word": true}
+]
+
+table_tokenize Terms "This is a pen" --index_column index
+
+log_level --level debug
+#@add-important-log-levels debug
+select Entries --filter 'body @ "This is a pen"'
+#@remove-important-log-levels debug
+log_level --level notice

--- a/test/command/suite/tokenizers/bigram/env/remove_blank_disable/include_blank.expected
+++ b/test/command/suite/tokenizers/bigram/env/remove_blank_disable/include_blank.expected
@@ -1,0 +1,50 @@
+tokenize TokenBigramSplitSymbolAlpha "Hong Kong" NormalizerAuto --mode GET
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "ho",
+      "position": 0,
+      "force_prefix": false
+    },
+    {
+      "value": "on",
+      "position": 1,
+      "force_prefix": false
+    },
+    {
+      "value": "ng",
+      "position": 2,
+      "force_prefix": false
+    },
+    {
+      "value": "g ",
+      "position": 3,
+      "force_prefix": false
+    },
+    {
+      "value": " k",
+      "position": 4,
+      "force_prefix": false
+    },
+    {
+      "value": "ko",
+      "position": 5,
+      "force_prefix": false
+    },
+    {
+      "value": "on",
+      "position": 6,
+      "force_prefix": false
+    },
+    {
+      "value": "ng",
+      "position": 7,
+      "force_prefix": false
+    }
+  ]
+]

--- a/test/command/suite/tokenizers/bigram/env/remove_blank_disable/include_blank.test
+++ b/test/command/suite/tokenizers/bigram/env/remove_blank_disable/include_blank.test
@@ -1,0 +1,3 @@
+#@omit "need enable `GRN_NGRAM_TOKENIZER_REMOVE_BLANK_DISABLE` environment variable."
+
+tokenize TokenBigramSplitSymbolAlpha "Hong Kong" NormalizerAuto --mode GET


### PR DESCRIPTION
iiのチャンクを分割して構築した場合のカーソルスキップの効果を有効的に保ちつつ、Ngramトークナイザーを
高速化するため、token_info_buildでレアトークンを優先的に選択しながらオーバラップトークンをスキップする処理を実装してみました。

環境変数``GRN_II_OVERLAP_TOKEN_SKIP_ENABLE``で有効になります。

実装の大まかな流れは以下のとおりです。
* トークナイズしたトークンとestimate_sizeを一旦全部取得する。
* 隙間なく遷移するように隣接リストでグラフを構築する。(オーバラップトークンか次の隣接トークン)
* グラフを幅優先探索で文頭から末尾までのトークン数が最少になる経路+1の経路のうち、sum(max_estiamted_size / estimated_size)が最も大きくなる(レア度が高い)経路を選ぶ。

ここで最少+1としたのは、TokenBigramでトークンが偶数個の場合、最短経路が一意に決まってしまうためです。
探索は幅優先探索で組み合わせ数が多くなりすぎないように16トークン単位ごとに行っています。
Bigramで16であれば、1000組み合わせ程度で全文検索にはほとんど影響しないと思います。(たぶん。32ごとだと10万組み合わせぐらい)
メモリ節約の観点と実装が簡単だったのでノードの組み合わせ候補をuint32_tのビット位置で表現しています。

### 極端なレアトークンなしのケース

以下のような極端なレアトークンがないフレーズでは、スキップしないものより1.5倍程度高速になります。

* 検索フレーズ:「情報処理システム」トークナイザー:TokenBigram
* 情報:0:1130550 / 報処:1:92306 / 処理:2:1475958 / 理シ:3:95071 /シス:4:928786 /ステ:5:1852329 / テム:6:881885 (token:pos:estimated_size)

|                                  | 利用トークン | 検索時間  |
|----------------------------------|--------------|-----------|
| スキップしない場合(ii_cursor_min_enableあり)              | 0,1,2,3,4,5,6    | 0.1850 sec |
| [先頭から順にスキップした場合](https://github.com/naoa/groonga/commit/e6843957cdba7fa0ad207a625c98b7b4bfe29485)(比較用)         | 0,2,4,6        | 0.240 sec |
| レア度を考慮してスキップした場合(本パッチ) | 0,1,3,4,6        | 0.1058 sec |
  
### 極端なレアトークンありのケース

以下の例ではトークナイザーで先頭から単純にスキップするとレアトークンを飛ばしてしまい逆に遅くなってしまいますが、本パッチの場合はほとんど損をしていません。

* 検索フレーズ:「情報データ」トークナイザー:TokenBigram
* 情報:0:1130550 / 報デ:1:19402 / デー:2:1068392 / ータ:3:2129864  (token:pos:estimated_size)

|                                  | 利用トークン | 検索時間  |
|----------------------------------|--------------|-----------|
| スキップしない場合(ii_cursor_min_enableあり)              | 0,1,2,3      | 0.155 sec |
| [先頭から順にスキップした場合](https://github.com/naoa/groonga/commit/e6843957cdba7fa0ad207a625c98b7b4bfe29485)(比較用)         | 0,2,3        | 0.446 sec |
| レア度を考慮してスキップした場合(本パッチ) | 0,1,3        | 0.156 sec |

### 1000フレーズのトータル比較
本パッチの場合が、スキップなしの場合と比べて1.13倍ほど早くなっています。ii_cursor_set_min_enable無しの場合と比較すると11.3倍。
固有名詞を抽出した辞書からランダムに選んだのでレア度が全体的に大き目で、チャンク分割とカーソルスキップの効果がとても効いているのだと思います。レア度がさほど高くないもの選んでやった場合は、1.3倍～1.5倍ぐらいはやいんじゃないかなと思います。

ii_cursor_set_min_enableの効果がとても高いですね。先頭からスキップするとそのレアトークンをスキップするなんてとんでもないという状態。

|                                  | MIN_ENABLE | 合計検索時間 | 平均検索時間 | 比率   |
|----------------------------------|----------------------|--------------|--------------|--------|
| スキップなし               | なし                 | 65.157 sec   | 0.065 sec    | 1      |
| 先頭から順にスキップ(比較用)               | なし                 | 49.956 sec    | 0.049 sec    | 1.304  |
| レア度を考慮してスキップ | なし                 | 39.191 sec     | 0.039 sec    | 1.663 |
| スキップなし               | あり                 | 6.549 sec    | 0.007 sec    | 9.949  |
| 先頭から順にスキップ(比較用)         | あり                 | 19.656 sec   | 0.019 sec     | 3.315 |
| レア度を考慮してスキップ | あり                 | 5.771 sec     | 0.006 sec    | 11.291 |

インデックスサイズは約30GiB

### 注意点
少し残念ですが、オーバラップをスキップするとトークンの間に空白がある場合でもマッチする(ことがある)ようになり、スキップしない場合とマッチ件数が少し異なってしまいます。

そのため、Ngramトークナイザーで空白を除去しないようにする環境変数``GRN_NGRAM_TOKENIZER_REMOVE_BLANK_DISABLE``も用意しました。これを使えば、当方の環境ではスキップしない場合とマッチ件数が変わらないことを確認しています(1万フレーズぐらいで確認)。これを使う場合はインデックスの再構築が必要です。

いかがでしょうか？