### PR TITLE
doc table_tokenize: add index_column option

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference.po
+++ b/doc/locale/ja/LC_MESSAGES/reference.po
@@ -12665,6 +12665,19 @@ msgstr ""
 "詳細は、 :doc:`/reference/commands/tokenize` の :ref:`tokenize-mode` オプショ"
 "ンを参照してください。"
 
+msgid "``index_column``"
+msgstr "``index_column``"
+
+msgid "Specifies an index column."
+msgstr "インデックスカラム名を指定します。"
+
+msgid "Return value includes ``estimated_size`` of the index."
+msgstr "戻り値にインデックスの ``estimated_size`` が含まれます。"
+
+msgid ""
+"The ``estimated_size`` is useful for checking estimated frequency of tokens."
+msgstr "``estimated_size`` はトークンの概算の出現頻度を調べるのに便利です。"
+
 msgid "``table_tokenize`` command returns tokenized tokens."
 msgstr "``table_tokenize`` コマンドはトークナイズしたトークンを返します。"
 

--- a/doc/source/reference/commands/table_tokenize.rst
+++ b/doc/source/reference/commands/table_tokenize.rst
@@ -25,6 +25,7 @@ optional::
                  string
                  [flags=NONE]
                  [mode=GET]
+                 [index_column=null]
 
 Usage
 -----
@@ -95,6 +96,15 @@ Specifies a tokenize mode.
 The default value is ``GET``.
 
 See :ref:`tokenize-mode` option in :doc:`/reference/commands/tokenize` about details.
+
+``index_column``
+""""""""""""""""
+
+Specifies an index column.
+
+Return value includes ``estimated_size`` of the index.
+
+The ``estimated_size`` is useful for checking estimated frequency of tokens.
 
 Return value
 ------------


### PR DESCRIPTION
とても簡素ですが存在があるだけでも示した方がよいと思って、追加した``table_tokenize``の``index_column``オプション項目を追加しました。

なんかたくさん書き換わりました。