### PR TITLE
highlight_html: support similar search

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8754,10 +8754,20 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords)
                                                    GRN_TOKENIZE_GET,
                                                    token_flags);
               if (token_cursor) {
+                grn_obj *source_table;
+                uint32_t n_records_threshold;
+                source_table = grn_ctx_at(ctx, grn_obj_get_range(ctx, index));
+                n_records_threshold = grn_table_size(ctx, source_table) / 2;
                 while (token_cursor->status != GRN_TOKEN_CURSOR_DONE) {
                   grn_id token_id;
+                  uint32_t n_estimated_records;
                   token_id = grn_token_cursor_next(ctx, token_cursor);
                   if (token_id == GRN_ID_NIL) {
+                    continue;
+                  }
+                  n_estimated_records =
+                    grn_ii_estimate_size(ctx, (grn_ii *)index, token_id);
+                  if (n_estimated_records >= n_records_threshold) {
                     continue;
                   }
                   grn_vector_add_element(ctx,

--- a/lib/proc/proc_highlight.c
+++ b/lib/proc/proc_highlight.c
@@ -421,19 +421,26 @@ func_highlight_html_create_keywords_table(grn_ctx *ctx, grn_obj *expression)
   if (condition) {
     size_t i, n_keywords;
     grn_obj current_keywords;
-    GRN_PTR_INIT(&current_keywords, GRN_OBJ_VECTOR, GRN_ID_NIL);
+    GRN_TEXT_INIT(&current_keywords, GRN_OBJ_VECTOR);
     grn_expr_get_keywords(ctx, condition, &current_keywords);
 
-    n_keywords = GRN_BULK_VSIZE(&current_keywords) / sizeof(grn_obj *);
+    n_keywords = grn_vector_size(ctx, &current_keywords);
     for (i = 0; i < n_keywords; i++) {
-      grn_obj *keyword;
-      keyword = GRN_PTR_VALUE_AT(&current_keywords, i);
-      grn_table_add(ctx, keywords,
-                    GRN_TEXT_VALUE(keyword),
-                    GRN_TEXT_LEN(keyword),
+      const char *keyword;
+      unsigned int keyword_size;
+      keyword_size = grn_vector_get_element(ctx,
+                                            &current_keywords,
+                                            i,
+                                            &keyword,
+                                            NULL,
+                                            NULL);
+      grn_table_add(ctx,
+                    keywords,
+                    keyword,
+                    keyword_size,
                     NULL);
     }
-    grn_obj_unlink(ctx, &current_keywords);
+    GRN_OBJ_FIN(ctx, &current_keywords);
   }
 
   return keywords;

--- a/test/command/suite/select/function/highlight_html/similar_search.expected
+++ b/test/command/suite/select/function/highlight_html/similar_search.expected
@@ -1,0 +1,47 @@
+plugin_register token_filters/stop_word
+[[0,0.0,0.0],true]
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters TokenFilterStopWord
+[[0,0.0,0.0],true]
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+[[0,0.0,0.0],true]
+load --table Terms
+[
+{"_key": "is", "is_stop_word": true},
+{"_key": ".",  "is_stop_word": true}
+]
+[[0,0.0,0.0],2]
+load --table Entries
+[
+{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."}
+]
+[[0,0.0,0.0],1]
+select Entries   --filter 'body *S "Groonga is fast full text search engine. There are SQL interfaces by Mroonga and PGroonga and Ruby interface by Rroonga."'   --output_columns 'highlight_html(body)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "highlight_html",
+          null
+        ]
+      ],
+      [
+        "<span class=\"keyword\">Mroonga</span> is a ＭｙＳＱＬ storage <span class=\"keyword\">engine</span> based on <span class=\"keyword\">Groonga</span>. &lt;b&gt;<span class=\"keyword\">Rroonga</span>&lt;/b&gt; is a <span class=\"keyword\">Ruby</span> binding of <span class=\"keyword\">Groonga</span>."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/highlight_html/similar_search.expected
+++ b/test/command/suite/select/function/highlight_html/similar_search.expected
@@ -1,26 +1,21 @@
-plugin_register token_filters/stop_word
-[[0,0.0,0.0],true]
 table_create Entries TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Entries body COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters TokenFilterStopWord
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
 [[0,0.0,0.0],true]
 column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
 [[0,0.0,0.0],true]
 column_create Terms is_stop_word COLUMN_SCALAR Bool
 [[0,0.0,0.0],true]
-load --table Terms
-[
-{"_key": "is", "is_stop_word": true},
-{"_key": ".",  "is_stop_word": true}
-]
-[[0,0.0,0.0],2]
 load --table Entries
 [
-{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."}
+{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."},
+{"body": "It is a pen."},
+{"body": "I am a boy."},
+{"body": "This is good."}
 ]
-[[0,0.0,0.0],1]
+[[0,0.0,0.0],4]
 select Entries   --filter 'body *S "Groonga is fast full text search engine. There are SQL interfaces by Mroonga and PGroonga and Ruby interface by Rroonga."'   --output_columns 'highlight_html(body)'
 [
   [
@@ -40,7 +35,7 @@ select Entries   --filter 'body *S "Groonga is fast full text search engine. The
         ]
       ],
       [
-        "<span class=\"keyword\">Mroonga</span> is a ＭｙＳＱＬ storage <span class=\"keyword\">engine</span> based on <span class=\"keyword\">Groonga</span>. &lt;b&gt;<span class=\"keyword\">Rroonga</span>&lt;/b&gt; is a <span class=\"keyword\">Ruby</span> binding of <span class=\"keyword\">Groonga</span>."
+        "<span class=\"keyword\">Mroonga</span> is a ＭｙＳＱＬ storage <span class=\"keyword\">engine</span> based on Groonga. &lt;b&gt;<span class=\"keyword\">Rroonga</span>&lt;/b&gt; is a <span class=\"keyword\">Ruby</span> binding of Groonga."
       ]
     ]
   ]

--- a/test/command/suite/select/function/highlight_html/similar_search.test
+++ b/test/command/suite/select/function/highlight_html/similar_search.test
@@ -1,0 +1,26 @@
+plugin_register token_filters/stop_word
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto \
+  --token_filters TokenFilterStopWord
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+
+load --table Terms
+[
+{"_key": "is", "is_stop_word": true},
+{"_key": ".",  "is_stop_word": true}
+]
+
+load --table Entries
+[
+{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."}
+]
+
+select Entries \
+  --filter 'body *S "Groonga is fast full text search engine. There are SQL interfaces by Mroonga and PGroonga and Ruby interface by Rroonga."' \
+  --output_columns 'highlight_html(body)'

--- a/test/command/suite/select/function/highlight_html/similar_search.test
+++ b/test/command/suite/select/function/highlight_html/similar_search.test
@@ -1,24 +1,18 @@
-plugin_register token_filters/stop_word
-
 table_create Entries TABLE_NO_KEY
 column_create Entries body COLUMN_SCALAR ShortText
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --normalizer NormalizerAuto \
-  --token_filters TokenFilterStopWord
+  --normalizer NormalizerAuto
 column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
 column_create Terms is_stop_word COLUMN_SCALAR Bool
 
-load --table Terms
-[
-{"_key": "is", "is_stop_word": true},
-{"_key": ".",  "is_stop_word": true}
-]
-
 load --table Entries
 [
-{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."}
+{"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."},
+{"body": "It is a pen."},
+{"body": "I am a boy."},
+{"body": "This is good."}
 ]
 
 select Entries \


### PR DESCRIPTION
類似文書検索のときに検索文書をトークナイズしてハイライト対象のキーワードに追加してみました。

句読点とかストップワードをちゃんと設定すれば実用になりそうな印象があります、が、ストップワードなしだといろんなところがハイライトされてビミョウです。。。