### PR TITLE
Fix 'col resolve error' to be caused by d40820ddb6a760eb3373f119d27eb…

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -5682,6 +5682,7 @@ grn_table_select_sequential(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
   grn_table_cursor *tc;
   grn_hash_cursor *hc;
   grn_hash *s = (grn_hash *)res;
+  GRN_RECORD_INIT(v, 0, grn_obj_id(ctx, table));
   grn_table_select_sequential_data data;
   grn_table_select_sequential_init_func init;
   grn_table_select_sequential_exec_func exec;
@@ -5754,7 +5755,6 @@ grn_table_select_sequential(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
     if ((hc = grn_hash_cursor_open(ctx, s, NULL, 0, NULL, 0, 0, -1, 0))) {
       while (grn_hash_cursor_next(ctx, hc)) {
         grn_hash_cursor_get_key(ctx, hc, (void **) &idp);
-        GRN_RECORD_SET(ctx, v, *idp);
         score = exec(ctx, *idp, &data);
         if (ctx->rc) {
           break;


### PR DESCRIPTION
d40820ddb6a760eb3373f119d27ebad5ff08b748 の変更で、v の初期化が意図せず消されているのではないかと思いましたがいかがでしょうか？
JNI として組み込んだプログラムで、grn_table_select() が "col resolve error" というエラーメッセージとともに失敗することがあり、 d40820ddb6a760eb3373f119d27ebad5ff08b748 以前に戻すことで現象が収まります。
検証環境では、grn_table_select_sequential() を抜ける時点での v の domain メンバの値に違いが出ていました。
（かたや 5757 行目は消し忘れ？）