### PR TITLE
pat_fuzzy: fix a bug that prefix_match_size option returns wrong node

### DIFF
--- a/test/command/suite/select/function/fuzzy_search/object_literal/prefix_length.expected
+++ b/test/command/suite/select/function/fuzzy_search/object_literal/prefix_length.expected
@@ -10,10 +10,15 @@ load --table Users
 [
 {"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Tomas"},
+{"name": "Pom"},
+{"name": "Pam"},
+{"name": "Tim"},
+{"name": "Tina"},
+{"name": "Tiga"}
 ]
-[[0,0.0,0.0],3]
-select Tags --filter 'fuzzy_search(_key, "To", {"max_distance": 5, "prefix_length": 1})'   --output_columns '_key, _score'   --match_escalation_threshold -1
+[[0,0.0,0.0],8]
+select Tags --filter 'fuzzy_search(_key, "Tom", {"prefix_length": 1})'   --output_columns '_key, _score'   --match_escalation_threshold -1
 [
   [
     0,
@@ -23,7 +28,7 @@ select Tags --filter 'fuzzy_search(_key, "To", {"max_distance": 5, "prefix_lengt
   [
     [
       [
-        2
+        3
       ],
       [
         [
@@ -37,11 +42,15 @@ select Tags --filter 'fuzzy_search(_key, "To", {"max_distance": 5, "prefix_lengt
       ],
       [
         "Tom",
-        5
+        2
+      ],
+      [
+        "Tim",
+        1
       ],
       [
         "Tomy",
-        4
+        1
       ]
     ]
   ]

--- a/test/command/suite/select/function/fuzzy_search/object_literal/prefix_length.test
+++ b/test/command/suite/select/function/fuzzy_search/object_literal/prefix_length.test
@@ -8,9 +8,14 @@ load --table Users
 [
 {"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Tomas"},
+{"name": "Pom"},
+{"name": "Pam"},
+{"name": "Tim"},
+{"name": "Tina"},
+{"name": "Tiga"}
 ]
 
-select Tags --filter 'fuzzy_search(_key, "To", {"max_distance": 5, "prefix_length": 1})' \
+select Tags --filter 'fuzzy_search(_key, "Tom", {"prefix_length": 1})' \
   --output_columns '_key, _score' \
   --match_escalation_threshold -1


### PR DESCRIPTION
``grn_pat_fuzzy_search``の``prefix_match_size``オプションにバグがありました。

prefixが一致しているノードまで進めるのにpat_cursorを使っていましたが、この場合、実キーのidまで進んでしまっていました。

たとえば、以下のgrn_patに対して``key:Tom``, ``prefix_match_size:1``だと``L:8{2,4,0}("Tiga")``まで進んでしまっていました。

1つ目の``R:6{1,5,0}``のところまで進めるように修正しました。

```
#<table:pat Tags key:ShortText value:(nil) size:8 columns:[tag] default_tokenizer:(nil) normalizer:(nil) keys:["Pam", "Pom", "Tiga", "Tim", "Tina", "Tom", "Tomas", "Tomy"] subrec:none nodes:{
4{0,5,0}
  L:5{1,4,0}
    L:5{1,4,0}("Pam")[01010000 01100001 01101101]
    R:4{0,5,0}("Pom")[01010000 01101111 01101101]
  R:6{1,5,0}
    L:8{2,4,0}
      L:8{2,4,0}("Tiga")[01010100 01101001 01100111 01100001]
      R:7{2,6,0}
        L:6{1,5,0}("Tim")[01010100 01101001 01101101]
        R:7{2,6,0}("Tina")[01010100 01101001 01101110 01100001]
    R:1{2,7,0}
      L:0{0,0,0}
      R:2{2,7,1}
        L:1{2,7,0}("Tom")[01010100 01101111 01101101]
        R:3{3,3,0}
          L:3{3,3,0}("Tomas")[01010100 01101111 01101101 01100001 01110011]
          R:2{2,7,1}("Tomy")[01010100 01101111 01101101 01111001]
```
