### PR TITLE
Fix memory leak when truncate hash/pat has many token filters

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -2156,6 +2156,7 @@ grn_hash_truncate(grn_ctx *ctx, grn_hash *hash)
         rc = grn_io_remove(ctx, path);
       }
     }
+    GRN_OBJ_FIN(ctx, &(hash->token_filters));
   }
   if (!rc) {
     rc = grn_hash_init(ctx, hash, path, key_size, value_size, flags);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -709,6 +709,7 @@ grn_pat_truncate(grn_ctx *ctx, grn_pat *pat)
     pat->header->truncated = GRN_TRUE;
   }
   if ((rc = grn_io_close(ctx, pat->io))) { goto exit; }
+  grn_pvector_fin(ctx, &pat->token_filters);
   pat->io = NULL;
   if (path && (rc = grn_io_remove(ctx, path))) { goto exit; }
   if (!_grn_pat_create(ctx, pat, path, key_size, value_size, flags)) {


### PR DESCRIPTION
テーブルをtruncateするタイミングでtoken_filtersのポインタの解放漏れがあるようです。
以下で再現できます。
静的索引構築時にも``grn_table_truncate``が呼ばれるところがあって、静的索引構築でも再現します。

```bash
plugin_register token_filters/stop_word

table_create Memos TABLE_NO_KEY
column_create Memos content COLUMN_SCALAR ShortText

table_create Terms TABLE_HASH_KEY ShortText \
  --default_tokenizer TokenBigram \
  --normalizer NormalizerAuto \
  --token_filters TokenFilterStopWord,TokenFilterStopWord,TokenFilterStopWord,TokenFilterStopWord,TokenFilterStopWord
column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
column_create Terms is_stop_word COLUMN_SCALAR Bool

load --table Terms
[
{"_key": "and", "is_stop_word": true}
]

load --table Memos
[
{"content": "Hello"},
{"content": "Hello and Good-bye"},
{"content": "Good-bye"}
]

truncate Terms

select Memos --match_columns content --query "Hello and"
```