### PR TITLE
doc contribution: Update Homebrew repository URL

### DIFF
--- a/doc/source/contribution/development/release.rst
+++ b/doc/source/contribution/development/release.rst
@@ -648,7 +648,7 @@ OS Xでのパッケージ管理方法として `Homebrew <http://brew.sh/>`_ が
 
 Groongaを簡単にインストールできるようにするために、Homebrewへpull requestを送ります。
 
-  https://github.com/mxcl/homebrew
+  https://github.com/Homebrew/homebrew-core
 
 すでにGroongaのFormulaは取り込まれているので、リリースのたびにFormulaの内容を更新する作業を実施します。
 


### PR DESCRIPTION
Because redirected `homebrew/legacy-homebrew` is the former repository
of Homebrew formulae.
This repository is not used anymore.
Now, that project uses `homebrew/homebrew-core` repository to manage
Formulae.