### PR TITLE
WIP test: add drilldowns[LABEL].columns[NAME].stage test case without cache

### DIFF
--- a/test/command/suite/sharding/logical_select/cache/drilldowns/columns/stage.expected
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/columns/stage.expected
@@ -1,0 +1,162 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Items TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Items price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170315 items COLUMN_VECTOR Items
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170316 items COLUMN_VECTOR Items
+[[0,0.0,0.0],true]
+table_create Logs_20170317 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170317 items COLUMN_VECTOR Items
+[[0,0.0,0.0],true]
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+[[0,0.0,0.0],6]
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "items": ["Book", "Note", "Box", "Pen"]},
+{"timestamp": "2017/03/15 01:00:00", "items": ["Food", "Drink", "Pen"]}
+]
+[[0,0.0,0.0],2]
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "items": ["Pen", "Note", "Food", "Drink"]},
+{"timestamp": "2017/03/16 11:00:00", "items": ["Note", "Box"]}
+]
+[[0,0.0,0.0],2]
+load --table Logs_20170317
+[
+{"timestamp": "2017/03/17 20:00:00", "items": ["Food", "Book"]},
+{"timestamp": "2017/03/17 20:00:00", "items": ["Drink", "Note"]}
+]
+[[0,0.0,0.0],2]
+logical_select Logs   --shard_key timestamp   --limit 0   --drilldowns[item].keys items   --drilldowns[item].sort_keys price   --drilldowns[item].columns[content].stage initial   --drilldowns[item].columns[content].type ShortText   --drilldowns[item].columns[content].flags COLUMN_SCALAR   --drilldowns[item].columns[content].value 'highlight_html(_key)'   --match_columns items   --output_columns content   --query "Book"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+
+      ]
+    ],
+    {
+      "item": [
+        [
+          5
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Box",
+          1
+        ],
+        [
+          "Pen",
+          1
+        ],
+        [
+          "Food",
+          1
+        ],
+        [
+          "Book",
+          2
+        ],
+        [
+          "Note",
+          1
+        ]
+      ]
+    }
+  ]
+]
+logical_select Logs   --shard_key timestamp   --limit 0   --drilldowns[item].keys items   --drilldowns[item].sort_keys price   --drilldowns[item].columns[content].stage filtered   --drilldowns[item].columns[content].type ShortText   --drilldowns[item].columns[content].flags COLUMN_SCALAR   --drilldowns[item].columns[content].value 'highlight_html(_key)'   --match_columns items   --output_columns content   --query "Book"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+
+      ]
+    ],
+    {
+      "item": [
+        [
+          5
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Box",
+          1
+        ],
+        [
+          "Pen",
+          1
+        ],
+        [
+          "Food",
+          1
+        ],
+        [
+          "Book",
+          2
+        ],
+        [
+          "Note",
+          1
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/columns/stage.test
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/columns/stage.test
@@ -1,0 +1,72 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Items TABLE_HASH_KEY ShortText
+column_create Items price COLUMN_SCALAR UInt32
+
+table_create Logs_20170315 TABLE_NO_KEY
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+column_create Logs_20170315 items COLUMN_VECTOR Items
+
+table_create Logs_20170316 TABLE_NO_KEY
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+column_create Logs_20170316 items COLUMN_VECTOR Items
+
+table_create Logs_20170317 TABLE_NO_KEY
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time
+column_create Logs_20170317 items COLUMN_VECTOR Items
+
+load --table Items
+[
+{"_key": "Book",  "price": 1000},
+{"_key": "Note",  "price": 1000},
+{"_key": "Box",   "price": 500},
+{"_key": "Pen",   "price": 500},
+{"_key": "Food",  "price": 500},
+{"_key": "Drink", "price": 300}
+]
+
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "items": ["Book", "Note", "Box", "Pen"]},
+{"timestamp": "2017/03/15 01:00:00", "items": ["Food", "Drink", "Pen"]}
+]
+
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "items": ["Pen", "Note", "Food", "Drink"]},
+{"timestamp": "2017/03/16 11:00:00", "items": ["Note", "Box"]}
+]
+
+load --table Logs_20170317
+[
+{"timestamp": "2017/03/17 20:00:00", "items": ["Food", "Book"]},
+{"timestamp": "2017/03/17 20:00:00", "items": ["Drink", "Note"]}
+]
+
+logical_select Logs \
+  --shard_key timestamp \
+  --limit 0 \
+  --drilldowns[item].keys items \
+  --drilldowns[item].sort_keys price \
+  --drilldowns[item].columns[content].stage initial \
+  --drilldowns[item].columns[content].type ShortText \
+  --drilldowns[item].columns[content].flags COLUMN_SCALAR \
+  --drilldowns[item].columns[content].value 'highlight_html(_key)' \
+  --match_columns items \
+  --output_columns content \
+  --query "Book"
+
+logical_select Logs \
+  --shard_key timestamp \
+  --limit 0 \
+  --drilldowns[item].keys items \
+  --drilldowns[item].sort_keys price \
+  --drilldowns[item].columns[content].stage filtered \
+  --drilldowns[item].columns[content].type ShortText \
+  --drilldowns[item].columns[content].flags COLUMN_SCALAR \
+  --drilldowns[item].columns[content].value 'highlight_html(_key)' \
+  --match_columns items \
+  --output_columns content \
+  --query "Book"


### PR DESCRIPTION
When the value of --drilldowns[LABEL].columns[NAME].stage parameter is
changed, Groonga returns result without using cache.