### PR TITLE
Revert "db: validate key_type existance when table type is not TABLE_NO_KEY"

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1011,14 +1011,6 @@ grn_table_create_validate(grn_ctx *ctx, const char *name, unsigned int name_size
     return ctx->rc;
   }
 
-  if (!key_type && table_type != GRN_OBJ_TABLE_NO_KEY) {
-    ERR(GRN_INVALID_ARGUMENT,
-        "[table][create] "
-        "key is necessary for %s table: <%.*s>",
-        table_type_name, name_size, name);
-    return ctx->rc;
-  }
-
   if ((flags & GRN_OBJ_KEY_WITH_SIS) &&
       table_type != GRN_OBJ_TABLE_PAT_KEY) {
     ERR(GRN_INVALID_ARGUMENT,


### PR DESCRIPTION
Reverts groonga/groonga#570

It also disables creating a result set table. It's not acceptable.