### PR TITLE
proc fuzzy_search: resolve record id on sequential search

### DIFF
--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -190,8 +190,17 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
     while ((id = grn_table_cursor_next(ctx, tc))) {
       unsigned int distance = 0;
       grn_obj *domain;
+      grn_id record_id;
+
+      if (op == GRN_OP_AND) {
+        grn_id *key;
+        grn_table_cursor_get_key(ctx, tc, (void **)&key);
+        record_id = *key;
+      } else {
+        record_id = id;
+      }
       GRN_BULK_REWIND(&value);
-      grn_obj_get_value(ctx, column, id, &value);
+      grn_obj_get_value(ctx, column, record_id, &value);
       domain = grn_ctx_at(ctx, ((&value))->header.domain);
       if ((&(value))->header.type == GRN_VECTOR) {
         n = grn_vector_size(ctx, &value);
@@ -207,7 +216,7 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
                                           (char *)vector_value,
                                           (char *)vector_value + length, flags);
             if (distance <= max_distance) {
-              score_heap_push(ctx, heap, id, distance);
+              score_heap_push(ctx, heap, record_id, distance);
               break;
             }
           }
@@ -228,7 +237,7 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
             distance = calc_edit_distance(ctx, sx, ex,
                                           key_name, key_name + key_length, flags);
             if (distance <= max_distance) {
-              score_heap_push(ctx, heap, id, distance);
+              score_heap_push(ctx, heap, record_id, distance);
               break;
             }
           }
@@ -246,7 +255,7 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
             distance = calc_edit_distance(ctx, sx, ex,
                                           key_name, key_name + key_length, flags);
             if (distance <= max_distance) {
-              score_heap_push(ctx, heap, id, distance);
+              score_heap_push(ctx, heap, record_id, distance);
             }
           }
         } else {
@@ -257,7 +266,7 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
                                           GRN_TEXT_VALUE(&value),
                                           GRN_BULK_CURR(&value), flags);
             if (distance <= max_distance) {
-              score_heap_push(ctx, heap, id, distance);
+              score_heap_push(ctx, heap, record_id, distance);
             }
           }
         }

--- a/test/command/suite/select/function/fuzzy_search/sequential/and.expected
+++ b/test/command/suite/select/function/fuzzy_search/sequential/and.expected
@@ -4,10 +4,10 @@ column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Ken"},
+{"name": "Tom"}
 ]
 [[0,0.0,0.0],3]
-select Users --filter 'name @^ "T" && fuzzy_search(name, "To")'   --output_columns 'name, _score'   --match_escalation_threshold -1
+select Users --filter '_id >= 2 && fuzzy_search(name, "To")'   --output_columns 'name, _score'   --match_escalation_threshold -1
 [[0,0.0,0.0],[[[1],[["name","ShortText"],["_score","Int32"]],["Tom",2]]]]

--- a/test/command/suite/select/function/fuzzy_search/sequential/and.test
+++ b/test/command/suite/select/function/fuzzy_search/sequential/and.test
@@ -3,11 +3,11 @@ column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"name": "Tom"},
 {"name": "Tomy"},
-{"name": "Ken"}
+{"name": "Ken"},
+{"name": "Tom"}
 ]
 
-select Users --filter 'name @^ "T" && fuzzy_search(name, "To")' \
+select Users --filter '_id >= 2 && fuzzy_search(name, "To")' \
   --output_columns 'name, _score' \
   --match_escalation_threshold -1


### PR DESCRIPTION
``fuzzy_search``関数のシーケンシャルサーチもridを解決すべきでした。