### PR TITLE
db: validate key_type existance when table type is not TABLE_NO_KEY

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1011,6 +1011,14 @@ grn_table_create_validate(grn_ctx *ctx, const char *name, unsigned int name_size
     return ctx->rc;
   }
 
+  if (!key_type && table_type != GRN_OBJ_TABLE_NO_KEY) {
+    ERR(GRN_INVALID_ARGUMENT,
+        "[table][create] "
+        "key is necessary for %s table: <%.*s>",
+        table_type_name, name_size, name);
+    return ctx->rc;
+  }
+
   if ((flags & GRN_OBJ_KEY_WITH_SIS) &&
       table_type != GRN_OBJ_TABLE_PAT_KEY) {
     ERR(GRN_INVALID_ARGUMENT,


### PR DESCRIPTION
``grn_table_create``で、```TABLE_NO_KEY```以外が指定された場合、keyの存在チェックをしたほうがいいと思ったのですがいかがでしょうか？

以下のコマンドが正常に通って、なんで検索できないか気づくのに少し時間がかかりました。

```
table_create Lexicon TABLE_PAT_KEY --default_tokenizer TokenDelimit
[[0,0.0,0.0],true]
table_create Entries TABLE_NO_KEY
[[0,0.0,0.0],true]
column_create Entries title COLUMN_SCALAR ShortText
[[0,0.0,0.0],true]
column_create Lexicon title COLUMN_INDEX|WITH_POSITION Entries title
[[0,0.0,0.0],true]
load --table Entries
[
{"title": "Groonga and MySQL"}
]
[[0,0.0,0.0],1]
select Entries   --filter 'title @ "MySQL"'
[[0,0.0,0.0],[[[0],[["_id","UInt32"],["title","ShortText"]]]]]
```