### PR TITLE
select drilldown: support dynamic column creation as initial staging

### DIFF
--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -73,6 +73,7 @@ typedef struct {
   grn_obj *type;
   grn_obj_flags flags;
   grn_select_string value;
+  grn_select_string sortby;
 } grn_column_data;
 
 typedef struct {
@@ -864,6 +865,7 @@ grn_select_apply_columns(grn_ctx *ctx,
 
   while (grn_hash_cursor_next(ctx, columns_cursor) != GRN_ID_NIL) {
     grn_column_data *column_data;
+    grn_obj *target_table = table;
     grn_obj *column;
     grn_obj *expression;
     grn_obj *record;
@@ -892,11 +894,56 @@ grn_select_apply_columns(grn_ctx *ctx,
       break;
     }
 
-    GRN_EXPR_CREATE_FOR_QUERY(ctx, table, expression, record);
+    if (column_data->sortby.length > 0) {
+      grn_table_sort_key *sort_keys;
+      uint32_t n_sort_keys;
+      sort_keys = grn_table_sort_key_from_str(ctx,
+                                              column_data->sortby.value,
+                                              column_data->sortby.length,
+                                              table, &n_sort_keys);
+      if (!sort_keys) {
+        char error_message[GRN_CTX_MSGSIZE];
+        grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+        grn_obj_close(ctx, column);
+        GRN_PLUGIN_ERROR(ctx,
+                         GRN_INVALID_ARGUMENT,
+                         "[select][column][%s][%.*s] failed to parse sort key: %s",
+                         grn_column_stage_name(column_data->stage),
+                         (int)(column_data->label.length),
+                         column_data->label.value,
+                         error_message);
+        break;
+      }
+
+      target_table = grn_table_create(ctx, NULL, 0, NULL, GRN_OBJ_TABLE_NO_KEY,
+                                      NULL, table);
+      if (!target_table) {
+        char error_message[GRN_CTX_MSGSIZE];
+        grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+        grn_obj_close(ctx, column);
+        grn_table_sort_key_close(ctx, sort_keys, n_sort_keys);
+        GRN_PLUGIN_ERROR(ctx,
+                         GRN_INVALID_ARGUMENT,
+                         "[select][column][%s][%.*s] failed to create sorted table: %s",
+                         grn_column_stage_name(column_data->stage),
+                         (int)(column_data->label.length),
+                         column_data->label.value,
+                         error_message);
+        break;
+      }
+      grn_table_sort(ctx, table, 0, -1,
+                     target_table, sort_keys, n_sort_keys);
+      grn_table_sort_key_close(ctx, sort_keys, n_sort_keys);
+    }
+
+    GRN_EXPR_CREATE_FOR_QUERY(ctx, target_table, expression, record);
     if (!expression) {
       char error_message[GRN_CTX_MSGSIZE];
       grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
       grn_obj_close(ctx, column);
+      if (column_data->sortby.length > 0) {
+        grn_obj_unlink(ctx, target_table);
+      }
       GRN_PLUGIN_ERROR(ctx,
                        GRN_INVALID_ARGUMENT,
                        "[select][column][%s][%.*s] "
@@ -920,6 +967,9 @@ grn_select_apply_columns(grn_ctx *ctx,
       grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
       grn_obj_close(ctx, expression);
       grn_obj_close(ctx, column);
+      if (column_data->sortby.length > 0) {
+        grn_obj_unlink(ctx, target_table);
+      }
       GRN_PLUGIN_ERROR(ctx,
                        GRN_INVALID_ARGUMENT,
                        "[select][column][%s][%.*s] "
@@ -934,15 +984,18 @@ grn_select_apply_columns(grn_ctx *ctx,
     }
     grn_select_expression_set_condition(ctx, expression, condition);
 
-    table_cursor = grn_table_cursor_open(ctx, table,
+    table_cursor = grn_table_cursor_open(ctx, target_table,
                                          NULL, 0,
                                          NULL, 0,
-                                         0, -1, 0);
+                                         0, -1, GRN_CURSOR_BY_ID);
     if (!table_cursor) {
       char error_message[GRN_CTX_MSGSIZE];
       grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
       grn_obj_close(ctx, expression);
       grn_obj_close(ctx, column);
+      if (column_data->sortby.length > 0) {
+        grn_obj_unlink(ctx, target_table);
+      }
       GRN_PLUGIN_ERROR(ctx,
                        GRN_INVALID_ARGUMENT,
                        "[select][column][%s][%.*s] "
@@ -959,11 +1012,19 @@ grn_select_apply_columns(grn_ctx *ctx,
 
       GRN_RECORD_SET(ctx, record, id);
       value = grn_expr_exec(ctx, expression, 0);
+      if (column_data->sortby.length > 0) {
+        void *buf;
+        grn_table_cursor_get_value(ctx, table_cursor, &buf);
+        id = *((grn_id *)buf);
+      }
       if (value) {
         grn_obj_set_value(ctx, column, id, value, GRN_OBJ_SET);
       }
     }
 
+    if (column_data->sortby.length > 0) {
+      grn_obj_unlink(ctx, target_table);
+    }
     grn_obj_close(ctx, expression);
   }
 
@@ -1487,7 +1548,8 @@ grn_column_data_fill(grn_ctx *ctx,
                      grn_column_data *column,
                      grn_obj *type_raw,
                      grn_obj *flags,
-                     grn_obj *value)
+                     grn_obj *value,
+                     grn_obj *sortby)
 {
   if (type_raw && GRN_TEXT_LEN(type_raw) > 0) {
     grn_obj *type;
@@ -1544,6 +1606,7 @@ grn_column_data_fill(grn_ctx *ctx,
   }
 
   GRN_SELECT_FILL_STRING(column->value, value);
+  GRN_SELECT_FILL_STRING(column->sortby, sortby);
 
   return GRN_TRUE;
 }
@@ -1575,6 +1638,7 @@ grn_select_data_fill_columns(grn_ctx *ctx,
     grn_obj *type;
     grn_obj *flags;
     grn_obj *value;
+    grn_obj *sortby;
 
     grn_hash_cursor_get_value(ctx, cursor, (void **)&column);
 
@@ -1590,11 +1654,12 @@ grn_select_data_fill_columns(grn_ctx *ctx,
     GET_VAR(type);
     GET_VAR(flags);
     GET_VAR(value);
+    GET_VAR(sortby);
 
 #undef GET_VAR
 
     grn_column_data_fill(ctx, column,
-                         type, flags, value);
+                         type, flags, value, sortby);
   }
   grn_hash_cursor_close(ctx, cursor);
 

--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -61,10 +61,14 @@ typedef struct {
   grn_table_group_flags calc_types;
   grn_select_string calc_target_name;
   grn_select_string table_name;
+  struct {
+    grn_hash *initial;
+  } columns;
 } grn_drilldown_data;
 
 typedef enum {
   GRN_COLUMN_STAGE_UNKNOWN,
+  GRN_COLUMN_STAGE_INITIAL,
   GRN_COLUMN_STAGE_FILTERED
 } grn_column_stage;
 
@@ -311,6 +315,8 @@ static const char *
 grn_column_stage_name(grn_column_stage stage)
 {
   switch (stage) {
+  case GRN_COLUMN_STAGE_INITIAL :
+    return "initial";
   case GRN_COLUMN_STAGE_FILTERED :
     return "filtered";
   default :
@@ -901,6 +907,10 @@ grn_select_drilldowns_execute(grn_ctx *ctx,
     if (keys) {
       grn_table_sort_key_close(ctx, keys, n_keys);
     }
+    if (drilldown->columns.initial) {
+      grn_select_apply_columns(ctx, result->table, drilldown->columns.initial,
+                               condition);
+    }
   }
 
 exit :
@@ -1466,6 +1476,8 @@ grn_column_data_init(grn_ctx *ctx, const char *label, size_t label_len,
 
   if (GRN_BULK_EQUAL_STRING(value, "filtered")) {
     stage = GRN_COLUMN_STAGE_FILTERED;
+  } else if (GRN_BULK_EQUAL_STRING(value, "initial")) {
+    stage = GRN_COLUMN_STAGE_INITIAL;
   } else {
     stage = GRN_COLUMN_STAGE_UNKNOWN;
   }
@@ -1575,7 +1587,9 @@ grn_column_data_fill(grn_ctx *ctx,
 static grn_bool
 grn_column_data_collect(grn_ctx *ctx,
                         grn_user_data *user_data,
-                        grn_hash *columns)
+                        grn_hash *columns,
+                        const char *prefix_label,
+                        size_t prefix_label_len)
 {
   grn_hash_cursor *cursor = NULL;
   cursor = grn_hash_cursor_open(ctx, columns,
@@ -1598,7 +1612,9 @@ grn_column_data_collect(grn_ctx *ctx,
     grn_snprintf(key_name,                                              \
                  GRN_TABLE_MAX_KEY_SIZE,                                \
                  GRN_TABLE_MAX_KEY_SIZE,                                \
-                 "column[%.*s]." # name,                                \
+                 "%.*scolumn[%.*s]." # name,                            \
+                 (int)prefix_label_len,                                 \
+                 prefix_label,                                          \
                  (int)(column->label.length),                           \
                  column->label.value);                                  \
     name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
@@ -1686,7 +1702,93 @@ grn_select_data_fill_columns(grn_ctx *ctx,
     return GRN_TRUE;
   }
 
-  if (!grn_column_data_collect(ctx, user_data, data->columns.filtered)) {
+  if (!grn_column_data_collect(ctx, user_data, data->columns.filtered, NULL, 0)) {
+    return GRN_FALSE;
+  }
+
+  return GRN_TRUE;
+}
+
+static grn_bool
+grn_drilldown_data_fill_columns_collect(grn_ctx *ctx,
+                                        grn_user_data *user_data,
+                                        grn_drilldown_data *data,
+                                        const char *drilldown_label)
+{
+  grn_obj *vars;
+  grn_table_cursor *cursor;
+  const char *prefix = "column[";
+  size_t prefix_len;
+  const char *suffix = "].stage";
+  size_t suffix_len;
+  size_t drilldown_label_len = strlen(drilldown_label);
+
+  vars = grn_plugin_proc_get_vars(ctx, user_data);
+  cursor = grn_table_cursor_open(ctx, vars, NULL, 0, NULL, 0, 0, -1, 0);
+  if (!cursor) {
+    return GRN_FALSE;
+  }
+
+  prefix_len = strlen(prefix);
+  suffix_len = strlen(suffix);
+  while (grn_table_cursor_next(ctx, cursor)) {
+    void *key;
+    char *name;
+    int name_len;
+    void *value_raw;
+    grn_obj *value;
+
+    name_len = grn_table_cursor_get_key(ctx, cursor, &key);
+    name = key;
+
+    name += drilldown_label_len;
+    name_len -= drilldown_label_len;
+
+    if (name_len < prefix_len + suffix_len + 1) {
+      continue;
+    }
+
+    if (memcmp(prefix, name, prefix_len) != 0) {
+      continue;
+    }
+
+    if (memcmp(suffix, name + (name_len - suffix_len), suffix_len) != 0) {
+      continue;
+    }
+
+    grn_table_cursor_get_value(ctx, cursor, &value_raw);
+    value = value_raw;
+
+    if (!grn_column_data_init(ctx,
+                              name + prefix_len,
+                              name_len - prefix_len - suffix_len,
+                              value, &(data->columns.initial))) {
+      grn_table_cursor_close(ctx, cursor);
+      return GRN_FALSE;
+    }
+  }
+  grn_table_cursor_close(ctx, cursor);
+
+  return GRN_TRUE;
+}
+
+static grn_bool
+grn_drilldown_data_fill_columns(grn_ctx *ctx,
+                                grn_user_data *user_data,
+                                grn_drilldown_data *data,
+                                const char *drilldown_label)
+{
+  if (!grn_drilldown_data_fill_columns_collect(ctx, user_data, data,
+                                               drilldown_label)) {
+    return GRN_FALSE;
+  }
+
+  if (!data->columns.initial) {
+    return GRN_TRUE;
+  }
+
+  if (!grn_column_data_collect(ctx, user_data, data->columns.initial,
+                               drilldown_label, strlen(drilldown_label))) {
     return GRN_FALSE;
   }
 
@@ -1767,6 +1869,7 @@ grn_select_data_fill_drilldowns(grn_ctx *ctx,
     drilldown_data = &(data->drilldowns[0]);
     drilldown_data->label.value = NULL;
     drilldown_data->label.length = 0;
+    drilldown_data->columns.initial = NULL;
     grn_drilldown_data_fill(ctx,
                             drilldown_data,
                             drilldown,
@@ -1811,6 +1914,7 @@ grn_select_data_fill_drilldowns(grn_ctx *ctx,
       grn_drilldown_data *drilldown = &(data->drilldowns[i]);
         const char *label;
         int label_len;
+        char drilldown_label[GRN_TABLE_MAX_KEY_SIZE];
         char key_name[GRN_TABLE_MAX_KEY_SIZE];
         grn_obj *keys;
         grn_obj *sortby;
@@ -1824,12 +1928,16 @@ grn_select_data_fill_drilldowns(grn_ctx *ctx,
         label_len = grn_table_cursor_get_key(ctx, cursor, (void **)&label);
         drilldown->label.value = label;
         drilldown->label.length = label_len;
+        grn_snprintf(drilldown_label,
+                     GRN_TABLE_MAX_KEY_SIZE,
+                     GRN_TABLE_MAX_KEY_SIZE,
+                     "drilldown[%.*s].", label_len, label);
 
 #define GET_VAR(name)                                                   \
         grn_snprintf(key_name,                                          \
                      GRN_TABLE_MAX_KEY_SIZE,                            \
                      GRN_TABLE_MAX_KEY_SIZE,                            \
-                     "drilldown[%.*s]." # name, label_len, label);      \
+                     "%s" # name, drilldown_label);                     \
         name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
 
         GET_VAR(keys);
@@ -1843,6 +1951,7 @@ grn_select_data_fill_drilldowns(grn_ctx *ctx,
 
 #undef GET_VAR
 
+        grn_drilldown_data_fill_columns(ctx, user_data, drilldown, drilldown_label);
         grn_drilldown_data_fill(ctx, drilldown,
                                 keys, sortby, output_columns, offset, limit,
                                 calc_types, calc_target, table);
@@ -1946,6 +2055,13 @@ exit :
   }
 
   if (data.drilldowns) {
+    int i;
+    for (i = 0; i < data.n_drilldowns; i++) {
+      grn_drilldown_data *drilldown = &(data.drilldowns[i]);
+      if (drilldown->columns.initial) {
+        grn_hash_close(ctx, drilldown->columns.initial);
+      }
+    }
     GRN_PLUGIN_FREE(ctx, data.drilldowns);
   }
   if (data.drilldown_labels) {

--- a/plugins/functions/CMakeLists.txt
+++ b/plugins/functions/CMakeLists.txt
@@ -98,3 +98,23 @@ else()
   install(TARGETS time_functions DESTINATION "${GRN_FUNCTIONS_PLUGIN_DIR}")
 endif()
 target_link_libraries(time_functions libgroonga)
+
+read_file_list(${CMAKE_CURRENT_SOURCE_DIR}/rank_sources.am
+  RANK_SOURCES)
+set_source_files_properties(${RANK_SOURCES}
+  PROPERTIES
+  COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS}")
+if(GRN_EMBED)
+  add_library(rank_functions STATIC ${RANK_SOURCES})
+  set_target_properties(
+    rank_functions
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON)
+else()
+  add_library(rank_functions MODULE ${RANK_SOURCES})
+  set_target_properties(rank_functions PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "rank")
+  install(TARGETS rank_functions DESTINATION "${GRN_FUNCTIONS_PLUGIN_DIR}")
+endif()
+target_link_libraries(rank_functions libgroonga)

--- a/plugins/functions/Makefile.am
+++ b/plugins/functions/Makefile.am
@@ -19,10 +19,12 @@ function_plugins_LTLIBRARIES += vector.la
 function_plugins_LTLIBRARIES += string.la
 function_plugins_LTLIBRARIES += number.la
 function_plugins_LTLIBRARIES += time.la
+function_plugins_LTLIBRARIES += rank.la
 
 include vector_sources.am
 include string_sources.am
 include number_sources.am
 include time_sources.am
+include rank_sources.am
 
 number_la_LIBADD = -lm

--- a/plugins/functions/rank.c
+++ b/plugins/functions/rank.c
@@ -1,0 +1,93 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2016 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef GRN_EMBEDDED
+#  define GRN_PLUGIN_FUNCTION_TAG functions_rank
+#endif
+
+#include <groonga/plugin.h>
+
+static grn_obj *
+func_rank(grn_ctx *ctx, int n_args, grn_obj **args,
+          grn_user_data *user_data)
+{
+  grn_obj *rank;
+  grn_obj *expression;
+  grn_obj *record;
+  grn_id id;
+
+  if (n_args != 0) {
+    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+                     "rank(): wrong number of arguments (%d for 0)",
+                     n_args);
+    return NULL;
+  }
+
+  grn_proc_get_info(ctx, user_data, NULL, NULL, &expression);
+  if (!expression) {
+    return NULL;
+  }
+
+  record = grn_expr_get_var_by_offset(ctx, expression, 0);
+  if (!record) {
+    return NULL;
+  }
+
+  id = GRN_RECORD_VALUE(record);
+  if (id == GRN_ID_NIL) {
+    return NULL;
+  }
+
+  rank = grn_plugin_proc_alloc(ctx,
+                               user_data,
+                               GRN_DB_UINT32,
+                               0);
+  if (!rank) {
+    return NULL;
+  }
+
+  GRN_UINT32_SET(ctx, rank, id);
+
+  return rank;
+}
+
+grn_rc
+GRN_PLUGIN_INIT(grn_ctx *ctx)
+{
+  return ctx->rc;
+}
+
+grn_rc
+GRN_PLUGIN_REGISTER(grn_ctx *ctx)
+{
+  grn_rc rc = GRN_SUCCESS;
+
+  grn_proc_create(ctx,
+                  "rank", -1,
+                  GRN_PROC_FUNCTION,
+                  func_rank,
+                  NULL, NULL, 0, NULL);
+
+  return rc;
+}
+
+grn_rc
+GRN_PLUGIN_FIN(grn_ctx *ctx)
+{
+  return GRN_SUCCESS;
+}

--- a/plugins/functions/rank_sources.am
+++ b/plugins/functions/rank_sources.am
@@ -1,0 +1,2 @@
+rank_la_SOURCES =				\
+	rank.c

--- a/test/command/suite/select/column/sortby/ascending.expected
+++ b/test/command/suite/select/column/sortby/ascending.expected
@@ -1,0 +1,58 @@
+plugin_register functions/rank
+[[0,0.0,0.0],true]
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+[[0,0.0,0.0],3]
+select Items   --filter 'price < 1200'   --sortby price_rank   --output_columns _id,_key,price,price_rank   --column[price_rank].stage filtered   --column[price_rank].type UInt32   --column[price_rank].flags COLUMN_SCALAR   --column[price_rank].value 'rank()'   --column[price_rank].sortby price
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "price",
+          "UInt32"
+        ],
+        [
+          "price_rank",
+          "UInt32"
+        ]
+      ],
+      [
+        3,
+        "Drink",
+        600,
+        1
+      ],
+      [
+        2,
+        "Food",
+        1198,
+        2
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/column/sortby/ascending.test
+++ b/test/command/suite/select/column/sortby/ascending.test
@@ -1,0 +1,21 @@
+plugin_register functions/rank
+
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+
+select Items \
+  --filter 'price < 1200' \
+  --sortby price_rank \
+  --output_columns _id,_key,price,price_rank \
+  --column[price_rank].stage filtered \
+  --column[price_rank].type UInt32 \
+  --column[price_rank].flags COLUMN_SCALAR \
+  --column[price_rank].value 'rank()' \
+  --column[price_rank].sortby price

--- a/test/command/suite/select/column/sortby/descending.expected
+++ b/test/command/suite/select/column/sortby/descending.expected
@@ -1,0 +1,58 @@
+plugin_register functions/rank
+[[0,0.0,0.0],true]
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+[[0,0.0,0.0],3]
+select Items   --filter 'price < 1200'   --sortby price_rank   --output_columns _id,_key,price,price_rank   --column[price_rank].stage filtered   --column[price_rank].type UInt32   --column[price_rank].flags COLUMN_SCALAR   --column[price_rank].value 'rank()'   --column[price_rank].sortby -price
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "price",
+          "UInt32"
+        ],
+        [
+          "price_rank",
+          "UInt32"
+        ]
+      ],
+      [
+        2,
+        "Food",
+        1198,
+        1
+      ],
+      [
+        3,
+        "Drink",
+        600,
+        2
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/column/sortby/descending.test
+++ b/test/command/suite/select/column/sortby/descending.test
@@ -1,0 +1,21 @@
+plugin_register functions/rank
+
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+load --table Items
+[
+{"_key": "Book",  "price": 1498},
+{"_key": "Food",  "price": 1198},
+{"_key": "Drink", "price": 600}
+]
+
+select Items \
+  --filter 'price < 1200' \
+  --sortby price_rank \
+  --output_columns _id,_key,price,price_rank \
+  --column[price_rank].stage filtered \
+  --column[price_rank].type UInt32 \
+  --column[price_rank].flags COLUMN_SCALAR \
+  --column[price_rank].value 'rank()' \
+  --column[price_rank].sortby -price

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/output_columns.expected
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/output_columns.expected
@@ -1,0 +1,109 @@
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+[[0,0.0,0.0],6]
+select Items   --drilldown[label].keys price   --drilldown[label].output_columns _key,_nsubrecs,tax_included   --drilldown[label].column[tax_included].stage initial   --drilldown[label].column[tax_included].type UInt32   --drilldown[label].column[tax_included].flags COLUMN_SCALAR   --drilldown[label].column[tax_included].value '_key * 1.08'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        6
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "price",
+          "UInt32"
+        ]
+      ],
+      [
+        1,
+        "Book",
+        1000
+      ],
+      [
+        2,
+        "Note",
+        1000
+      ],
+      [
+        3,
+        "Box",
+        500
+      ],
+      [
+        4,
+        "Pen",
+        500
+      ],
+      [
+        5,
+        "Food",
+        500
+      ],
+      [
+        6,
+        "Drink",
+        300
+      ]
+    ],
+    {
+      "label": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "UInt32"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "tax_included",
+            "UInt32"
+          ]
+        ],
+        [
+          1000,
+          2,
+          1080
+        ],
+        [
+          500,
+          3,
+          540
+        ],
+        [
+          300,
+          1,
+          324
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/output_columns.test
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/output_columns.test
@@ -1,0 +1,20 @@
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+
+select Items \
+  --drilldown[label].keys price \
+  --drilldown[label].output_columns _key,_nsubrecs,tax_included \
+  --drilldown[label].column[tax_included].stage initial \
+  --drilldown[label].column[tax_included].type UInt32 \
+  --drilldown[label].column[tax_included].flags COLUMN_SCALAR \
+  --drilldown[label].column[tax_included].value '_key * 1.08'

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/sortby.expected
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/sortby.expected
@@ -1,0 +1,111 @@
+plugin_register functions/rank
+[[0,0.0,0.0],true]
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+[[0,0.0,0.0],6]
+select Items   --drilldown[label].keys price   --drilldown[label].sortby price_rank   --drilldown[label].output_columns _key,_nsubrecs,price_rank   --drilldown[label].column[price_rank].stage initial   --drilldown[label].column[price_rank].type UInt32   --drilldown[label].column[price_rank].flags COLUMN_SCALAR   --drilldown[label].column[price_rank].value 'rank()'   --drilldown[label].column[price_rank].sortby '-_nsubrecs'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        6
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "price",
+          "UInt32"
+        ]
+      ],
+      [
+        1,
+        "Book",
+        1000
+      ],
+      [
+        2,
+        "Note",
+        1000
+      ],
+      [
+        3,
+        "Box",
+        500
+      ],
+      [
+        4,
+        "Pen",
+        500
+      ],
+      [
+        5,
+        "Food",
+        500
+      ],
+      [
+        6,
+        "Drink",
+        300
+      ]
+    ],
+    {
+      "label": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "UInt32"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "price_rank",
+            "UInt32"
+          ]
+        ],
+        [
+          500,
+          3,
+          1
+        ],
+        [
+          1000,
+          2,
+          2
+        ],
+        [
+          300,
+          1,
+          3
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/sortby.test
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/sortby.test
@@ -1,0 +1,24 @@
+plugin_register functions/rank
+
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+
+select Items \
+  --drilldown[label].keys price \
+  --drilldown[label].sortby price_rank \
+  --drilldown[label].output_columns _key,_nsubrecs,price_rank \
+  --drilldown[label].column[price_rank].stage initial \
+  --drilldown[label].column[price_rank].type UInt32 \
+  --drilldown[label].column[price_rank].flags COLUMN_SCALAR \
+  --drilldown[label].column[price_rank].value 'rank()' \
+  --drilldown[label].column[price_rank].sortby '-_nsubrecs'

--- a/test/command/suite/select/function/rank/output_columns.expected
+++ b/test/command/suite/select/function/rank/output_columns.expected
@@ -1,0 +1,87 @@
+plugin_register functions/rank
+[[0,0.0,0.0],true]
+table_create Prices TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+load --table Prices
+[
+{"_key": -201},
+{"_key": -200},
+{"_key": -199},
+{"_key": -101},
+{"_key": -100},
+{"_key": -99},
+{"_key": -1},
+{"_key": 0},
+{"_key": 1},
+{"_key": 99},
+{"_key": 100},
+{"_key": 101},
+{"_key": 199},
+{"_key": 200},
+{"_key": 201}
+]
+[[0,0.0,0.0],15]
+select Prices   --filter '_key > 0'   --sortby -_id   --limit -1   --output_columns '_id, _key, rank()'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        7
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "Int32"
+        ],
+        [
+          "rank",
+          "null"
+        ]
+      ],
+      [
+        15,
+        201,
+        1
+      ],
+      [
+        14,
+        200,
+        2
+      ],
+      [
+        13,
+        199,
+        3
+      ],
+      [
+        12,
+        101,
+        4
+      ],
+      [
+        11,
+        100,
+        5
+      ],
+      [
+        10,
+        99,
+        6
+      ],
+      [
+        9,
+        1,
+        7
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/rank/output_columns.test
+++ b/test/command/suite/select/function/rank/output_columns.test
@@ -1,0 +1,28 @@
+plugin_register functions/rank
+
+table_create Prices TABLE_PAT_KEY Int32
+
+load --table Prices
+[
+{"_key": -201},
+{"_key": -200},
+{"_key": -199},
+{"_key": -101},
+{"_key": -100},
+{"_key": -99},
+{"_key": -1},
+{"_key": 0},
+{"_key": 1},
+{"_key": 99},
+{"_key": 100},
+{"_key": 101},
+{"_key": 199},
+{"_key": 200},
+{"_key": 201}
+]
+
+select Prices \
+  --filter '_key > 0' \
+  --sortby -_id \
+  --limit -1 \
+  --output_columns '_id, _key, rank()'


### PR DESCRIPTION
[groonga-dev 04027](https://osdn.jp/projects/groonga/lists/archive/dev/2016-May/004027.html)

以下の構文を実装してみました。

```
  --drilldown[label].column[rank].stage initial \
  --drilldown[label].column[rank].type UInt32 \
  --drilldown[label].column[rank].flags COLUMN_SCALAR \
  --drilldown[label].column[rank].value 'rank()' \
  --drilldown[label].column[rank].sortby _nsubrecs
```

* a68521f rank関数``rank()``
* 8cc11a7 sortしてから動的カラムでvalueの評価のサポート``column[label].sortby``
* 8cc11a7...76ba4cf ドリルダウン結果で動的カラムを使うためのコード整理
* 3a345f8 ドリルダウン結果での動的カラム(initial)のサポート``drilldown[label].column[label2]...``

コード共有の関係上、``column[label].sortby``で通常の動的カラムでもsortしてからのvalueの評価ができるようにしています。
おそらく、通常の動的カラムでこのような用途はstage outputでの実装を想定している感じですが、通常の動的カラムでは除外すべきでしょうか？