### PR TITLE
Support detecting changed database isn't closed

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -664,7 +664,18 @@ grn_db_touch(grn_ctx *ctx, grn_obj *s)
 static inline void
 grn_obj_touch_db(grn_ctx *ctx, grn_obj *obj, grn_timeval *tv)
 {
+  grn_db *db = (grn_db *)obj;
+
   grn_obj_io(obj)->header->lastmod = tv->tv_sec;
+
+  switch (db->keys->header.type) {
+  case GRN_TABLE_PAT_KEY :
+    grn_pat_dirty(ctx, (grn_pat *)(db->keys));
+    break;
+  case GRN_TABLE_DAT_KEY :
+    grn_dat_dirty(ctx, (grn_dat *)(db->keys));
+    break;
+  }
 }
 
 void

--- a/lib/grn_dat.h
+++ b/lib/grn_dat.h
@@ -37,6 +37,7 @@ struct _grn_dat {
   grn_obj *normalizer;
   grn_obj token_filters;
   grn_critical_section lock;
+  grn_bool is_dirty;
 };
 
 struct grn_dat_header {
@@ -45,7 +46,8 @@ struct grn_dat_header {
   grn_id tokenizer;
   uint32_t file_id;
   grn_id normalizer;
-  uint32_t reserved[235];
+  uint32_t n_dirty_opens;
+  uint32_t reserved[234];
 };
 
 struct _grn_dat_cursor {
@@ -78,6 +80,8 @@ GRN_API grn_rc grn_dat_clear_status_flags(grn_ctx *ctx, grn_dat *dat);
 GRN_API grn_rc grn_dat_repair(grn_ctx *ctx, grn_dat *dat);
 
 GRN_API grn_rc grn_dat_flush(grn_ctx *ctx, grn_dat *dat);
+
+grn_rc grn_dat_dirty(grn_ctx *ctx, grn_dat *dat);
 
 #ifdef __cplusplus
 }

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -41,6 +41,8 @@ struct _grn_pat {
   grn_obj token_filters;
   grn_id *cache;
   uint32_t cache_size;
+  grn_bool is_dirty;
+  grn_critical_section lock;
 };
 
 #define GRN_PAT_NDELINFOS 0x100
@@ -68,7 +70,8 @@ struct grn_pat_header {
   uint32_t n_garbages;
   grn_id normalizer;
   uint32_t truncated;
-  uint32_t reserved[1003];
+  uint32_t n_dirty_opens;
+  uint32_t reserved[1002];
   grn_pat_delinfo delinfos[GRN_PAT_NDELINFOS];
   grn_id garbages[GRN_PAT_MAX_KEY_SIZE + 1];
 };
@@ -115,6 +118,8 @@ GRN_API grn_rc grn_pat_fuzzy_search(grn_ctx *ctx, grn_pat *pat,
 uint32_t grn_pat_total_key_size(grn_ctx *ctx, grn_pat *pat);
 
 grn_bool grn_pat_is_key_encoded(grn_ctx *ctx, grn_pat *pat);
+
+grn_rc grn_pat_dirty(grn_ctx *ctx, grn_pat *pat);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
It doesn't increase no overhead when the database isn't changed. For
example, you have no overhead and no change when you only use select
command.

It doesn't flush many times. It flushes only at the first database
change.