### PR TITLE
column_remove: add "dependent" parameter

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -9272,14 +9272,68 @@ _grn_obj_remove_array(grn_ctx *ctx, grn_obj *obj, grn_obj *db, grn_id id,
   return rc;
 }
 
+static grn_bool
+is_removable_column(grn_ctx *ctx, grn_obj *column, grn_obj *db)
+{
+  grn_hook *hooks;
+
+  hooks = DB_OBJ(column)->hooks[GRN_HOOK_SET];
+  while (hooks) {
+    grn_obj_default_set_value_hook_data *data = (void *)GRN_NEXT_ADDR(hooks);
+    char name[GRN_TABLE_MAX_KEY_SIZE];
+    int name_size;
+    grn_obj *index_column;
+
+    name_size = grn_obj_name(ctx, column, name, GRN_TABLE_MAX_KEY_SIZE);
+
+    index_column = grn_ctx_at(ctx, data->target);
+    if (!index_column) {
+      ERR(GRN_UNKNOWN_ERROR,
+          "[column][remove] "
+          "hook has a dangling reference: <%.*s>",
+          name_size, name);
+      return GRN_FALSE;
+    }
+
+    {
+      char index_column_name[GRN_TABLE_MAX_KEY_SIZE];
+      int index_column_name_size;
+
+      index_column_name_size = grn_obj_name(ctx,
+                                            index_column,
+                                            index_column_name,
+                                            GRN_TABLE_MAX_KEY_SIZE);
+      ERR(GRN_OPERATION_NOT_PERMITTED,
+          "[column][remove] an index column for target column exists: "
+          "<%.*s> -> <%.*s>",
+          index_column_name_size,
+          index_column_name,
+          name_size,
+          name);
+      return GRN_FALSE;
+    }
+  }
+
+  return GRN_TRUE;
+}
+
 static grn_rc
 _grn_obj_remove_ja(grn_ctx *ctx, grn_obj *obj, grn_obj *db, grn_id id,
-                   const char *path)
+                   const char *path, grn_bool dependent)
 {
   grn_rc rc = GRN_SUCCESS;
 
-  rc = remove_index(ctx, obj, GRN_HOOK_SET);
-  if (rc != GRN_SUCCESS) { return rc; }
+  if (dependent) {
+    rc = remove_index(ctx, obj, GRN_HOOK_SET);
+    if (rc != GRN_SUCCESS) {
+      return rc;
+    }
+  } else {
+    if (!is_removable_column(ctx, obj, db)) {
+      return ctx->rc;
+    }
+  }
+
   rc = grn_obj_close(ctx, obj);
   if (rc != GRN_SUCCESS) { return rc; }
 
@@ -9299,12 +9353,21 @@ _grn_obj_remove_ja(grn_ctx *ctx, grn_obj *obj, grn_obj *db, grn_id id,
 
 static grn_rc
 _grn_obj_remove_ra(grn_ctx *ctx, grn_obj *obj, grn_obj *db, grn_id id,
-                   const char *path)
+                   const char *path, grn_bool dependent)
 {
   grn_rc rc = GRN_SUCCESS;
 
-  rc = remove_index(ctx, obj, GRN_HOOK_SET);
-  if (rc != GRN_SUCCESS) { return rc; }
+  if (dependent) {
+    rc = remove_index(ctx, obj, GRN_HOOK_SET);
+    if (rc != GRN_SUCCESS) {
+      return rc;
+    }
+  } else {
+    if (!is_removable_column(ctx, obj, db)) {
+      return ctx->rc;
+    }
+  }
+
   rc = grn_obj_close(ctx, obj);
   if (rc != GRN_SUCCESS) { return rc; }
 
@@ -9423,10 +9486,10 @@ _grn_obj_remove(grn_ctx *ctx, grn_obj *obj, grn_bool dependent)
     rc = _grn_obj_remove_array(ctx, obj, db, id, path, dependent);
     break;
   case GRN_COLUMN_VAR_SIZE :
-    rc = _grn_obj_remove_ja(ctx, obj, db, id, path);
+    rc = _grn_obj_remove_ja(ctx, obj, db, id, path, dependent);
     break;
   case GRN_COLUMN_FIX_SIZE :
-    rc = _grn_obj_remove_ra(ctx, obj, db, id, path);
+    rc = _grn_obj_remove_ra(ctx, obj, db, id, path, dependent);
     break;
   case GRN_COLUMN_INDEX :
     rc = _grn_obj_remove_index(ctx, obj, db, id, path);

--- a/lib/proc/proc_column.c
+++ b/lib/proc/proc_column.c
@@ -296,6 +296,7 @@ command_column_remove(grn_ctx *ctx, int nargs, grn_obj **args,
 {
   grn_obj *table_raw;
   grn_obj *name;
+  grn_bool dependent;
   grn_obj *table;
   grn_obj *column;
   char fullname[GRN_TABLE_MAX_KEY_SIZE];
@@ -303,6 +304,8 @@ command_column_remove(grn_ctx *ctx, int nargs, grn_obj **args,
 
   table_raw = grn_plugin_proc_get_var(ctx, user_data, "table", -1);
   name      = grn_plugin_proc_get_var(ctx, user_data, "name", -1);
+  dependent = grn_plugin_proc_get_var_bool(ctx, user_data, "dependent", -1,
+                                           GRN_TRUE);
 
   table = grn_ctx_get(ctx,
                       GRN_TEXT_VALUE(table_raw),
@@ -351,7 +354,11 @@ command_column_remove(grn_ctx *ctx, int nargs, grn_obj **args,
     return NULL;
   }
 
-  grn_obj_remove(ctx, column);
+  if (dependent) {
+    grn_obj_remove_dependent(ctx, column);
+  } else {
+    grn_obj_remove(ctx, column);
+  }
   grn_ctx_output_bool(ctx, ctx->rc == GRN_SUCCESS);
   return NULL;
 }
@@ -359,14 +366,15 @@ command_column_remove(grn_ctx *ctx, int nargs, grn_obj **args,
 void
 grn_proc_init_column_remove(grn_ctx *ctx)
 {
-  grn_expr_var vars[2];
+  grn_expr_var vars[3];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "table", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "name", -1);
+  grn_plugin_expr_var_init(ctx, &(vars[2]), "dependent", -1);
   grn_plugin_command_create(ctx,
                             "column_remove", -1,
                             command_column_remove,
-                            2,
+                            3,
                             vars);
 }
 

--- a/test/command/suite/column_remove/dependent/default.expected
+++ b/test/command/suite/column_remove/dependent/default.expected
@@ -1,0 +1,21 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+column_remove Users name
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto

--- a/test/command/suite/column_remove/dependent/default.test
+++ b/test/command/suite/column_remove/dependent/default.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+
+dump
+
+column_remove Users name
+
+dump

--- a/test/command/suite/column_remove/dependent/no.expected
+++ b/test/command/suite/column_remove/dependent/no.expected
@@ -1,0 +1,35 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+column_remove Users name --dependent no
+[
+  [
+    [
+      -2,
+      0.0,
+      0.0
+    ],
+    "[column][remove] an index column for target column exists: <Terms.users_name> -> <Users.name>"
+  ],
+  false
+]
+#|e| [column][remove] an index column for target column exists: <Terms.users_name> -> <Users.name>
+dump
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name

--- a/test/command/suite/column_remove/dependent/no.test
+++ b/test/command/suite/column_remove/dependent/no.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+
+dump
+
+column_remove Users name --dependent no
+
+dump

--- a/test/command/suite/column_remove/dependent/yes.expected
+++ b/test/command/suite/column_remove/dependent/yes.expected
@@ -1,0 +1,21 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+column_remove Users name --dependent yes
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto

--- a/test/command/suite/column_remove/dependent/yes.test
+++ b/test/command/suite/column_remove/dependent/yes.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION Users name
+
+dump
+
+column_remove Users name --dependent yes
+
+dump


### PR DESCRIPTION
If "dependent=no" (not default), column_remove reports error for a
column that has one or more indexes.

This change also changes grn_obj_remove(ctx, column) behavior. It
reports error for a column that has one ore more indexes. It's backward
incompatible change.

We need to use grn_obj_remove_dependent(ctx, column) for the previous
behavior.

This is not acceptable. So we need to consider about it carefully.