### PR TITLE
fuzzy_search: fix a bug that have same distance

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1279,7 +1279,7 @@ fuzzy_heap_push(grn_ctx *ctx, fuzzy_heap *h, grn_id id, uint16_t distance)
   h->nodes[h->n_entries] = node;
   n = h->n_entries++;
   while (n) {
-    n2 = (n - 1) >> 1;
+    n2 = n >> 1;
     if (h->nodes[n2].distance <= h->nodes[n].distance) { break; }
     node2 = h->nodes[n];
     h->nodes[n] = h->nodes[n2];

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -142,7 +142,7 @@ score_heap_push(grn_ctx *ctx, score_heap *h, grn_id id, uint32_t score)
   h->nodes[h->n_entries] = node;
   n = h->n_entries++;
   while (n) {
-    n2 = (n - 1) >> 1;
+    n2 = n >> 1;
     if (h->nodes[n2].score <= h->nodes[n].score) { break; }
     node2 = h->nodes[n];
     h->nodes[n] = h->nodes[n2];

--- a/test/command/suite/select/function/fuzzy_search/sequential/same_score.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/same_score.expected
@@ -1,0 +1,49 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Tom"},
+{"name": "Ken"}
+]
+[[0,0.0,0.0],4]
+select Users --filter 'fuzzy_search(name, "Tom")'   --output_columns 'name, _score'   --match_escalation_threshold -1
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "name",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Tom",
+        2
+      ],
+      [
+        "Tom",
+        2
+      ],
+      [
+        "Tomy",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/fuzzy_search/sequential/same_score.test
+++ b/test/command/suite/select/function/fuzzy_search/sequential/same_score.test
@@ -1,0 +1,14 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Tom"},
+{"name": "Ken"}
+]
+
+select Users --filter 'fuzzy_search(name, "Tom")' \
+  --output_columns 'name, _score' \
+  --match_escalation_threshold -1


### PR DESCRIPTION
すいません。fuzzy_search用にdistance順に出力するために実装した二分ヒープにバグがありました。
２分木にすでに同じ値がある場合、最後の位置に取り残されてしまっていました。