### PR TITLE
test: add no hit dynamic columns with drilldown_filter without error

### DIFF
--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/drilldown_filter.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/drilldown_filter.expected
@@ -1,0 +1,65 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+plugin_register functions/number
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170316 price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 100},
+{"timestamp": "2017/03/15 01:00:00", "price": 200}
+]
+[[0,0.0,0.0],2]
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "price": 100},
+{"timestamp": "2017/03/16 11:00:00", "price": 200},
+{"timestamp": "2017/03/16 11:00:00", "price": 300}
+]
+[[0,0.0,0.0],3]
+logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id   --columns[price_with_tax].stage initial   --columns[price_with_tax].type UInt32   --columns[price_with_tax].flags COLUMN_SCALAR   --columns[price_with_tax].value 'price * 1.05'   --min "2017/04/01 00:00:00"   --drilldown price_with_tax   --drilldown_filter "_nsubrecs > 1"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        0
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ]
+      ]
+    ],
+    [
+      [
+        0
+      ],
+      [
+        [
+          "_key",
+          "UInt32"
+        ],
+        [
+          "_nsubrecs",
+          "Int32"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/drilldown_filter.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/no_hit/drilldown_filter.test
@@ -1,0 +1,39 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+plugin_register functions/number
+
+table_create Logs_20170315 TABLE_NO_KEY
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+
+table_create Logs_20170316 TABLE_NO_KEY
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+column_create Logs_20170316 price COLUMN_SCALAR UInt32
+
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 100},
+{"timestamp": "2017/03/15 01:00:00", "price": 200}
+]
+
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "price": 100},
+{"timestamp": "2017/03/16 11:00:00", "price": 200},
+{"timestamp": "2017/03/16 11:00:00", "price": 300}
+]
+
+logical_select Logs \
+  --shard_key timestamp \
+  --limit 0 \
+  --output_columns _id \
+  --columns[price_with_tax].stage initial \
+  --columns[price_with_tax].type UInt32 \
+  --columns[price_with_tax].flags COLUMN_SCALAR \
+  --columns[price_with_tax].value 'price * 1.05' \
+  --min "2017/04/01 00:00:00" \
+  --drilldown price_with_tax \
+  --drilldown_filter "_nsubrecs > 1"
+


### PR DESCRIPTION
This test case checks whether drilldown_filter with empty drilldown
records (price_with_tax) in initial stage doesn't cause an error.