### PR TITLE
token_filter: fix thread unsafe code

### DIFF
--- a/lib/grn_token_cursor.h
+++ b/lib/grn_token_cursor.h
@@ -58,7 +58,10 @@ typedef struct {
   grn_encoding encoding;
   grn_obj *tokenizer;
   grn_proc_ctx pctx;
-  grn_obj *token_filters;
+  struct {
+    grn_obj *objects;
+    grn_obj user_data_ptrs;
+  } token_filters;
   uint32_t variant;
   grn_obj *nstr;
 } grn_token_cursor;


### PR DESCRIPTION
GitHub: #556

grn_procのuser_dataにトークンフィルター内でmallocしたアドレスを持たせるのではなく、grn_token_cursorに持たせるようにしてみました。

このパッチ適用後では、issueの再現手順でダブルフリーが発生しなくなることを確認しています。