### PR TITLE
test: add no hit dynamic columns with output_columns without error

### DIFF
--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/output_columns.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/output_columns.expected
@@ -1,0 +1,16 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 01:00:00", "price":  900}
+]
+[[0,0.0,0.0],2]
+logical_select Logs   --shard_key timestamp   --columns[price_with_tax].stage initial   --columns[price_with_tax].type UInt32   --columns[price_with_tax].flags COLUMN_SCALAR   --columns[price_with_tax].value "price * 1.08"   --min "2017/04/01 00:00:00"   --output_columns price_with_tax
+[[0,0.0,0.0],[[[0],[["price_with_tax","UInt32"]]]]]

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/output_columns.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/output_columns.test
@@ -1,0 +1,22 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_20170315 TABLE_NO_KEY
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 01:00:00", "price":  900}
+]
+
+logical_select Logs \
+  --shard_key timestamp \
+  --columns[price_with_tax].stage initial \
+  --columns[price_with_tax].type UInt32 \
+  --columns[price_with_tax].flags COLUMN_SCALAR \
+  --columns[price_with_tax].value "price * 1.08" \
+  --min "2017/04/01 00:00:00" \
+  --output_columns price_with_tax


### PR DESCRIPTION
This test case checks whether output_columns with empty records of
dynamic columns (price_with_tax) in initial stage doesn't cause an
error.