### PR TITLE
grn_pat_scan: ignore blanks in target string.

### DIFF
--- a/test/command/suite/select/function/highlight_html/space_in_target.expected
+++ b/test/command/suite/select/function/highlight_html/space_in_target.expected
@@ -1,0 +1,37 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": "高速な Mroonga ストレージエンジン"}
+]
+[[0,0.0,0.0],1]
+select Entries --output_columns   --match_columns body --query 'Mroongaストレージ'   --output_columns 'highlight_html(body)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "highlight_html",
+          null
+        ]
+      ],
+      [
+        "高速な <span class=\"keyword\">Mroonga ストレージ</span>エンジン"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/highlight_html/space_in_target.test
+++ b/test/command/suite/select/function/highlight_html/space_in_target.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+
+load --table Entries
+[
+{"body": "高速な Mroonga ストレージエンジン"}
+]
+
+select Entries --output_columns \
+  --match_columns body --query 'Mroongaストレージ' \
+  --output_columns 'highlight_html(body)'


### PR DESCRIPTION
With this change, highlight family functions support highlighting text
that has some blanks. See the test in this change for example.