### PR TITLE
ii: improve performance on buffer_new's worst case

### DIFF
--- a/lib/grn_ii.h
+++ b/lib/grn_ii.h
@@ -39,6 +39,7 @@ struct _grn_ii {
                          /* This member is used for matching */
   uint32_t n_elements;   /* Number of elements in postings */
                          /* rid, [sid], tf, [weight] and [pos] */
+  grn_id next_buffer_candidate_tid;
   struct grn_ii_header *header;
 };
 

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -3961,9 +3961,62 @@ buffer_split(grn_ctx *ctx, grn_ii *ii, uint32_t seg, grn_hash *h)
 
 #define SCALE_FACTOR 2048
 #define MAX_NTERMS   8192
-#define SPLIT_COND  (b->header.nterms > 1024 ||\
-                     (b->header.nterms > 1 &&\
-                      b->header.chunk_size * 100 > ii->header->total_chunk_size))
+#define SPLIT_COND(b)\
+  ((b)->header.nterms > 1024 ||\
+   ((b)->header.nterms > 1 &&\
+    (b)->header.chunk_size * 100 > ii->header->total_chunk_size))
+
+inline static uint32_t
+buffer_open_by_tid(grn_ctx *ctx,
+                   grn_ii *ii,
+                   grn_id tid,
+                   int size,
+                   grn_hash *h,
+                   buffer **b,
+                   uint32_t *lseg)
+{
+  uint32_t pseg = NOT_ASSIGNED;
+  uint32_t *a;
+
+  a = array_at(ctx, ii, tid);
+  if (!a) {
+    return pseg;
+  }
+
+  for (;;) {
+    uint32_t pos = a[0];
+
+    if (!pos || (pos & 1)) { break; }
+    pseg = buffer_open(ctx, ii, pos, NULL, b);
+    if (pseg == NOT_ASSIGNED) { break; }
+    if ((*b)->header.buffer_free >= size + sizeof(buffer_term)) {
+      *lseg = LSEG(pos);
+      break;
+    }
+    buffer_close(ctx, ii, pseg);
+    if (SPLIT_COND(*b)) {
+      /* ((S_SEGMENT - sizeof(buffer_header) + ii->header->bmax -
+         (*b)->header.nterms * sizeof(buffer_term)) * 4 <
+         (*b)->header.chunk_size) */
+      GRN_LOG(ctx, GRN_LOG_DEBUG,
+              "nterms=%d chunk=%d total=%" GRN_FMT_INT64U,
+              (*b)->header.nterms,
+              (*b)->header.chunk_size,
+              ii->header->total_chunk_size >> 10);
+      if (buffer_split(ctx, ii, LSEG(pos), h)) { break; }
+    } else {
+      if (S_SEGMENT - sizeof(buffer_header)
+          - (*b)->header.nterms * sizeof(buffer_term)
+          < size + sizeof(buffer_term)) {
+        break;
+      }
+      if (buffer_flush(ctx, ii, LSEG(pos), h)) { break; }
+    }
+  }
+  array_unref(ii, tid);
+
+  return pseg;
+}
 
 inline static uint32_t
 buffer_new(grn_ctx *ctx, grn_ii *ii, int size, uint32_t *pos,
@@ -3977,7 +4030,7 @@ buffer_new(grn_ctx *ctx, grn_ii *ii, int size, uint32_t *pos,
   // const char *key = _grn_table_key(ctx, ii->lexicon, id, &key_size);
   int key_size = grn_table_get_key(ctx, ii->lexicon, id, key,
                                    GRN_TABLE_MAX_KEY_SIZE);
-  uint32_t *a, lseg = NOT_ASSIGNED, pseg = NOT_ASSIGNED;
+  uint32_t lseg = NOT_ASSIGNED, pseg = NOT_ASSIGNED;
   grn_table_cursor *tc = NULL;
   if (S_SEGMENT - sizeof(buffer_header) < size + sizeof(buffer_term)) {
     DEFINE_NAME(ii);
@@ -4005,40 +4058,17 @@ buffer_new(grn_ctx *ctx, grn_ii *ii, int size, uint32_t *pos,
     while (ctx->rc == GRN_SUCCESS &&
            lseg == NOT_ASSIGNED &&
            (tid = grn_table_cursor_next(ctx, tc))) {
-      if ((a = array_at(ctx, ii, tid))) {
-        for (;;) {
-          uint32_t pos = a[0];
-          if (!pos || (pos & 1)) { break; }
-          pseg = buffer_open(ctx, ii, pos, NULL, &b);
-          if (pseg == NOT_ASSIGNED) { break; }
-          if (b->header.buffer_free >= size + sizeof(buffer_term)) {
-            lseg = LSEG(pos);
-            break;
-          }
-          buffer_close(ctx, ii, pseg);
-          if (SPLIT_COND) {
-            /* ((S_SEGMENT - sizeof(buffer_header) + ii->header->bmax -
-               b->header.nterms * sizeof(buffer_term)) * 4 <
-               b->header.chunk_size) */
-            GRN_LOG(ctx, GRN_LOG_DEBUG,
-                    "nterms=%d chunk=%d total=%" GRN_FMT_INT64U,
-                    b->header.nterms,
-                    b->header.chunk_size,
-                    ii->header->total_chunk_size >> 10);
-            if (buffer_split(ctx, ii, LSEG(pos), h)) { break; }
-          } else {
-            if (S_SEGMENT - sizeof(buffer_header)
-                - b->header.nterms * sizeof(buffer_term)
-                < size + sizeof(buffer_term)) {
-              break;
-            }
-            if (buffer_flush(ctx, ii, LSEG(pos), h)) { break; }
-          }
-        }
-        array_unref(ii, tid);
-      }
+      pseg = buffer_open_by_tid(ctx, ii, tid, size, h, &b, &lseg);
     }
     grn_table_cursor_close(ctx, tc);
+  }
+  if (lseg == NOT_ASSIGNED && ii->next_buffer_candidate_tid != GRN_ID_NIL) {
+    pseg = buffer_open_by_tid(ctx, ii,
+                              ii->next_buffer_candidate_tid,
+                              size, h, &b, &lseg);
+    if (lseg == NOT_ASSIGNED) {
+      ii->next_buffer_candidate_tid = GRN_ID_NIL;
+    }
   }
   if (lseg == NOT_ASSIGNED) {
     if (buffer_segment_new(ctx, ii, &lseg) ||
@@ -4147,6 +4177,7 @@ _grn_ii_create(grn_ctx *ctx, grn_ii *ii, const char *path, grn_obj *lexicon, uin
   ii->lexicon = lexicon;
   ii->lflags = lflags;
   ii->encoding = encoding;
+  ii->next_buffer_candidate_tid = GRN_ID_NIL;
   ii->header = header;
   ii->n_elements = 2;
   if ((flags & GRN_OBJ_WITH_SECTION)) { ii->n_elements++; }
@@ -4271,6 +4302,7 @@ grn_ii_open(grn_ctx *ctx, const char *path, grn_obj *lexicon)
   ii->lexicon = lexicon;
   ii->lflags = lflags;
   ii->encoding = encoding;
+  ii->next_buffer_candidate_tid = GRN_ID_NIL;
   ii->header = header;
   ii->n_elements = 2;
   if ((header->flags & GRN_OBJ_WITH_SECTION)) { ii->n_elements++; }
@@ -4404,7 +4436,7 @@ grn_ii_update_one(grn_ctx *ctx, grn_ii *ii, grn_id tid, grn_ii_updspec *u, grn_h
           GRN_LOG(ctx, GRN_LOG_DEBUG, "flushing a[0]=%d seg=%d(%p) free=%d",
                   a[0], LSEG(a[0]), b, b->header.buffer_free);
           buffer_close(ctx, ii, pseg);
-          if (SPLIT_COND) {
+          if (SPLIT_COND(b)) {
             /*((S_SEGMENT - sizeof(buffer_header) + ii->header->bmax -
                b->header.nterms * sizeof(buffer_term)) * 4 <
                b->header.chunk_size)*/
@@ -4583,7 +4615,12 @@ grn_ii_update_one(grn_ctx *ctx, grn_ii *ii, grn_id tid, grn_ii_updspec *u, grn_h
   }
   buffer_put(ctx, ii, b, bt, br, bs, u, size);
   buffer_close(ctx, ii, pseg);
-  if (!a[0] || (a[0] & 1)) { a[0] = pos; }
+  if (!a[0] || (a[0] & 1)) {
+    a[0] = pos;
+    if (ii->next_buffer_candidate_tid == GRN_ID_NIL) {
+      ii->next_buffer_candidate_tid = tid;
+    }
+  }
 exit :
   array_unref(ii, tid);
   if (bs) { GRN_FREE(bs); }


### PR DESCRIPTION
See commit messages of 5b6129d76a2491e6199f420f90aa3d2ffde52a1a and dd679629787d760032fbb13c36fd614662ace1be about description of this case in English.

転置インデックスを更新するときに`buffer_new()`をすることがありますが、データの内容・更新順序によって、すごく遅く、かつ、インデックスサイズがすごく増えることがあります。

どのような内容・更新順序かというと次のようなケースです。

    table_create a TABLE_NO_KEY
    column_create a x COLUMN_SCALAR ShortText
    table_create b TABLE_PAT_KEY ShortText
    column_create b index COLUMN_INDEX a x

    load --table a
    [
    {"x": "00000000"},
    {"x": "00000001"},
    ...
    {"x": "00486036"},
    {"x": "00000000"},
    {"x": "00000001"},
    ...
    {"x": "00413962"}
    ]

Rubyスクリプトだと次のようになります。

```ruby
puts "table_create a TABLE_NO_KEY"
puts "column_create a x COLUMN_SCALAR ShortText"
puts "table_create b TABLE_PAT_KEY ShortText"
puts "column_create b index COLUMN_INDEX a x"

puts "load --table a"
puts "["
n = 900_000
n.times do |i|
  i %= 486_037
  puts "{\"x\": \"#{i.to_s.rjust(8, '0')}\"},"
end
puts "]"
```

`buffer_new()`の中で語彙表をカーソルで回して既存のbufferがないか探していますが、↑のケースだとカーソルを回しきっても既存のbufferが見つかりません。`00486036`のレコードが終わって2週目（2回目の`00000000`）に入ると、レコードが増えるごとにカーソルが返すレコード数が増えるので`buffer_new()`の時間がどんどん増えてインデックス更新が遅くなります。

また、既存のbufferが見つからないので毎回新しくbufferを作ります。このためインデックスサイズも大きくなります。

解決策として以下を提案します。

  * 既存のbufferが見つからなかった場合に過去に`grn_ii_update_one()`したときに新しく作ったbufferを使いまわせないかチェックする。
    * 既存のbufferが見つからないケースを減らす。これでインデックスサイズの増加を抑えられる。
  * カーソルで回すレコード数を制限する。
    * 既存のbufferを見つけられるケースが減ることがあるが、`buffer_new()`にかかる時間が一定以下に抑えられるので前述のケースでの速度劣化が抑えられる。
    * 既存のbufferを見つけられない場合は↑の使いまわせないかチェックでフォローするので影響は軽微なはず。

前者の実装は 5b6129d76a2491e6199f420f90aa3d2ffde52a1a です。

`grn_ii`に追加している`next_buffer_candidate_tid`が使いまわせないかチェック対象のbuffer（に紐付いている`tid`）です。

`buffer_open_by_tid()`は`buffer_open()`のコードの一部を抜き出しただけでロジックは変えていません。

`SPLIT_COND()`が変わっているのはbufferが`b`以外の変数にも入れられるようにです。

後者の実装は dd679629787d760032fbb13c36fd614662ace1be です。

`EXISTING_BUFFER_FIND_LIMIT`の`10000`はなんとなくで決めました。特に計測したわけではありません。

この変更を入れる前と入れた後では実行時間・サイズは以下のように変わります。データは前述のRubyスクリプトを実行した結果です。それを`groonga`コマンドで処理しました。

項目     | 変更なし                        | 変更あり
-------- | ------------------------------- | -------
実行時間 | 30分以上(*)                      | 約4分30秒
サイズ   | 約15GB（1GB * 15 + 4.5MB + 4KB） | 約51MB（22MB + 29MB）

(*) 30分を過ぎたくらいからエラー発生。50万件後半くらいから発生する。45分くらいたって65万件くらいしかロードできていない。

以下は生結果です。

変更なし：

```text
[[0,1482816822.219858,0.04200315475463867],true]
[[0,1482816822.261966,0.05740857124328613],true]
[[0,1482816822.319439,0.04283547401428223],true]
[[0,1482816822.362304,0.07676839828491211],true]
```

```text
# select a --limit 0
[[0,1482821246.286818,0.0002453327178955078],[[[649709],[["_id","UInt32"],["x","ShortText"]]]]]
```

```text
-rw-r----- 1 kou kou 4.0K Dec 27 14:33 db
-rw-r----- 1 kou kou  21M Dec 27 15:47 db.0000000
-rw-r----- 1 kou kou 8.1M Dec 27 15:47 db.0000100
-rw-r----- 1 kou kou  17M Dec 27 15:07 db.0000101
-rw-r----- 1 kou kou  13M Dec 27 15:47 db.0000102
-rw-r----- 1 kou kou 1.0G Dec 27 15:47 db.0000103
-rw-r----- 1 kou kou 1.0G Dec 27 14:38 db.0000103.001
-rw-r----- 1 kou kou 1.0G Dec 27 14:40 db.0000103.002
-rw-r----- 1 kou kou 1.0G Dec 27 14:42 db.0000103.003
-rw-r----- 1 kou kou 1.0G Dec 27 14:44 db.0000103.004
-rw-r----- 1 kou kou 1.0G Dec 27 14:46 db.0000103.005
-rw-r----- 1 kou kou 1.0G Dec 27 14:48 db.0000103.006
-rw-r----- 1 kou kou 1.0G Dec 27 14:51 db.0000103.007
-rw-r----- 1 kou kou 1.0G Dec 27 14:53 db.0000103.008
-rw-r----- 1 kou kou 1.0G Dec 27 14:55 db.0000103.009
-rw-r----- 1 kou kou 1.0G Dec 27 14:57 db.0000103.00A
-rw-r----- 1 kou kou 1.0G Dec 27 14:59 db.0000103.00B
-rw-r----- 1 kou kou 1.0G Dec 27 15:01 db.0000103.00C
-rw-r----- 1 kou kou 1.0G Dec 27 15:03 db.0000103.00D
-rw-r----- 1 kou kou 1.0G Dec 27 15:05 db.0000103.00E
-rw-r----- 1 kou kou 1.0G Dec 27 15:07 db.0000103.00F
-rw-r----- 1 kou kou 4.5M Dec 27 15:07 db.0000103.010
-rw-r----- 1 kou kou 4.0K Dec 27 14:33 db.0000103.c
-rw-r----- 1 kou kou 1.0M Dec 27 14:33 db.001
-rw-r----- 1 kou kou  13M Dec 27 14:33 db.conf
-rw-r--r-- 1 kou kou 177M Dec 27 15:48 log
-rw-r--r-- 1 kou kou  634 Dec 27 14:33 query.log
```

エラーログ：

```text
2016-12-27 15:07:09.642377|A| [ii][update][one] failed to create a buffer2: <b.index>: <65537>:<1>:<65537>: size:<16>
2016-12-27 15:07:09.691508|A| /tmp/local/lib/libgroonga.so.0(grn_ii_update_one+0x2229) [0x7fb0403ff47e]
2016-12-27 15:07:09.691530|A| /tmp/local/lib/libgroonga.so.0(grn_ii_column_update+0x2740) [0x7fb040408be2]
2016-12-27 15:07:09.691534|A| /tmp/local/lib/libgroonga.so.0(grn_obj_default_set_value_hook+0x2f9) [0x7fb040270a1e]
2016-12-27 15:07:09.691536|A| /tmp/local/lib/libgroonga.so.0(+0xfe4a2) [0x7fb0402964a2]
2016-12-27 15:07:09.691538|A| /tmp/local/lib/libgroonga.so.0(+0xfe979) [0x7fb040296979]
2016-12-27 15:07:09.691540|A| /tmp/local/lib/libgroonga.so.0(grn_obj_set_value+0x3ad) [0x7fb040299ce0]
2016-12-27 15:07:09.691543|A| /tmp/local/lib/libgroonga.so.0(+0x122519) [0x7fb0402ba519]
2016-12-27 15:07:09.691545|A| /tmp/local/lib/libgroonga.so.0(+0x122dad) [0x7fb0402badad]
2016-12-27 15:07:09.691547|A| /tmp/local/lib/libgroonga.so.0(grn_load_+0xc42) [0x7fb0402bdf66]
2016-12-27 15:07:09.691549|A| /tmp/local/lib/libgroonga.so.0(+0x402282) [0x7fb04059a282]
2016-12-27 15:07:09.691552|A| /tmp/local/lib/libgroonga.so.0(grn_proc_call+0x426) [0x7fb0402cf606]
2016-12-27 15:07:09.691554|A| /tmp/local/lib/libgroonga.so.0(grn_command_run+0xce) [0x7fb040253187]
2016-12-27 15:07:09.691556|A| /tmp/local/lib/libgroonga.so.0(grn_expr_exec+0x1a5) [0x7fb0402cfd22]
2016-12-27 15:07:09.691558|A| /tmp/local/lib/libgroonga.so.0(grn_ctx_send+0x4d0) [0x7fb04025c122]
2016-12-27 15:07:09.691560|A| /tmp/local/bin/groonga(+0x634b) [0x56001bf9334b]
2016-12-27 15:07:09.691563|A| /tmp/local/bin/groonga(+0x18008) [0x56001bfa5008]
2016-12-27 15:07:09.691581|e| [table][load] failed to set column value: [ii][update][one] failed to create a buffer2: <b.index>: <65537>:<1>:<65537>: size:<16>: key: <(NULL)>, column: <x>, value: <"00065536">
```

変更あり：

```text
[[0,1482814433.974035,0.04183840751647949],true]
[[0,1482814434.015956,0.05599784851074219],true]
[[0,1482814434.072021,0.04459285736083984],true]
[[0,1482814434.116677,0.08618617057800293],true]
[[0,1482814434.20292,272.1374449729919],900000]
```

```text
-rw-r----- 1 kou kou 4.0K Dec 27 13:58 db
-rw-r----- 1 kou kou  21M Dec 27 13:58 db.0000000
-rw-r----- 1 kou kou 8.1M Dec 27 13:58 db.0000100
-rw-r----- 1 kou kou  17M Dec 27 13:58 db.0000101
-rw-r----- 1 kou kou  13M Dec 27 13:58 db.0000102
-rw-r----- 1 kou kou  22M Dec 27 13:58 db.0000103
-rw-r----- 1 kou kou  29M Dec 27 13:58 db.0000103.c
-rw-r----- 1 kou kou 1.0M Dec 27 13:53 db.001
-rw-r----- 1 kou kou  13M Dec 27 13:53 db.conf
-rw-r--r-- 1 kou kou  13K Dec 27 13:58 log
-rw-r--r-- 1 kou kou  787 Dec 27 13:58 query.log
```
