### PR TITLE
Don't resolve record id on dynamic column

### DIFF
--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -868,6 +868,7 @@ grn_select_apply_columns(grn_ctx *ctx,
     grn_obj *expression;
     grn_obj *record;
     grn_table_cursor *table_cursor;
+    grn_id id;
 
     grn_hash_cursor_get_value(ctx, columns_cursor, (void **)&column_data);
 
@@ -953,13 +954,9 @@ grn_select_apply_columns(grn_ctx *ctx,
       break;
     }
 
-    while (grn_table_cursor_next(ctx, table_cursor) != GRN_ID_NIL) {
-      grn_id id;
-      void *key;
+    while ((id = grn_table_cursor_next(ctx, table_cursor)) != GRN_ID_NIL) {
       grn_obj *value;
 
-      grn_table_cursor_get_key(ctx, table_cursor, &key);
-      id = *((grn_id *)key);
       GRN_RECORD_SET(ctx, record, id);
       value = grn_expr_exec(ctx, expression, 0);
       if (value) {

--- a/test/command/suite/select/column/stage/filtered/filter.expected
+++ b/test/command/suite/select/column/stage/filtered/filter.expected
@@ -1,0 +1,56 @@
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+[[0,0.0,0.0],3]
+select Items   --filter 'price < 1200'   --output_columns _id,_key,price,filtered   --column[filtered].stage filtered   --column[filtered].type UInt32   --column[filtered].flags COLUMN_SCALAR   --column[filtered].value '_id'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "price",
+          "UInt32"
+        ],
+        [
+          "filtered",
+          "UInt32"
+        ]
+      ],
+      [
+        2,
+        "Food",
+        1198,
+        2
+      ],
+      [
+        3,
+        "Drink",
+        600,
+        3
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/column/stage/filtered/filter.test
+++ b/test/command/suite/select/column/stage/filtered/filter.test
@@ -1,0 +1,17 @@
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+
+select Items \
+  --filter 'price < 1200' \
+  --output_columns _id,_key,price,filtered \
+  --column[filtered].stage filtered \
+  --column[filtered].type UInt32 \
+  --column[filtered].flags COLUMN_SCALAR \
+  --column[filtered].value '_id'


### PR DESCRIPTION
現在、動的カラムのRECORDのidは、resultテーブルのidでなく、元の実テーブルのidを辿っていると思うのですが、これはresultのidで良いのではないですか？

以下は本パッチ前の結果です。valueでの``_id``が0になってしまっています。
```bash
table_create Items TABLE_HASH_KEY ShortText
[[0,0.0,0.0],true]
column_create Items price COLUMN_SCALAR UInt32
[[0,0.0,0.0],true]
load --table Items
[
{"_key": "Book",  "price": 1498},
{"_key": "Food",  "price": 1198},
{"_key": "Drink", "price": 600}
]
[[0,0.0,0.0],3]
select Items   --filter 'price < 1200'   \
--output_columns _id,_key,price,filtered   \
--column[filtered].stage filtered   \
--column[filtered].type UInt32   \
--column[filtered].flags COLUMN_SCALAR \ 
--column[filtered].value '_id'
[
  [
    0,
    0.0,
    0.0
  ],
  [
    [
      [
        2
      ],
      [
        [
          "_id",
          "UInt32"
        ],
        [
          "_key",
          "ShortText"
        ],
        [
          "price",
          "UInt32"
        ],
        [
          "filtered",
          "UInt32"
        ]
      ],
      [
        2,
        "Food",
        1198,
        0
      ],
      [
        3,
        "Drink",
        600,
        3
      ]
    ]
  ]
]
```