### PR TITLE
Use `gzcat` instead of `zcat` if exists.

### DIFF
--- a/examples/dictionary/edict/edict-import.sh
+++ b/examples/dictionary/edict/edict-import.sh
@@ -16,6 +16,12 @@ else
     edict_gz=$2
 fi
 
-if zcat $edict_gz | ${base_dir}/edict2grn.rb | groonga $1 > /dev/null; then
+if type gzcat > /dev/null 2>&1; then
+    zcat='gzcat'
+else
+    zcat='zcat'
+fi
+
+if $zcat $edict_gz | ${base_dir}/edict2grn.rb | groonga $1 > /dev/null; then
   echo "edict data loaded."
 fi


### PR DESCRIPTION
OSXの`zcat`コマンドではシェルスクリプト実行時にエラーとなるため、`gzcat`コマンドで代用できるようにしたい。