### PR TITLE
select slices: support target sorted table

### DIFF
--- a/test/command/suite/select/slices/target.expected
+++ b/test/command/suite/select/slices/target.expected
@@ -1,0 +1,99 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos title COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Memos date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+column_create Tags memos_tag COLUMN_INDEX Memos tag
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"title": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"title": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"title": "Groonga sticker!", "date": "2016-05-19 12:00:02", "tag": "Groonga"},
+{"title": "Rroonga is fast!", "date": "2016-05-19 12:00:03", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --filter 'date < "2016-05-19 12:00:02"'   --columns[day].stage output   --columns[day].type Time   --columns[day].value 'time_classify_day(date)'   --slices[groonga].target output   --slices[groonga].filter 'tag @ "Groonga"'   --slices[groonga].sort_keys 'date'   --slices[groonga].output_columns 'title, date, day'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "day",
+          "Time"
+        ],
+        [
+          "date",
+          "Time"
+        ],
+        [
+          "tag",
+          "Tags"
+        ],
+        [
+          "title",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        1463583600.0,
+        1463626800.0,
+        "Groonga",
+        "Groonga is fast!"
+      ],
+      [
+        2,
+        1463583600.0,
+        1463626801.0,
+        "Mroonga",
+        "Mroonga is fast!"
+      ]
+    ],
+    {
+      "groonga": [
+        [
+          1
+        ],
+        [
+          [
+            "title",
+            "ShortText"
+          ],
+          [
+            "date",
+            "Time"
+          ],
+          [
+            "day",
+            "Time"
+          ]
+        ],
+        [
+          "Groonga is fast!",
+          1463626800.0,
+          1463583600.0
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/slices/target.test
+++ b/test/command/suite/select/slices/target.test
@@ -1,0 +1,28 @@
+plugin_register functions/time
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_NO_KEY
+column_create Memos title COLUMN_SCALAR ShortText
+column_create Memos date COLUMN_SCALAR Time
+column_create Memos tag COLUMN_SCALAR Tags
+
+column_create Tags memos_tag COLUMN_INDEX Memos tag
+
+load --table Memos
+[
+{"title": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"title": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"title": "Groonga sticker!", "date": "2016-05-19 12:00:02", "tag": "Groonga"},
+{"title": "Rroonga is fast!", "date": "2016-05-19 12:00:03", "tag": "Rroonga"}
+]
+
+select Memos \
+  --filter 'date < "2016-05-19 12:00:02"' \
+  --columns[day].stage output \
+  --columns[day].type Time \
+  --columns[day].value 'time_classify_day(date)' \
+  --slices[groonga].target output \
+  --slices[groonga].filter 'tag @ "Groonga"' \
+  --slices[groonga].sort_keys 'date' \
+  --slices[groonga].output_columns 'title, date, day'


### PR DESCRIPTION
selectのslicesでfilter結果のresultテーブルだけでなくて、
sortedテーブルを指定できるといいなと思っています。

私の考えている１つのユースケースは、filterで誤差が含まれるが
高速な類似演算を行った後、outputステージで低速だが厳密な
類似演算を行って、それをソートしたいと考えています。