### PR TITLE
Fix a crash bug by lock_clear against temporary database

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -11317,7 +11317,12 @@ grn_obj_clear_lock(grn_ctx *ctx, grn_obj *obj)
       }
     }
     grn_io_clear_lock(grn_obj_io(obj));
-    grn_obj_clear_lock(ctx, (grn_obj *)(((grn_db *)obj)->specs));
+    {
+      grn_db *db = (grn_db *)obj;
+      if (db->specs) {
+        grn_obj_clear_lock(ctx, (grn_obj *)(db->specs));
+      }
+    }
     break;
   case GRN_TABLE_NO_KEY :
     grn_array_queue_lock_clear(ctx, (grn_array *)obj);


### PR DESCRIPTION
    % groonga
    > lock_clear
    (crash)