### PR TITLE
expression_tree: add IndexColumn

### DIFF
--- a/lib/mrb/scripts/expression_tree.rb
+++ b/lib/mrb/scripts/expression_tree.rb
@@ -1,6 +1,7 @@
 require "expression_tree/constant"
 require "expression_tree/binary_operation"
 require "expression_tree/function_call"
+require "expression_tree/index_column"
 require "expression_tree/logical_operation"
 require "expression_tree/procedure"
 require "expression_tree/variable"

--- a/lib/mrb/scripts/expression_tree/index_column.rb
+++ b/lib/mrb/scripts/expression_tree/index_column.rb
@@ -1,0 +1,14 @@
+module Groonga
+  module ExpressionTree
+    class IndexColumn
+      attr_reader :index_column
+      def initialize(index_column)
+        @index_column = index_column
+      end
+
+      def build(expression)
+        expression.append_object(@index_column, Operator::PUSH, 1)
+      end
+    end
+  end
+end

--- a/lib/mrb/scripts/expression_tree/sources.am
+++ b/lib/mrb/scripts/expression_tree/sources.am
@@ -2,6 +2,7 @@ RUBY_SCRIPT_FILES =				\
 	binary_operation.rb			\
 	constant.rb				\
 	function_call.rb			\
+	index_column.rb				\
 	logical_operation.rb			\
 	procedure.rb				\
 	variable.rb

--- a/lib/mrb/scripts/expression_tree_builder.rb
+++ b/lib/mrb/scripts/expression_tree_builder.rb
@@ -72,6 +72,8 @@ module Groonga
         when Operator::PUSH
           if code.value.is_a?(Procedure)
             node = ExpressionTree::Procedure.new(code.value)
+          elsif code.value.is_a?(IndexColumn)
+            node = ExpressionTree::IndexColumn.new(code.value)
           else
             node = ExpressionTree::Constant.new(code.value.value)
           end

--- a/test/mruby/suite/expression_rewriter/test_between.rb
+++ b/test/mruby/suite/expression_rewriter/test_between.rb
@@ -9,6 +9,14 @@ class TestBetween < ExpressionRewriterTestCase
 
       schema.create_table("Logs") do |table|
         table.time("timestamp")
+        table.text("message")
+      end
+
+      schema.create_table("Terms",
+                          :type => :patricia_trie,
+                          :default_tokenizer => "TokenBigram",
+                          :normalizer => "NormalizerAuto") do |table|
+        table.index("Logs", "message")
       end
     end
 
@@ -100,6 +108,31 @@ class TestBetween < ExpressionRewriterTestCase
   args[4]:    <"2015-11-00 00:00:00">
   args[5]:    <"exclude">
   expr:       <7..13>
+    DUMP
+  end
+
+  def test_with_index_column
+    code =
+      "Terms.Logs_message @ 'Groonga' && " +
+      "timestamp >= '2015-10-01 00:00:00' && " +
+      "timestamp <  '2015-11-00 00:00:00'"
+    assert_equal(<<-DUMP, dump_rewritten_plan(code))
+[0]
+  op:         <match>
+  logical_op: <or>
+  index:      <[#<column:index Terms.Logs_message range:Logs sources:[Logs.message] flags:POSITION>]>
+  query:      <\"Groonga\">
+  expr:       <0..2>
+[1]
+  op:         <call>
+  logical_op: <and>
+  args[0]:    <#<proc:function between arguments:[]>>
+  args[1]:    <#<column:fix_size Logs.timestamp range:Time type:scalar compress:none>>
+  args[2]:    <\"2015-10-01 00:00:00\">
+  args[3]:    <\"include\">
+  args[4]:    <\"2015-11-00 00:00:00\">
+  args[5]:    <\"exclude\">
+  expr:       <3..9>
     DUMP
   end
 end


### PR DESCRIPTION
IndexColumnがある場合でもExpressionTreeBuilderを落ちないようにしたいです。

とりあえず私の当面の目的は、私の使う予定のある構文でExpressionTreeBuilderが落ちないようにして、検索ワードに応じて使うインデックスをすげ替えるexpression-rewriterプラグインが動くようにしたいです。

https://github.com/naoa/groonga-index-selector

あと、AccesorとHashTableが指定された場合に落ちることがわかっています。