### PR TITLE
ii: resolve record id on grn_ii_select_sequential_search

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -7602,6 +7602,8 @@ grn_ii_select_sequential_search_body(grn_ctx *ctx,
         grn_obj *value;
         const char *normalized_value;
         unsigned int normalized_value_length;
+        grn_id *rid;
+        grn_hash_cursor_get_key(ctx, cursor, (void **)&rid);
 
         GRN_BULK_REWIND(&buffer);
         grn_obj_get_value(ctx, accessor, id, &buffer);
@@ -7622,7 +7624,7 @@ grn_ii_select_sequential_search_body(grn_ctx *ctx,
         if (position != ONIG_MISMATCH) {
           grn_rset_posinfo info;
           double score;
-          info.rid = id;
+          info.rid = *rid;
           info.sid = i + 1;
           info.pos = 0;
           score = get_weight(ctx, result, info.rid, info.sid, wvm, optarg);

--- a/test/command/suite/select/query/sequential_search/ii/short_text.expected
+++ b/test/command/suite/select/query/sequential_search/ii/short_text.expected
@@ -1,0 +1,56 @@
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"body": "Rroonga is fast!"},
+{"body": "Groonga is fast!"},
+{"body": "Mroonga is fast!"},
+{"body": "Groonga sticker!"},
+{"body": "Groonga is good!"}
+]
+[[0,0.0,0.0],5]
+column_create Terms memos_body COLUMN_INDEX Memos body
+[[0,0.0,0.0],true]
+select Memos --query '_id:>=3 body:@"Groonga"' --output_columns _id,_score,body
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_score",
+          "Int32"
+        ],
+        [
+          "body",
+          "ShortText"
+        ]
+      ],
+      [
+        4,
+        2,
+        "Groonga sticker!"
+      ],
+      [
+        5,
+        2,
+        "Groonga is good!"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/query/sequential_search/ii/short_text.test
+++ b/test/command/suite/select/query/sequential_search/ii/short_text.test
@@ -1,0 +1,19 @@
+#$GRN_II_SELECT_TOO_MANY_INDEX_MATCH_RATIO=0.7
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
+
+table_create Memos TABLE_NO_KEY
+column_create Memos body COLUMN_SCALAR ShortText
+
+load --table Memos
+[
+{"body": "Rroonga is fast!"},
+{"body": "Groonga is fast!"},
+{"body": "Mroonga is fast!"},
+{"body": "Groonga sticker!"},
+{"body": "Groonga is good!"}
+]
+
+column_create Terms memos_body COLUMN_INDEX Memos body
+
+select Memos --query '_id:>=3 body:@"Groonga"' --output_columns _id,_score,body


### PR DESCRIPTION
``ii_select``のシーケンシャルサーチで``res``に対するcursorのIDをそのままpostingのridに設定しているのですが、これはレコードテーブル側の``record_id``に解決すべきだと思います。