### PR TITLE
Avoid access to non existence sub records for group

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -5575,6 +5575,17 @@ grn_obj_get_accessor_rset_value(grn_ctx *ctx, grn_obj *obj,
     (*rp)->obj = obj;
 
     switch (action) {
+#define CHECK_GROUP_CALC_FLAG(flag) do {   \
+      if (GRN_TABLE_IS_GROUPED(obj)) {     \
+        grn_table_group_flags flags;       \
+        flags = DB_OBJ(obj)->flags.group;  \
+        if (flags & flag) {                \
+          succeeded = GRN_TRUE;            \
+          (*rp)->action = action;          \
+          goto exit;                       \
+        }                                  \
+      }                                    \
+    } while(GRN_FALSE)
     case GRN_ACCESSOR_GET_SCORE :
       if (DB_OBJ(obj)->header.flags & GRN_OBJ_WITH_SUBREC) {
         (*rp)->action = action;
@@ -5583,9 +5594,17 @@ grn_obj_get_accessor_rset_value(grn_ctx *ctx, grn_obj *obj,
       }
       break;
     case GRN_ACCESSOR_GET_MAX :
+      CHECK_GROUP_CALC_FLAG(GRN_TABLE_GROUP_CALC_MAX);
+      break;
     case GRN_ACCESSOR_GET_MIN :
+      CHECK_GROUP_CALC_FLAG(GRN_TABLE_GROUP_CALC_MIN);
+      break;
     case GRN_ACCESSOR_GET_SUM :
+      CHECK_GROUP_CALC_FLAG(GRN_TABLE_GROUP_CALC_SUM);
+      break;
     case GRN_ACCESSOR_GET_AVG :
+      CHECK_GROUP_CALC_FLAG(GRN_TABLE_GROUP_CALC_AVG);
+      break;
     case GRN_ACCESSOR_GET_NSUBRECS :
       if (GRN_TABLE_IS_GROUPED(obj)) {
         (*rp)->action = action;
@@ -5614,6 +5633,7 @@ grn_obj_get_accessor_rset_value(grn_ctx *ctx, grn_obj *obj,
     if (!(obj = grn_ctx_at(ctx, obj->header.domain))) {
       goto exit;
     }
+#undef CHECK_GROUP_CALC_FLAG
   }
 
 exit :


### PR DESCRIPTION
ドリルダウンでcalc_typesが設定されていないときに、_sum等でソートをしようとすると、
存在しない_sumのサブレコードにアクセスしようとしてクラッシュします。

以下は再現ケースです。
```bash
table_create Tags TABLE_PAT_KEY ShortText
[[0,0.0,0.0],true]
table_create Memos TABLE_HASH_KEY ShortText
[[0,0.0,0.0],true]
column_create Memos tag COLUMN_SCALAR Tags
[[0,0.0,0.0],true]
column_create Memos value COLUMN_SCALAR Int64
[[0,0.0,0.0],true]
load --table Memos
[
{"_key": "Groonga is fast!", "tag": "Groonga", "value": 10},
{"_key": "Mroonga is fast!", "tag": "Mroonga", "value": 20},
{"_key": "Groonga sticker!", "tag": "Groonga", "value": 40},
{"_key": "Rroonga is fast!", "tag": "Rroonga", "value": 80}
]
[[0,0.0,0.0],4]
select Memos   --filter ''  \
 --drilldowns[tag].keys tag  \
 --drilldowns[tag].output_columns _key \
 --drilldowns[tag].sort_keys -_sum
#|C| -- CRASHED!!! --
```
実際のケースではqueryもfilterもなしのときに_scoreの_sumを取ってソートしようとして
クラッシュしました。(_scoreがないから、calc_typesは指定しても無視される)