### PR TITLE
test: add no hit dynamic columns with match_columns without error

### DIFF
--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/match_columns.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/match_columns.expected
@@ -1,0 +1,61 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+plugin_register functions/string
+[[0,0.0,0.0],true]
+table_create Memos_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos_20170315 content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Memos_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos_20170316 content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+load --table Memos_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "content": "Groonga is fast."},
+{"timestamp": "2017/03/15 01:00:00", "content": "Mroonga is fast and easy to use."}
+]
+[[0,0.0,0.0],2]
+load --table Memos_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "content": "PGroonga is fast and easy to use."},
+{"timestamp": "2017/03/16 11:00:00", "content": "Rroonga is fast and easy to use."}
+]
+[[0,0.0,0.0],2]
+logical_select Memos   --shard_key timestamp   --columns[caption].stage initial   --columns[caption].type ShortText   --columns[caption].flags COLUMN_SCALAR   --columns[caption].value "string_substring(content, 0, 8)"   --min "2017/04/01 00:00:00"   --query "Groonga"   --match_columns caption
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        0
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "caption",
+          "ShortText"
+        ],
+        [
+          "content",
+          "Text"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/match_columns.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/match_columns.test
@@ -1,0 +1,35 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+plugin_register functions/string
+
+table_create Memos_20170315 TABLE_NO_KEY
+column_create Memos_20170315 timestamp COLUMN_SCALAR Time
+column_create Memos_20170315 content COLUMN_SCALAR Text
+
+table_create Memos_20170316 TABLE_NO_KEY
+column_create Memos_20170316 timestamp COLUMN_SCALAR Time
+column_create Memos_20170316 content COLUMN_SCALAR Text
+
+load --table Memos_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "content": "Groonga is fast."},
+{"timestamp": "2017/03/15 01:00:00", "content": "Mroonga is fast and easy to use."}
+]
+
+load --table Memos_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "content": "PGroonga is fast and easy to use."},
+{"timestamp": "2017/03/16 11:00:00", "content": "Rroonga is fast and easy to use."}
+]
+
+logical_select Memos \
+  --shard_key timestamp \
+  --columns[caption].stage initial \
+  --columns[caption].type ShortText \
+  --columns[caption].flags COLUMN_SCALAR \
+  --columns[caption].value "string_substring(content, 0, 8)" \
+  --min "2017/04/01 00:00:00" \
+  --query "Groonga" \
+  --match_columns caption


### PR DESCRIPTION
This test case checks whether match_columns with empty records of
dynamic columns (price_with_tax) in initial stage doesn't cause an
error.