### PR TITLE
test: add drilldowns[LABEL].table test case without cache

### DIFF
--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
@@ -1,0 +1,233 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_20150203 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150203 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150203 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150203 action COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Logs_20150204 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150204 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150204 action COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Logs_20150205 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150205 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150205 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150205 action COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Logs_20150203
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00",
+  "action":    "Start"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59",
+  "action":    "Shutdown"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_20150204
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00",
+  "action":    "Start"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00",
+  "action":    "Restart"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_20150205
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00",
+  "action":    "Shutdown"
+}
+]
+[[0,0.0,0.0],4]
+logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id   --drilldowns[restart].stage initial   --drilldowns[restart].keys 'action'   --drilldowns[restart].filter "_key @ 'Restart'"   --drilldowns[restart].output_columns _key   --drilldowns[start].stage initial   --drilldowns[start].keys 'action'   --drilldowns[start].filter "_key @ 'Start'"   --drilldowns[start].output_columns _key   --drilldowns[action].table restart   --drilldowns[action].keys _key 
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ]
+      ]
+    ],
+    {
+      "restart": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ]
+        ],
+        [
+          "Restart"
+        ]
+      ],
+      "start": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ]
+        ],
+        [
+          "Start"
+        ],
+        [
+          "Restart"
+        ]
+      ],
+      "action": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Restart",
+          1
+        ]
+      ]
+    }
+  ]
+]
+logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id   --drilldowns[restart].stage initial   --drilldowns[restart].keys 'action'   --drilldowns[restart].filter "_key @ 'Restart'"   --drilldowns[restart].output_columns _key   --drilldowns[start].stage initial   --drilldowns[start].keys 'action'   --drilldowns[start].filter "_key @ 'Start'"   --drilldowns[start].output_columns _key   --drilldowns[action].table start   --drilldowns[action].keys _key 
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ]
+      ]
+    ],
+    {
+      "restart": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ]
+        ],
+        [
+          "Restart"
+        ]
+      ],
+      "start": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ]
+        ],
+        [
+          "Start"
+        ],
+        [
+          "Restart"
+        ]
+      ],
+      "action": [
+        [
+          2
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Start",
+          1
+        ],
+        [
+          "Restart",
+          1
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
@@ -1,0 +1,105 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_20150203 TABLE_NO_KEY
+column_create Logs_20150203 timestamp COLUMN_SCALAR Time
+column_create Logs_20150203 memo COLUMN_SCALAR ShortText
+column_create Logs_20150203 action COLUMN_SCALAR ShortText
+
+table_create Logs_20150204 TABLE_NO_KEY
+column_create Logs_20150204 timestamp COLUMN_SCALAR Time
+column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+column_create Logs_20150204 action COLUMN_SCALAR ShortText
+
+table_create Logs_20150205 TABLE_NO_KEY
+column_create Logs_20150205 timestamp COLUMN_SCALAR Time
+column_create Logs_20150205 memo COLUMN_SCALAR ShortText
+column_create Logs_20150205 action COLUMN_SCALAR ShortText
+
+load --table Logs_20150203
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00",
+  "action":    "Start"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59",
+  "action":    "Shutdown"
+}
+]
+
+load --table Logs_20150204
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00",
+  "action":    "Start"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00",
+  "action":    "Restart"
+}
+]
+
+load --table Logs_20150205
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00",
+  "action":    "Restart"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00",
+  "action":    "Shutdown"
+}
+]
+
+logical_select Logs \
+  --shard_key timestamp \
+  --limit 0 \
+  --output_columns _id \
+  --drilldowns[restart].stage initial \
+  --drilldowns[restart].keys 'action' \
+  --drilldowns[restart].filter "_key @ 'Restart'" \
+  --drilldowns[restart].output_columns _key \
+  --drilldowns[start].stage initial \
+  --drilldowns[start].keys 'action' \
+  --drilldowns[start].filter "_key @ 'Start'" \
+  --drilldowns[start].output_columns _key \
+  --drilldowns[action].table restart \
+  --drilldowns[action].keys _key 
+
+logical_select Logs \
+  --shard_key timestamp \
+  --limit 0 \
+  --output_columns _id \
+  --drilldowns[restart].stage initial \
+  --drilldowns[restart].keys 'action' \
+  --drilldowns[restart].filter "_key @ 'Restart'" \
+  --drilldowns[restart].output_columns _key \
+  --drilldowns[start].stage initial \
+  --drilldowns[start].keys 'action' \
+  --drilldowns[start].filter "_key @ 'Start'" \
+  --drilldowns[start].output_columns _key \
+  --drilldowns[action].table start \
+  --drilldowns[action].keys _key 


### PR DESCRIPTION
When the value of --drilldowns[LABEL].table parameter is changed,
Groonga returns result without using cache.