### PR TITLE
[WIP] fuzzy_search: use sequential search if enough filtered

### DIFF
--- a/lib/grn_proc.h
+++ b/lib/grn_proc.h
@@ -30,6 +30,7 @@ extern "C" {
 #define GRN_SELECT_INTERNAL_VAR_CONDITION     "$condition"
 
 void grn_proc_init_from_env(void);
+void grn_proc_fuzzy_search_init_from_env(void);
 
 GRN_VAR const char *grn_document_root;
 void grn_db_init_builtin_commands(grn_ctx *ctx);

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -73,6 +73,7 @@ grn_proc_init_from_env(void)
         atof(grn_in_values_too_many_index_match_ratio_env);
     }
   }
+  grn_proc_fuzzy_search_init_from_env();
 }
 
 /* bulk must be initialized grn_bulk or grn_msg */

--- a/lib/proc/proc_fuzzy_search.c
+++ b/lib/proc/proc_fuzzy_search.c
@@ -327,6 +327,7 @@ sequential_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *column, grn_obj *
 
 static grn_bool
 sequential_fuzzy_search_should_use(grn_ctx *ctx,
+                                   grn_obj *obj,
                                    grn_obj *index,
                                    grn_obj *table,
                                    grn_obj *res,
@@ -353,6 +354,10 @@ sequential_fuzzy_search_should_use(grn_ctx *ctx,
   }
 
   if (index->header.flags & GRN_OBJ_WITH_WEIGHT) {
+    return GRN_FALSE;
+  }
+
+  if (!grn_obj_is_reference_column(ctx, obj)) {
     return GRN_FALSE;
   }
 
@@ -468,7 +473,7 @@ selector_fuzzy_search(grn_ctx *ctx, grn_obj *table, grn_obj *index,
   }
 
   if (target) {
-    use_sequential_search = sequential_fuzzy_search_should_use(ctx, target,
+    use_sequential_search = sequential_fuzzy_search_should_use(ctx, obj, target,
                                                                table, res, op);
   } else {
     if (grn_obj_is_key_accessor(ctx, obj) &&

--- a/test/command/suite/select/function/fuzzy_search/index/enough_filtered_ratio.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/enough_filtered_ratio.expected
@@ -1,0 +1,17 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags tag COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Ken"}
+]
+[[0,0.0,0.0],3]
+select Users --filter 'name @^ "T" && fuzzy_search(name, "To")'   --output_columns 'name, _score'   --match_escalation_threshold -1
+[[0,0.0,0.0],[[[1],[["name","ShortText"],["_score","Int32"]],["Tom",2]]]]

--- a/test/command/suite/select/function/fuzzy_search/index/enough_filtered_ratio.test
+++ b/test/command/suite/select/function/fuzzy_search/index/enough_filtered_ratio.test
@@ -1,0 +1,18 @@
+#$GRN_FUZZY_SEARCH_ENOUGH_FILTERED_RATIO=0.7
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags tag COLUMN_INDEX Users name
+
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Ken"}
+]
+
+select Users --filter 'name @^ "T" && fuzzy_search(name, "To")' \
+  --output_columns 'name, _score' \
+  --match_escalation_threshold -1

--- a/test/command/suite/select/function/fuzzy_search/index/max_n_enough_filtered_records.expected
+++ b/test/command/suite/select/function/fuzzy_search/index/max_n_enough_filtered_records.expected
@@ -1,0 +1,17 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Tags tag COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Ken"}
+]
+[[0,0.0,0.0],3]
+select Users --filter 'name @^ "T" && fuzzy_search(name, "To")'   --output_columns 'name, _score'   --match_escalation_threshold -1
+[[0,0.0,0.0],[[[1],[["name","ShortText"],["_score","Int32"]],["Tom",2]]]]

--- a/test/command/suite/select/function/fuzzy_search/index/max_n_enough_filtered_records.test
+++ b/test/command/suite/select/function/fuzzy_search/index/max_n_enough_filtered_records.test
@@ -1,0 +1,19 @@
+#$GRN_FUZZY_SEARCH_ENOUGH_FILTERED_RATIO=0.7
+#$GRN_FUZZY_SEARCH_MAX_N_ENOUGH_FILTERED_RECORDS=1
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Tags TABLE_PAT_KEY ShortText
+column_create Tags tag COLUMN_INDEX Users name
+
+load --table Users
+[
+{"name": "Tom"},
+{"name": "Tomy"},
+{"name": "Ken"}
+]
+
+select Users --filter 'name @^ "T" && fuzzy_search(name, "To")' \
+  --output_columns 'name, _score' \
+  --match_escalation_threshold -1


### PR DESCRIPTION
``fuzzy_search()``関数ですでに十分に絞り込まれている場合にはシーケンシャルサーチを使えるようにしたいです。tokenはこの時点では揃わないので、``res``の件数を利用しています。

``GRN_FUZZY_SEARCH_ENOUGH_FILTERED_RATIO``
``GRN_FUZZY_SEARCH_MAX_N_ENOUGH_FILTERED_RECORDS``