### PR TITLE
Extract dynamic column related functions

### DIFF
--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -305,6 +305,139 @@ grn_proc_select_output_columns(grn_ctx *ctx, grn_obj *res,
   GRN_OBJ_FORMAT_FIN(ctx, &format);
 }
 
+static const char *
+grn_column_stage_name(grn_column_stage stage)
+{
+  switch (stage) {
+  case GRN_COLUMN_STAGE_FILTERED :
+    return "filtered";
+  default :
+    return "unknown";
+  }
+}
+
+static void
+grn_select_apply_columns(grn_ctx *ctx,
+                         grn_obj *table,
+                         grn_hash *columns,
+                         grn_obj *condition)
+{
+  grn_hash_cursor *columns_cursor;
+
+  columns_cursor = grn_hash_cursor_open(ctx, columns,
+                                        NULL, 0, NULL, 0, 0, -1, 0);
+  if (!columns_cursor) {
+    return;
+  }
+
+  while (grn_hash_cursor_next(ctx, columns_cursor) != GRN_ID_NIL) {
+    grn_column_data *column_data;
+    grn_obj *column;
+    grn_obj *expression;
+    grn_obj *record;
+    grn_table_cursor *table_cursor;
+    grn_id id;
+
+    grn_hash_cursor_get_value(ctx, columns_cursor, (void **)&column_data);
+
+    column = grn_column_create(ctx,
+                               table,
+                               column_data->label.value,
+                               column_data->label.length,
+                               NULL,
+                               column_data->flags,
+                               column_data->type);
+    if (!column) {
+      char error_message[GRN_CTX_MSGSIZE];
+      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] failed to create column: %s",
+                       grn_column_stage_name(column_data->stage),
+                       (int)(column_data->label.length),
+                       column_data->label.value,
+                       error_message);
+      break;
+    }
+
+    GRN_EXPR_CREATE_FOR_QUERY(ctx, table, expression, record);
+    if (!expression) {
+      char error_message[GRN_CTX_MSGSIZE];
+      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+      grn_obj_close(ctx, column);
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] "
+                       "failed to create expression to compute value: %s",
+                       grn_column_stage_name(column_data->stage),
+                       (int)(column_data->label.length),
+                       column_data->label.value,
+                       error_message);
+      break;
+    }
+    grn_expr_parse(ctx,
+                   expression,
+                   column_data->value.value,
+                   column_data->value.length,
+                   NULL,
+                   GRN_OP_MATCH,
+                   GRN_OP_AND,
+                   GRN_EXPR_SYNTAX_SCRIPT);
+    if (ctx->rc != GRN_SUCCESS) {
+      char error_message[GRN_CTX_MSGSIZE];
+      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+      grn_obj_close(ctx, expression);
+      grn_obj_close(ctx, column);
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] "
+                       "failed to parse value: <%.*s>: %s",
+                       grn_column_stage_name(column_data->stage),
+                       (int)(column_data->label.length),
+                       column_data->label.value,
+                       (int)(column_data->value.length),
+                       column_data->value.value,
+                       error_message);
+      break;
+    }
+    grn_select_expression_set_condition(ctx, expression, condition);
+
+    table_cursor = grn_table_cursor_open(ctx, table,
+                                         NULL, 0,
+                                         NULL, 0,
+                                         0, -1, 0);
+    if (!table_cursor) {
+      char error_message[GRN_CTX_MSGSIZE];
+      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
+      grn_obj_close(ctx, expression);
+      grn_obj_close(ctx, column);
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] "
+                       "failed to create cursor for getting records: %s",
+                       grn_column_stage_name(column_data->stage),
+                       (int)(column_data->label.length),
+                       column_data->label.value,
+                       error_message);
+      break;
+    }
+
+    while ((id = grn_table_cursor_next(ctx, table_cursor)) != GRN_ID_NIL) {
+      grn_obj *value;
+
+      GRN_RECORD_SET(ctx, record, id);
+      value = grn_expr_exec(ctx, expression, 0);
+      if (value) {
+        grn_obj_set_value(ctx, column, id, value, GRN_OBJ_SET);
+      }
+    }
+
+    grn_obj_close(ctx, expression);
+  }
+
+  grn_hash_cursor_close(ctx, columns_cursor);
+}
+
 static grn_table_group_flags
 grn_parse_table_group_calc_types(grn_ctx *ctx,
                                  const char *calc_types,
@@ -837,139 +970,6 @@ grn_select_drilldowns(grn_ctx *ctx, grn_obj *table,
   GRN_PLUGIN_FREE(ctx, results);
 }
 
-static const char *
-grn_column_stage_name(grn_column_stage stage)
-{
-  switch (stage) {
-  case GRN_COLUMN_STAGE_FILTERED :
-    return "filtered";
-  default :
-    return "unknown";
-  }
-}
-
-static void
-grn_select_apply_columns(grn_ctx *ctx,
-                         grn_obj *table,
-                         grn_hash *columns,
-                         grn_obj *condition)
-{
-  grn_hash_cursor *columns_cursor;
-
-  columns_cursor = grn_hash_cursor_open(ctx, columns,
-                                        NULL, 0, NULL, 0, 0, -1, 0);
-  if (!columns_cursor) {
-    return;
-  }
-
-  while (grn_hash_cursor_next(ctx, columns_cursor) != GRN_ID_NIL) {
-    grn_column_data *column_data;
-    grn_obj *column;
-    grn_obj *expression;
-    grn_obj *record;
-    grn_table_cursor *table_cursor;
-    grn_id id;
-
-    grn_hash_cursor_get_value(ctx, columns_cursor, (void **)&column_data);
-
-    column = grn_column_create(ctx,
-                               table,
-                               column_data->label.value,
-                               column_data->label.length,
-                               NULL,
-                               column_data->flags,
-                               column_data->type);
-    if (!column) {
-      char error_message[GRN_CTX_MSGSIZE];
-      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] failed to create column: %s",
-                       grn_column_stage_name(column_data->stage),
-                       (int)(column_data->label.length),
-                       column_data->label.value,
-                       error_message);
-      break;
-    }
-
-    GRN_EXPR_CREATE_FOR_QUERY(ctx, table, expression, record);
-    if (!expression) {
-      char error_message[GRN_CTX_MSGSIZE];
-      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
-      grn_obj_close(ctx, column);
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] "
-                       "failed to create expression to compute value: %s",
-                       grn_column_stage_name(column_data->stage),
-                       (int)(column_data->label.length),
-                       column_data->label.value,
-                       error_message);
-      break;
-    }
-    grn_expr_parse(ctx,
-                   expression,
-                   column_data->value.value,
-                   column_data->value.length,
-                   NULL,
-                   GRN_OP_MATCH,
-                   GRN_OP_AND,
-                   GRN_EXPR_SYNTAX_SCRIPT);
-    if (ctx->rc != GRN_SUCCESS) {
-      char error_message[GRN_CTX_MSGSIZE];
-      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
-      grn_obj_close(ctx, expression);
-      grn_obj_close(ctx, column);
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] "
-                       "failed to parse value: <%.*s>: %s",
-                       grn_column_stage_name(column_data->stage),
-                       (int)(column_data->label.length),
-                       column_data->label.value,
-                       (int)(column_data->value.length),
-                       column_data->value.value,
-                       error_message);
-      break;
-    }
-    grn_select_expression_set_condition(ctx, expression, condition);
-
-    table_cursor = grn_table_cursor_open(ctx, table,
-                                         NULL, 0,
-                                         NULL, 0,
-                                         0, -1, 0);
-    if (!table_cursor) {
-      char error_message[GRN_CTX_MSGSIZE];
-      grn_memcpy(error_message, ctx->errbuf, GRN_CTX_MSGSIZE);
-      grn_obj_close(ctx, expression);
-      grn_obj_close(ctx, column);
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] "
-                       "failed to create cursor for getting records: %s",
-                       grn_column_stage_name(column_data->stage),
-                       (int)(column_data->label.length),
-                       column_data->label.value,
-                       error_message);
-      break;
-    }
-
-    while ((id = grn_table_cursor_next(ctx, table_cursor)) != GRN_ID_NIL) {
-      grn_obj *value;
-
-      GRN_RECORD_SET(ctx, record, id);
-      value = grn_expr_exec(ctx, expression, 0);
-      if (value) {
-        grn_obj_set_value(ctx, column, id, value, GRN_OBJ_SET);
-      }
-    }
-
-    grn_obj_close(ctx, expression);
-  }
-
-  grn_hash_cursor_close(ctx, columns_cursor);
-}
-
 static grn_rc
 grn_select(grn_ctx *ctx, grn_select_data *data)
 {
@@ -1397,6 +1397,72 @@ exit :
 }
 
 static grn_bool
+grn_column_data_fill(grn_ctx *ctx,
+                     grn_column_data *column,
+                     grn_obj *type_raw,
+                     grn_obj *flags,
+                     grn_obj *value)
+{
+  if (type_raw && GRN_TEXT_LEN(type_raw) > 0) {
+    grn_obj *type;
+
+    type = grn_ctx_get(ctx, GRN_TEXT_VALUE(type_raw), GRN_TEXT_LEN(type_raw));
+    if (!type) {
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] unknown type: <%.*s>",
+                       grn_column_stage_name(column->stage),
+                       (int)(column->label.length),
+                       column->label.value,
+                       (int)(GRN_TEXT_LEN(type_raw)),
+                       GRN_TEXT_VALUE(type_raw));
+      return GRN_FALSE;
+    }
+    if (!(grn_obj_is_type(ctx, type) || grn_obj_is_table(ctx, type))) {
+      grn_obj inspected;
+      GRN_TEXT_INIT(&inspected, 0);
+      grn_inspect(ctx, &inspected, type);
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "[select][column][%s][%.*s] invalid type: %.*s",
+                       grn_column_stage_name(column->stage),
+                       (int)(column->label.length),
+                       column->label.value,
+                       (int)(GRN_TEXT_LEN(&inspected)),
+                       GRN_TEXT_VALUE(&inspected));
+      GRN_OBJ_FIN(ctx, &inspected);
+      grn_obj_unlink(ctx, type);
+      return GRN_FALSE;
+    }
+    column->type = type;
+  }
+
+  if (flags && GRN_TEXT_LEN(flags) > 0) {
+    char error_message_tag[GRN_TABLE_MAX_KEY_SIZE];
+
+    grn_snprintf(error_message_tag,
+                 GRN_TABLE_MAX_KEY_SIZE,
+                 GRN_TABLE_MAX_KEY_SIZE,
+                 "[select][column][%s][%.*s]",
+                 grn_column_stage_name(column->stage),
+                 (int)(column->label.length),
+                 column->label.value);
+    column->flags =
+      grn_proc_column_parse_flags(ctx,
+                                  error_message_tag,
+                                  GRN_TEXT_VALUE(flags),
+                                  GRN_TEXT_VALUE(flags) + GRN_TEXT_LEN(flags));
+    if (ctx->rc != GRN_SUCCESS) {
+      return GRN_FALSE;
+    }
+  }
+
+  GRN_SELECT_FILL_STRING(column->value, value);
+
+  return GRN_TRUE;
+}
+
+static grn_bool
 grn_select_data_fill_columns_collect(grn_ctx *ctx,
                                      grn_user_data *user_data,
                                      grn_select_data *data)
@@ -1478,72 +1544,6 @@ grn_select_data_fill_columns_collect(grn_ctx *ctx,
     }
   }
   grn_table_cursor_close(ctx, cursor);
-
-  return GRN_TRUE;
-}
-
-static grn_bool
-grn_column_data_fill(grn_ctx *ctx,
-                     grn_column_data *column,
-                     grn_obj *type_raw,
-                     grn_obj *flags,
-                     grn_obj *value)
-{
-  if (type_raw && GRN_TEXT_LEN(type_raw) > 0) {
-    grn_obj *type;
-
-    type = grn_ctx_get(ctx, GRN_TEXT_VALUE(type_raw), GRN_TEXT_LEN(type_raw));
-    if (!type) {
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] unknown type: <%.*s>",
-                       grn_column_stage_name(column->stage),
-                       (int)(column->label.length),
-                       column->label.value,
-                       (int)(GRN_TEXT_LEN(type_raw)),
-                       GRN_TEXT_VALUE(type_raw));
-      return GRN_FALSE;
-    }
-    if (!(grn_obj_is_type(ctx, type) || grn_obj_is_table(ctx, type))) {
-      grn_obj inspected;
-      GRN_TEXT_INIT(&inspected, 0);
-      grn_inspect(ctx, &inspected, type);
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "[select][column][%s][%.*s] invalid type: %.*s",
-                       grn_column_stage_name(column->stage),
-                       (int)(column->label.length),
-                       column->label.value,
-                       (int)(GRN_TEXT_LEN(&inspected)),
-                       GRN_TEXT_VALUE(&inspected));
-      GRN_OBJ_FIN(ctx, &inspected);
-      grn_obj_unlink(ctx, type);
-      return GRN_FALSE;
-    }
-    column->type = type;
-  }
-
-  if (flags && GRN_TEXT_LEN(flags) > 0) {
-    char error_message_tag[GRN_TABLE_MAX_KEY_SIZE];
-
-    grn_snprintf(error_message_tag,
-                 GRN_TABLE_MAX_KEY_SIZE,
-                 GRN_TABLE_MAX_KEY_SIZE,
-                 "[select][column][%s][%.*s]",
-                 grn_column_stage_name(column->stage),
-                 (int)(column->label.length),
-                 column->label.value);
-    column->flags =
-      grn_proc_column_parse_flags(ctx,
-                                  error_message_tag,
-                                  GRN_TEXT_VALUE(flags),
-                                  GRN_TEXT_VALUE(flags) + GRN_TEXT_LEN(flags));
-    if (ctx->rc != GRN_SUCCESS) {
-      return GRN_FALSE;
-    }
-  }
-
-  GRN_SELECT_FILL_STRING(column->value, value);
 
   return GRN_TRUE;
 }

--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -64,6 +64,7 @@ typedef struct {
 } grn_drilldown_data;
 
 typedef enum {
+  GRN_COLUMN_STAGE_UNKNOWN,
   GRN_COLUMN_STAGE_FILTERED
 } grn_column_stage;
 
@@ -1397,6 +1398,52 @@ exit :
 }
 
 static grn_bool
+grn_column_data_init(grn_ctx *ctx, const char *label, size_t label_len,
+                     grn_obj *value, grn_hash **columns)
+{
+  grn_column_stage stage;
+
+  if (GRN_BULK_EQUAL_STRING(value, "filtered")) {
+    stage = GRN_COLUMN_STAGE_FILTERED;
+  } else {
+    stage = GRN_COLUMN_STAGE_UNKNOWN;
+  }
+
+  if (stage != GRN_COLUMN_STAGE_UNKNOWN) {
+    void *column_raw;
+    grn_column_data *column;
+
+    if (!*columns) {
+      *columns = grn_hash_create(ctx,
+                                 NULL,
+                                 GRN_TABLE_MAX_KEY_SIZE,
+                                 sizeof(grn_column_data),
+                                 GRN_OBJ_TABLE_HASH_KEY |
+                                 GRN_OBJ_KEY_VAR_SIZE |
+                                 GRN_HASH_TINY);
+    }
+    if (!*columns) {
+      return GRN_FALSE;
+    }
+    grn_hash_add(ctx,
+                 *columns,
+                 label,
+                 label_len,
+                 &column_raw,
+                 NULL);
+    column = column_raw;
+    column->label.value = label;
+    column->label.length = label_len;
+    column->stage = stage;
+    column->type = grn_ctx_at(ctx, GRN_DB_TEXT);
+    column->flags = GRN_OBJ_COLUMN_SCALAR;
+    column->value.value = NULL;
+    column->value.length = 0;
+  }
+  return GRN_TRUE;
+}
+
+static grn_bool
 grn_column_data_fill(grn_ctx *ctx,
                      grn_column_data *column,
                      grn_obj *type_raw,
@@ -1463,6 +1510,49 @@ grn_column_data_fill(grn_ctx *ctx,
 }
 
 static grn_bool
+grn_column_data_collect(grn_ctx *ctx,
+                        grn_user_data *user_data,
+                        grn_hash *columns)
+{
+  grn_hash_cursor *cursor = NULL;
+  cursor = grn_hash_cursor_open(ctx, columns,
+                                NULL, 0, NULL, 0, 0, -1, 0);
+  if (!cursor) {
+    return GRN_FALSE;
+  }
+
+  while (grn_hash_cursor_next(ctx, cursor)) {
+    grn_column_data *column;
+    char key_name[GRN_TABLE_MAX_KEY_SIZE];
+    grn_obj *type;
+    grn_obj *flags;
+    grn_obj *value;
+
+    grn_hash_cursor_get_value(ctx, cursor, (void **)&column);
+
+#define GET_VAR(name)                                                   \
+    grn_snprintf(key_name,                                              \
+                 GRN_TABLE_MAX_KEY_SIZE,                                \
+                 GRN_TABLE_MAX_KEY_SIZE,                                \
+                 "column[%.*s]." # name,                                \
+                 (int)(column->label.length),                           \
+                 column->label.value);                                  \
+    name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
+
+    GET_VAR(type);
+    GET_VAR(flags);
+    GET_VAR(value);
+
+#undef GET_VAR
+
+    grn_column_data_fill(ctx, column,
+                         type, flags, value);
+  }
+  grn_hash_cursor_close(ctx, cursor);
+  return GRN_TRUE;
+}
+
+static grn_bool
 grn_select_data_fill_columns_collect(grn_ctx *ctx,
                                      grn_user_data *user_data,
                                      grn_select_data *data)
@@ -1505,42 +1595,12 @@ grn_select_data_fill_columns_collect(grn_ctx *ctx,
 
     grn_table_cursor_get_value(ctx, cursor, &value_raw);
     value = value_raw;
-    if (GRN_BULK_EQUAL_STRING(value, "filtered")) {
-      const char *label;
-      size_t label_len;
-      void *column_raw;
-      grn_column_data *column;
-
-      if (!data->columns.filtered) {
-        data->columns.filtered = grn_hash_create(ctx,
-                                                 NULL,
-                                                 GRN_TABLE_MAX_KEY_SIZE,
-                                                 sizeof(grn_column_data),
-                                                 GRN_OBJ_TABLE_HASH_KEY |
-                                                 GRN_OBJ_KEY_VAR_SIZE |
-                                                 GRN_HASH_TINY);
-      }
-      if (!data->columns.filtered) {
-        grn_table_cursor_close(ctx, cursor);
-        return GRN_FALSE;
-      }
-
-      label = name + prefix_len;
-      label_len = name_len - prefix_len - suffix_len;
-      grn_hash_add(ctx,
-                   data->columns.filtered,
-                   label,
-                   label_len,
-                   &column_raw,
-                   NULL);
-      column = column_raw;
-      column->label.value = label;
-      column->label.length = label_len;
-      column->stage = GRN_COLUMN_STAGE_FILTERED;
-      column->type = grn_ctx_at(ctx, GRN_DB_TEXT);
-      column->flags = GRN_OBJ_COLUMN_SCALAR;
-      column->value.value = NULL;
-      column->value.length = 0;
+    if (!grn_column_data_init(ctx,
+                              name + prefix_len,
+                              name_len - prefix_len - suffix_len,
+                              value, &(data->columns.filtered))) {
+      grn_table_cursor_close(ctx, cursor);
+      return GRN_FALSE;
     }
   }
   grn_table_cursor_close(ctx, cursor);
@@ -1553,8 +1613,6 @@ grn_select_data_fill_columns(grn_ctx *ctx,
                              grn_user_data *user_data,
                              grn_select_data *data)
 {
-  grn_hash_cursor *cursor = NULL;
-
   if (!grn_select_data_fill_columns_collect(ctx, user_data, data)) {
     return GRN_FALSE;
   }
@@ -1563,40 +1621,9 @@ grn_select_data_fill_columns(grn_ctx *ctx,
     return GRN_TRUE;
   }
 
-  cursor = grn_hash_cursor_open(ctx, data->columns.filtered,
-                                NULL, 0, NULL, 0, 0, -1, 0);
-  if (!cursor) {
+  if (!grn_column_data_collect(ctx, user_data, data->columns.filtered)) {
     return GRN_FALSE;
   }
-
-  while (grn_hash_cursor_next(ctx, cursor)) {
-    grn_column_data *column;
-    char key_name[GRN_TABLE_MAX_KEY_SIZE];
-    grn_obj *type;
-    grn_obj *flags;
-    grn_obj *value;
-
-    grn_hash_cursor_get_value(ctx, cursor, (void **)&column);
-
-#define GET_VAR(name)                                                   \
-    grn_snprintf(key_name,                                              \
-                 GRN_TABLE_MAX_KEY_SIZE,                                \
-                 GRN_TABLE_MAX_KEY_SIZE,                                \
-                 "column[%.*s]." # name,                                \
-                 (int)(column->label.length),                           \
-                 column->label.value);                                  \
-    name = grn_plugin_proc_get_var(ctx, user_data, key_name, -1);
-
-    GET_VAR(type);
-    GET_VAR(flags);
-    GET_VAR(value);
-
-#undef GET_VAR
-
-    grn_column_data_fill(ctx, column,
-                         type, flags, value);
-  }
-  grn_hash_cursor_close(ctx, cursor);
 
   return GRN_TRUE;
 }


### PR DESCRIPTION
#540 より分割

まずは、ドリルダウン結果で動的カラムを作るコードを流用するために、コードの移動と抽出だけのコミットにしました。