### PR TITLE
plugin vector: add vector_slice()

### DIFF
--- a/test/command/suite/select/function/vector/vector_slice/from.expected
+++ b/test/command/suite/select/function/vector/vector_slice/from.expected
@@ -1,0 +1,63 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 1, 1)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Ruby"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/from.test
+++ b/test/command/suite/select/function/vector/vector_slice/from.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 1, 1)'

--- a/test/command/suite/select/function/vector/vector_slice/negative_from.expected
+++ b/test/command/suite/select/function/vector/vector_slice/negative_from.expected
@@ -1,0 +1,63 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, -1, 1)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Ruby"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/negative_from.test
+++ b/test/command/suite/select/function/vector/vector_slice/negative_from.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, -1, 1)'

--- a/test/command/suite/select/function/vector/vector_slice/negative_length.expected
+++ b/test/command/suite/select/function/vector/vector_slice/negative_length.expected
@@ -1,0 +1,64 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 0, -1)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Groonga",
+          "Ruby"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/negative_length.test
+++ b/test/command/suite/select/function/vector/vector_slice/negative_length.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 0, -1)'

--- a/test/command/suite/select/function/vector/vector_slice/no_length.expected
+++ b/test/command/suite/select/function/vector/vector_slice/no_length.expected
@@ -1,0 +1,63 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 0)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/no_length.test
+++ b/test/command/suite/select/function/vector/vector_slice/no_length.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 0)'

--- a/test/command/suite/select/function/vector/vector_slice/over_length.expected
+++ b/test/command/suite/select/function/vector/vector_slice/over_length.expected
@@ -1,0 +1,64 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 0, 2)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Groonga",
+          "Ruby"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/over_length.test
+++ b/test/command/suite/select/function/vector/vector_slice/over_length.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 0, 2)'

--- a/test/command/suite/select/function/vector/vector_slice/reference_vector.expected
+++ b/test/command/suite/select/function/vector/vector_slice/reference_vector.expected
@@ -1,0 +1,65 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 0, 1)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "Tags"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/reference_vector.test
+++ b/test/command/suite/select/function/vector/vector_slice/reference_vector.test
@@ -1,0 +1,16 @@
+plugin_register functions/vector
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR Tags
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 0, 1)'

--- a/test/command/suite/select/function/vector/vector_slice/vector.expected
+++ b/test/command/suite/select/function/vector/vector_slice/vector.expected
@@ -1,0 +1,63 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --output_columns 'tags, vector_slice(tags, 0, 1)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "ShortText"
+        ],
+        [
+          "vector_slice",
+          null
+        ]
+      ],
+      [
+        [
+          "Groonga"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+          "Groonga",
+          "Ruby"
+        ],
+        [
+          "Groonga"
+        ]
+      ],
+      [
+        [
+
+        ],
+        [
+
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/vector.test
+++ b/test/command/suite/select/function/vector/vector_slice/vector.test
@@ -1,0 +1,14 @@
+plugin_register functions/vector
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR ShortText
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": ["Groonga"]},
+{"_key": "Rroonga", "tags": ["Groonga", "Ruby"]},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --output_columns 'tags, vector_slice(tags, 0, 1)'

--- a/test/command/suite/select/function/vector/vector_slice/weight_reference_vector.expected
+++ b/test/command/suite/select/function/vector/vector_slice/weight_reference_vector.expected
@@ -1,0 +1,63 @@
+plugin_register functions/vector
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tags COLUMN_VECTOR|WITH_WEIGHT Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga", "tags": {"Groonga": 100}},
+{"_key": "Rroonga", "tags": {"Groonga": 100, "Ruby": 50}},
+{"_key": "Nothing"}
+]
+[[0,0.0,0.0],3]
+select Memos   --columns[slice].stage output   --columns[slice].type Tags   --columns[slice].flags COLUMN_VECTOR|WITH_WEIGHT   --columns[slice].value 'vector_slice(tags, 0, 1)'   --output_columns 'tags, slice'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "tags",
+          "Tags"
+        ],
+        [
+          "slice",
+          "Tags"
+        ]
+      ],
+      [
+        {
+          "Groonga": 100
+        },
+        {
+          "Groonga": 100
+        }
+      ],
+      [
+        {
+          "Groonga": 100,
+          "Ruby": 50
+        },
+        {
+          "Groonga": 100
+        }
+      ],
+      [
+        {
+        },
+        {
+        }
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/vector/vector_slice/weight_reference_vector.test
+++ b/test/command/suite/select/function/vector/vector_slice/weight_reference_vector.test
@@ -1,0 +1,20 @@
+plugin_register functions/vector
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tags COLUMN_VECTOR|WITH_WEIGHT Tags
+
+load --table Memos
+[
+{"_key": "Groonga", "tags": {"Groonga": 100}},
+{"_key": "Rroonga", "tags": {"Groonga": 100, "Ruby": 50}},
+{"_key": "Nothing"}
+]
+
+select Memos \
+  --columns[slice].stage output \
+  --columns[slice].type Tags \
+  --columns[slice].flags COLUMN_VECTOR|WITH_WEIGHT \
+  --columns[slice].value 'vector_slice(tags, 0, 1)' \
+  --output_columns 'tags, slice'


### PR DESCRIPTION
ベクターから要素を抽出する関数が欲しいです。

具体的には、文書から抽出した特徴語を２００次元ほどの重み付きリファレンスベクターに入れているのですが、それをサジェストワードに使うために上位10個ほどを抽出する目的に使いたいです。

第二引数fromに負の値を指定して後ろ１個だけ指定などをし易そうだったので、第三引数はlength(要素数)にしました。

他の方が良いなどの意見があればお願いします。

## syntax
```
vector_slice(vector, from*[, length])
```
*fromは0 origin

## Other language's syntax

* PostgreSQL
ARRAY[start:end]
1 origin

* Ruby
array.slice(index)
array.slice(index, length)
array.slice(start..end)
0 origin

* Python
array[start:end]
0 origin

* Javascript
array.slice(start,end)
0 origin

* PHP
array_slice(array, offset, length)
0 origin

