### PR TITLE
Reset match_info->min when escalation

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -8281,23 +8281,50 @@ grn_ii_sel(grn_ctx *ctx, grn_ii *ii, const char *string, unsigned int string_len
     }
     GRN_LOG(ctx, GRN_LOG_INFO, "exact: %d", GRN_HASH_SIZE(s));
     if (op == GRN_OP_OR) {
+      grn_id min = GRN_ID_NIL;
       if ((int64_t)GRN_HASH_SIZE(s) <= ctx->impl->match_escalation_threshold) {
         arg.mode = GRN_OP_UNSPLIT;
+        if (arg.match_info) {
+          if (arg.match_info->flags & GRN_MATCH_INFO_GET_MIN_RECORD_ID) {
+            min = arg.match_info->min;
+            arg.match_info->min = GRN_ID_NIL;
+          }
+        }
         if (grn_ii_select(ctx, ii, string, string_len, s, op, &arg)) {
           GRN_LOG(ctx, GRN_LOG_ERROR,
                   "grn_ii_select on grn_ii_sel(2) failed !");
           return ctx->rc;
         }
         GRN_LOG(ctx, GRN_LOG_INFO, "unsplit: %d", GRN_HASH_SIZE(s));
+        if (arg.match_info) {
+          if (arg.match_info->flags & GRN_MATCH_INFO_GET_MIN_RECORD_ID) {
+            if (min > GRN_ID_NIL && min < arg.match_info->min) {
+              arg.match_info->min = min;
+            }
+          }
+        }
       }
       if ((int64_t)GRN_HASH_SIZE(s) <= ctx->impl->match_escalation_threshold) {
         arg.mode = GRN_OP_PARTIAL;
+        if (arg.match_info) {
+          if (arg.match_info->flags & GRN_MATCH_INFO_GET_MIN_RECORD_ID) {
+            min = arg.match_info->min;
+            arg.match_info->min = GRN_ID_NIL;
+          }
+        }
         if (grn_ii_select(ctx, ii, string, string_len, s, op, &arg)) {
           GRN_LOG(ctx, GRN_LOG_ERROR,
                   "grn_ii_select on grn_ii_sel(3) failed !");
           return ctx->rc;
         }
         GRN_LOG(ctx, GRN_LOG_INFO, "partial: %d", GRN_HASH_SIZE(s));
+        if (arg.match_info) {
+          if (arg.match_info->flags & GRN_MATCH_INFO_GET_MIN_RECORD_ID) {
+            if (min > GRN_ID_NIL && min < arg.match_info->min) {
+              arg.match_info->min = min;
+            }
+          }
+        }
       }
     }
     GRN_LOG(ctx, GRN_LOG_INFO, "hits=%d", GRN_HASH_SIZE(s));


### PR DESCRIPTION
escalationが実行されるときに最初のii_selectの結果のminが適用されていたので、escalation時はminを退避しておいてnilにし、escalation結果のminよりも小さい場合はそちらのminを適用するようにしました。
（match_escalation_thresholdが1以上の場合は１つ目のii_selectでminが設定されることがある）