### PR TITLE
fix a bug object literal expression codes is broken

### DIFF
--- a/lib/grn_ecmascript.lemon
+++ b/lib/grn_ecmascript.lemon
@@ -431,6 +431,7 @@ property_name_and_value ::= property_name COLON assignment_expression. {
       if (added) {
         GRN_OBJ_INIT(buf, value->header.type, 0, value->header.domain);
         GRN_TEXT_PUT(ctx, buf, GRN_TEXT_VALUE(value), GRN_TEXT_LEN(value));
+        grn_expr_dfi_pop(e);
         e->codes_curr -= 3;
       } else {
         ERR(GRN_INVALID_ARGUMENT,

--- a/test/command/suite/select/function/fuzzy_search/with_logical_operation.expected
+++ b/test/command/suite/select/function/fuzzy_search/with_logical_operation.expected
@@ -1,0 +1,49 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags tag COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Tomas"},
+{"name": "Pom"}
+]
+[[0,0.0,0.0],4]
+select Tags --filter '_key @^ "T" && fuzzy_search(_key, "To", {"max_distance": 2})'   --output_columns '_key, _score'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Tomy",
+        2
+      ],
+      [
+        "Tom",
+        3
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/fuzzy_search/with_logical_operation.test
+++ b/test/command/suite/select/function/fuzzy_search/with_logical_operation.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags tag COLUMN_INDEX Users name
+
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Tomas"},
+{"name": "Pom"}
+]
+
+select Tags --filter '_key @^ "T" && fuzzy_search(_key, "To", {"max_distance": 2})' \
+  --output_columns '_key, _score'


### PR DESCRIPTION
fix #584

オブジェクトリテラル形式のオプションを使うとgrn_expr_dfiがずれていて、複数の論理演算のときにうまくscan_infoを構築できていませんでしたので、修正しました。

なお、ubuntu16.04を入れてlemon 3.11を使ってみたのですが、grn_ecmascript.c が激しく書き換わってしまいました。

後で更新をお願いできますでしょうか。