### PR TITLE
Support args for window function

### DIFF
--- a/include/groonga/window_function.h
+++ b/include/groonga/window_function.h
@@ -47,7 +47,7 @@ typedef struct _grn_window_definition {
 typedef grn_rc grn_window_function_func(grn_ctx *ctx,
                                         grn_obj *output_column,
                                         grn_window *window,
-                                        grn_obj *args,
+                                        grn_obj **args,
                                         int n_args);
 
 GRN_API grn_obj *grn_window_function_create(grn_ctx *ctx,

--- a/lib/window_function.c
+++ b/lib/window_function.c
@@ -285,7 +285,7 @@ grn_expr_call_window_function(grn_ctx *ctx,
   proc = (grn_proc *)(expr->codes[0].value);
 
   GRN_PTR_INIT(&args, GRN_OBJ_VECTOR, GRN_ID_NIL);
-  n = expr->codes_curr - 2;
+  n = expr->codes_curr - 1;
   for (i = 1; i < n; i++) {
     /* TODO: Check op. */
     GRN_PTR_PUT(ctx, &args, expr->codes[i].value);
@@ -293,7 +293,7 @@ grn_expr_call_window_function(grn_ctx *ctx,
   rc = proc->callbacks.window_function(ctx,
                                        output_column,
                                        window,
-                                       (grn_obj *)GRN_BULK_HEAD(&args),
+                                       (grn_obj **)GRN_BULK_HEAD(&args),
                                        GRN_BULK_VSIZE(&args) / sizeof(grn_obj *));
   GRN_OBJ_FIN(ctx, &args);
 

--- a/lib/window_functions.c
+++ b/lib/window_functions.c
@@ -23,7 +23,7 @@ static grn_rc
 window_function_record_number(grn_ctx *ctx,
                               grn_obj *output_column,
                               grn_window *window,
-                              grn_obj *args,
+                              grn_obj **args,
                               int n_args)
 {
   grn_id id;


### PR DESCRIPTION
window関数の引数がうまく渡っていないようで渡せるようにしたいです。

時系列を右肩上がりになるよう累積値で取得したくて、window関数を自作しています。
window関数があると全部出力しなくても昇順で累積した後に降順でソートして必要な直近のものだけだしたりできて便利です。

https://github.com/naoa/groonga-function-yawindow