### PR TITLE
mruby: support float bulk

### DIFF
--- a/lib/mrb/mrb_bulk.c
+++ b/lib/mrb/mrb_bulk.c
@@ -173,6 +173,13 @@ grn_mrb_value_from_bulk(mrb_state *mrb, grn_obj *bulk)
       }
     }
     break;
+  case GRN_DB_FLOAT :
+    {
+      double value;
+      value = GRN_FLOAT_VALUE(bulk);
+      mrb_value_ = mrb_float_value(mrb, value);
+    }
+    break;
   case GRN_DB_TIME :
     {
       int64_t value;


### PR DESCRIPTION
expression_rewriterにfloatを通すと以下のようにエラーになったのでfloatに対応したいです。

```
  [
    -22,
    1469353071.917372,
    0.001502752304077148,
    "unsupported bulk value type: <12>(Float)",
    [
      [
        "Groonga::ExpressionTreeBuilder.build",
        "/usr/lib64/groonga/scripts/ruby/expression_tree_builder.rb",
        83
      ]
    ]
  ]
```