### PR TITLE
test: add no hit dynamic columns with output_columns without error

### DIFF
--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/no_hit/output_columns.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/no_hit/output_columns.expected
@@ -1,0 +1,28 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Memos_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos_20170315 content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Memos_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos_20170316 content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+load --table Memos_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "content": "Groonga is fast."},
+{"timestamp": "2017/03/15 01:00:00", "content": "Mroonga is fast and easy to use."}
+]
+[[0,0.0,0.0],2]
+load --table Memos_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "content": "PGroonga is fast and easy to use."},
+{"timestamp": "2017/03/16 11:00:00", "content": "Rroonga is fast and easy to use."}
+]
+[[0,0.0,0.0],2]
+logical_select Memos   --shard_key timestamp   --query 'content:@slow'   --columns[highlighted_content].stage filtered   --columns[highlighted_content].type Text   --columns[highlighted_content].flags COLUMN_SCALAR   --columns[highlighted_content].value 'highlight_html(content)'   --output_columns highlighted_content
+[[0,0.0,0.0],[[[0],[["highlighted_content","Text"]]]]]

--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/no_hit/output_columns.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/no_hit/output_columns.test
@@ -1,0 +1,32 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Memos_20170315 TABLE_NO_KEY
+column_create Memos_20170315 timestamp COLUMN_SCALAR Time
+column_create Memos_20170315 content COLUMN_SCALAR Text
+
+table_create Memos_20170316 TABLE_NO_KEY
+column_create Memos_20170316 timestamp COLUMN_SCALAR Time
+column_create Memos_20170316 content COLUMN_SCALAR Text
+
+load --table Memos_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "content": "Groonga is fast."},
+{"timestamp": "2017/03/15 01:00:00", "content": "Mroonga is fast and easy to use."}
+]
+
+load --table Memos_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "content": "PGroonga is fast and easy to use."},
+{"timestamp": "2017/03/16 11:00:00", "content": "Rroonga is fast and easy to use."}
+]
+
+logical_select Memos \
+  --shard_key timestamp \
+  --query 'content:@slow' \
+  --columns[highlighted_content].stage filtered \
+  --columns[highlighted_content].type Text \
+  --columns[highlighted_content].flags COLUMN_SCALAR \
+  --columns[highlighted_content].value 'highlight_html(content)' \
+  --output_columns highlighted_content


### PR DESCRIPTION
This test case checks whether output_columns with empty records of
dynamic columns (highlighted_content) in filtered stage doesn't cause
an error.