### PR TITLE
Don't unlink dynamic column in grn_table_sort_key_close

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -12806,7 +12806,11 @@ grn_table_sort_key_close(grn_ctx *ctx, grn_table_sort_key *keys, unsigned int nk
   int i;
   if (keys) {
     for (i = 0; i < nkeys; i++) {
-      grn_obj_unlink(ctx, keys[i].key);
+      grn_obj *key = keys[i].key;
+      grn_id id = grn_obj_id(ctx, key);
+      if (!(id & GRN_OBJ_TMP_COLUMN)) {
+        grn_obj_unlink(ctx, key);
+      }
     }
     GRN_FREE(keys);
   }

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/drilldown.expected
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/drilldown.expected
@@ -1,0 +1,171 @@
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+table_create Shops TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Shops items COLUMN_VECTOR Items
+[[0,0.0,0.0],true]
+load --table Shops
+[
+{"_key": "Stationery store",  "items": ["Book", "Note", "Box", "Pen"]},
+{"_key": "Supermarket",       "items": ["Food", "Drink", "Pen"]},
+{"_key": "Convenience store", "items": ["Pen", "Note","Food", "Drink"]}
+]
+[[0,0.0,0.0],3]
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+[[0,0.0,0.0],6]
+select Shops   --drilldown[label].keys items   --drilldown[label].sortby price   --drilldown[label].output_columns _key,_nsubrecs,price,price_with_tax   --drilldown[label].column[price_with_tax].stage initial   --drilldown[label].column[price_with_tax].type UInt32   --drilldown[label].column[price_with_tax].flags COLUMN_SCALAR   --drilldown[label].column[price_with_tax].value 'price * 1.08'   --drilldown[label2].table label   --drilldown[label2].keys price_with_tax
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "items",
+          "Items"
+        ]
+      ],
+      [
+        1,
+        "Stationery store",
+        [
+          "Book",
+          "Note",
+          "Box",
+          "Pen"
+        ]
+      ],
+      [
+        2,
+        "Supermarket",
+        [
+          "Food",
+          "Drink",
+          "Pen"
+        ]
+      ],
+      [
+        3,
+        "Convenience store",
+        [
+          "Pen",
+          "Note",
+          "Food",
+          "Drink"
+        ]
+      ]
+    ],
+    {
+      "label": [
+        [
+          6
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ],
+          [
+            "price",
+            "UInt32"
+          ],
+          [
+            "price_with_tax",
+            "UInt32"
+          ]
+        ],
+        [
+          "Drink",
+          2,
+          300,
+          324
+        ],
+        [
+          "Food",
+          2,
+          500,
+          540
+        ],
+        [
+          "Pen",
+          3,
+          500,
+          540
+        ],
+        [
+          "Box",
+          1,
+          500,
+          540
+        ],
+        [
+          "Book",
+          1,
+          1000,
+          1080
+        ],
+        [
+          "Note",
+          2,
+          1000,
+          1080
+        ]
+      ],
+      "label2": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "UInt32"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          1080,
+          2
+        ],
+        [
+          540,
+          3
+        ],
+        [
+          324,
+          1
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldown/labeled/column/stage/initial/drilldown.test
+++ b/test/command/suite/select/drilldown/labeled/column/stage/initial/drilldown.test
@@ -1,0 +1,33 @@
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+table_create Shops TABLE_HASH_KEY ShortText
+column_create Shops items COLUMN_VECTOR Items
+
+load --table Shops
+[
+{"_key": "Stationery store",  "items": ["Book", "Note", "Box", "Pen"]},
+{"_key": "Supermarket",       "items": ["Food", "Drink", "Pen"]},
+{"_key": "Convenience store", "items": ["Pen", "Note","Food", "Drink"]}
+]
+
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+
+select Shops \
+  --drilldown[label].keys items \
+  --drilldown[label].sortby price \
+  --drilldown[label].output_columns _key,_nsubrecs,price,price_with_tax \
+  --drilldown[label].column[price_with_tax].stage initial \
+  --drilldown[label].column[price_with_tax].type UInt32 \
+  --drilldown[label].column[price_with_tax].flags COLUMN_SCALAR \
+  --drilldown[label].column[price_with_tax].value 'price * 1.08' \
+  --drilldown[label2].table label \
+  --drilldown[label2].keys price_with_tax


### PR DESCRIPTION
grn_table_sort_key_closeで動的カラムが解放されてしまうのを回避します。