### PR TITLE
Fix a bug that couldn't search index correctly

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6663,6 +6663,7 @@ grn_table_select_index(grn_ctx *ctx, grn_obj *table, scan_info *si,
         int32_t *wp = &GRN_INT32_VALUE(&si->wv);
         grn_search_optarg optarg;
         grn_id previous_min = GRN_ID_NIL;
+        unsigned int previous_n_hits = grn_table_size(ctx, res);
         GRN_INT32_INIT(&wv, GRN_OBJ_VECTOR);
         if (si->op == GRN_OP_MATCH) {
           optarg.mode = GRN_OP_EXACT;
@@ -6735,6 +6736,12 @@ grn_table_select_index(grn_ctx *ctx, grn_obj *table, scan_info *si,
             if (previous_min < optarg.match_info.min && (*min == previous_min || optarg.match_info.min < *min)) {
               *min = optarg.match_info.min;
             }
+          }
+        }
+        if (min) {
+          if (!((si->logical_op == GRN_OP_AND) || 
+                (si->logical_op == GRN_OP_OR && previous_n_hits == 0))) {
+            *min = GRN_ID_NIL;
           }
         }
         GRN_OBJ_FIN(ctx, &wv);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6874,6 +6874,7 @@ grn_table_select(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
           grn_table_setoperation(ctx, res_, res, res_, si->logical_op);
           grn_obj_close(ctx, res);
           res = res_;
+          min = GRN_ID_NIL;
         } else {
           grn_bool processed = GRN_FALSE;
           if (si->flags & SCAN_PUSH) {
@@ -6885,6 +6886,7 @@ grn_table_select(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
             }
             GRN_PTR_PUT(ctx, &res_stack, res);
             res = res_;
+            min = GRN_ID_NIL;
           }
           if (si->logical_op != GRN_OP_AND) {
             min = GRN_ID_NIL;
@@ -6896,6 +6898,7 @@ grn_table_select(grn_ctx *ctx, grn_obj *table, grn_obj *expr,
             e->codes_curr = si->end - si->start + 1;
             grn_table_select_sequential(ctx, table, (grn_obj *)e, v,
                                         res, si->logical_op);
+            min = GRN_ID_NIL;
           }
         }
         GRN_QUERY_LOG(ctx, GRN_QUERY_LOG_SIZE,

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6733,7 +6733,8 @@ grn_table_select_index(grn_ctx *ctx, grn_obj *table, scan_info *si,
           }
           GRN_BULK_REWIND(&wv);
           if (min) {
-            if (previous_min < optarg.match_info.min && (*min == previous_min || optarg.match_info.min < *min)) {
+            if (previous_min < optarg.match_info.min &&
+                (*min == previous_min || optarg.match_info.min < *min)) {
               *min = optarg.match_info.min;
             }
           }


### PR DESCRIPTION
すいません

ANDの高速化のパッチ(#618)により一部のケースで絞り込みすぎのバグがありました。

わかっている１つのケースは以下の再現ケースのように、

１つめのORクエリの最小record_id < 2つめのORクエリの最小record_id 
(``today``min:1) < (``tommow``min:2)

の後にANDクエリが続くようなケースです。
この場合、3つめの``day``のANDクエリの``ii_select``では``min:2``が設定されて``id:2``しかヒットしないため、
それ以外のレコードは``ii_resolve_sel_and``で削除されてしまいます。

* 再現ケース
```
table_create Terms TABLE_HASH_KEY ShortText \
  --default_tokenizer TokenBigram \
  --normalizer NormalizerAuto

table_create Memos TABLE_NO_KEY
column_create Memos content COLUMN_SCALAR ShortText
column_create Terms index COLUMN_INDEX|WITH_POSITION Memos content

load --table Memos
[
{"content": "Today is good day."},
{"content": "Tomorrow will be good day."}
]

select Memos   --match_columns 'content'   --query 'today OR tomorrow day'
[
  [
    0,
    0.0,
    0.0
  ],
  [
    [
      [
        1
      ],
      [
        [
          "_id",
          "UInt32"
        ],
        [
          "content",
          "ShortText"
        ]
      ],
      [
        2,
        "Tomorrow will be good day."
      ]
    ]
  ]
]
```

きっちりとminが結果hashテーブル``res``の最小レコードIDのキーを示すようにできればいいの
ですが、そのためには、全ての検索ケースでminを設定するようにしないといけず、また、最初
から``res``にレコードが入っている状態で``grn_table_select``が``GRN_OP_OR``で呼ばれる
ケースもあるかもしれないので難しそうに感じました。

今のところ、ii_selectで取得したminを次のANDクエリに安全に引き継げるケースは
1. ``OP_AND``の場合
2. ``OP_OR``の場合であって、(検索前の)結果テーブル``res``のサイズが0

ぐらいと考えました。
そこで、その他のケースはすべて取得したminをすぐに``GRN_ID_NIL``するようにしています。

ここまで絞っても、効果のあるケースはそこそこあると考えています。
(検索クエリはだいたいOR AND AND...みたいな形になると思われる。)