### PR TITLE
Fix a bug that occur "argument out of range" when executing `logical_select` with min and max options.

### DIFF
--- a/plugins/sharding/logical_enumerator.rb
+++ b/plugins/sharding/logical_enumerator.rb
@@ -162,7 +162,7 @@ module Groonga
         end
 
         def least_over_time
-          Time.local(@year, @month, @day + 1)
+          Time.local(@year, @month, @day, 23, 59, 59, 999999)
         end
 
         def min_time
@@ -186,9 +186,10 @@ module Groonga
 
         def least_over_time
           if @max_day.nil?
-            Time.local(@year, @month + 1, 1)
+             @next_month = (1..11).include?(@month) ? @month+1 : 1
+             Time.local(@year, @next_month, 1)
           else
-            Time.local(@year, @month, @max_day + 1)
+            Time.local(@year, @month, @max_day, 23, 59, 59, 999999)
           end
         end
 

--- a/test/command/suite/sharding/logical_select/no_condition/max_exclude.expected
+++ b/test/command/suite/sharding/logical_select/no_condition/max_exclude.expected
@@ -30,6 +30,16 @@ table_create Times_20150205 TABLE_PAT_KEY Time
 [[0,0.0,0.0],true]
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 [[0,0.0,0.0],true]
+table_create Logs_20150131 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150131 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150131 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_20150131 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_20150131 timestamp_index COLUMN_INDEX Logs_20150131 timestamp
+[[0,0.0,0.0],true]
 load --table Logs_20150203
 [
 {
@@ -78,6 +88,18 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
+load --table Logs_20150131
+[
+{
+  "timestamp": "2015-01-31 12:49:00",
+  "memo":      "2015-01-31 12:49:00"
+},
+{
+  "timestamp": "2015-01-31 23:59:59",
+  "memo":      "2015-01-31 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
 logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "exclude"
 [
   [
@@ -88,7 +110,7 @@ logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "excl
   [
     [
       [
-        2
+        4
       ],
       [
         [
@@ -103,6 +125,16 @@ logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "excl
           "timestamp",
           "Time"
         ]
+      ],
+      [
+        1,
+        "2015-01-31 12:49:00",
+        1422676140.0
+      ],
+      [
+        2,
+        "2015-01-31 23:59:59",
+        1422716399.0
       ],
       [
         1,

--- a/test/command/suite/sharding/logical_select/no_condition/max_exclude.test
+++ b/test/command/suite/sharding/logical_select/no_condition/max_exclude.test
@@ -20,6 +20,12 @@ column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 table_create Times_20150205 TABLE_PAT_KEY Time
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 
+table_create Logs_20150131 TABLE_NO_KEY
+column_create Logs_20150131 timestamp COLUMN_SCALAR Time
+column_create Logs_20150131 memo COLUMN_SCALAR ShortText
+table_create Times_20150131 TABLE_PAT_KEY Time
+column_create Times_20150131 timestamp_index COLUMN_INDEX Logs_20150131 timestamp
+
 load --table Logs_20150203
 [
 {
@@ -65,6 +71,18 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00"
+}
+]
+
+load --table Logs_20150131
+[
+{
+  "timestamp": "2015-01-31 12:49:00",
+  "memo":      "2015-01-31 12:49:00"
+},
+{
+  "timestamp": "2015-01-31 23:59:59",
+  "memo":      "2015-01-31 23:59:59"
 }
 ]
 

--- a/test/command/suite/sharding/logical_select/no_condition/max_include.expected
+++ b/test/command/suite/sharding/logical_select/no_condition/max_include.expected
@@ -30,6 +30,16 @@ table_create Times_20150205 TABLE_PAT_KEY Time
 [[0,0.0,0.0],true]
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 [[0,0.0,0.0],true]
+table_create Logs_20150131 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150131 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150131 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_20150131 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_20150131 timestamp_index COLUMN_INDEX Logs_20150131 timestamp
+[[0,0.0,0.0],true]
 load --table Logs_20150203
 [
 {
@@ -78,6 +88,18 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
+load --table Logs_20150131
+[
+{
+  "timestamp": "2015-01-31 12:49:00",
+  "memo":      "2015-01-31 12:49:00"
+},
+{
+  "timestamp": "2015-01-31 23:59:59",
+  "memo":      "2015-01-31 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
 logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "include"
 [
   [
@@ -88,7 +110,7 @@ logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "incl
   [
     [
       [
-        3
+        5
       ],
       [
         [
@@ -103,6 +125,16 @@ logical_select Logs timestamp   --max "2015-02-04 00:00:00"   --max_border "incl
           "timestamp",
           "Time"
         ]
+      ],
+      [
+        1,
+        "2015-01-31 12:49:00",
+        1422676140.0
+      ],
+      [
+        2,
+        "2015-01-31 23:59:59",
+        1422716399.0
       ],
       [
         1,

--- a/test/command/suite/sharding/logical_select/no_condition/max_include.test
+++ b/test/command/suite/sharding/logical_select/no_condition/max_include.test
@@ -20,6 +20,12 @@ column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 table_create Times_20150205 TABLE_PAT_KEY Time
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 
+table_create Logs_20150131 TABLE_NO_KEY
+column_create Logs_20150131 timestamp COLUMN_SCALAR Time
+column_create Logs_20150131 memo COLUMN_SCALAR ShortText
+table_create Times_20150131 TABLE_PAT_KEY Time
+column_create Times_20150131 timestamp_index COLUMN_INDEX Logs_20150131 timestamp
+
 load --table Logs_20150203
 [
 {
@@ -65,6 +71,18 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00"
+}
+]
+
+load --table Logs_20150131
+[
+{
+  "timestamp": "2015-01-31 12:49:00",
+  "memo":      "2015-01-31 12:49:00"
+},
+{
+  "timestamp": "2015-01-31 23:59:59",
+  "memo":      "2015-01-31 23:59:59"
 }
 ]
 

--- a/test/command/suite/sharding/logical_select/no_condition/min_exclude.expected
+++ b/test/command/suite/sharding/logical_select/no_condition/min_exclude.expected
@@ -30,6 +30,16 @@ table_create Times_20150205 TABLE_PAT_KEY Time
 [[0,0.0,0.0],true]
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 [[0,0.0,0.0],true]
+table_create Logs_20150331 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150331 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150331 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_20150331 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_20150331 timestamp_index COLUMN_INDEX Logs_20150331 timestamp
+[[0,0.0,0.0],true]
 load --table Logs_20150203
 [
 {
@@ -78,6 +88,18 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
+load --table Logs_20150331
+[
+{
+  "timestamp": "2015-03-31 12:49:00",
+  "memo":      "2015-03-31 12:49:00"
+},
+{
+  "timestamp": "2015-03-31 23:59:59",
+  "memo":      "2015-03-31 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
 logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "exclude"
 [
   [
@@ -88,7 +110,7 @@ logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "excl
   [
     [
       [
-        6
+        8
       ],
       [
         [
@@ -133,6 +155,16 @@ logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "excl
         4,
         "2015-02-05 13:52:00",
         1423111920.0
+      ],
+      [
+        1,
+        "2015-03-31 12:49:00",
+        1427773740.0
+      ],
+      [
+        2,
+        "2015-03-31 23:59:59",
+        1427813999.0
       ]
     ]
   ]

--- a/test/command/suite/sharding/logical_select/no_condition/min_exclude.test
+++ b/test/command/suite/sharding/logical_select/no_condition/min_exclude.test
@@ -20,6 +20,12 @@ column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 table_create Times_20150205 TABLE_PAT_KEY Time
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 
+table_create Logs_20150331 TABLE_NO_KEY
+column_create Logs_20150331 timestamp COLUMN_SCALAR Time
+column_create Logs_20150331 memo COLUMN_SCALAR ShortText
+table_create Times_20150331 TABLE_PAT_KEY Time
+column_create Times_20150331 timestamp_index COLUMN_INDEX Logs_20150331 timestamp
+
 load --table Logs_20150203
 [
 {
@@ -65,6 +71,18 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00"
+}
+]
+
+load --table Logs_20150331
+[
+{
+  "timestamp": "2015-03-31 12:49:00",
+  "memo":      "2015-03-31 12:49:00"
+},
+{
+  "timestamp": "2015-03-31 23:59:59",
+  "memo":      "2015-03-31 23:59:59"
 }
 ]
 

--- a/test/command/suite/sharding/logical_select/no_condition/min_include.expected
+++ b/test/command/suite/sharding/logical_select/no_condition/min_include.expected
@@ -30,6 +30,16 @@ table_create Times_20150205 TABLE_PAT_KEY Time
 [[0,0.0,0.0],true]
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 [[0,0.0,0.0],true]
+table_create Logs_20150331 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20150331 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20150331 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_20150331 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_20150331 timestamp_index COLUMN_INDEX Logs_20150331 timestamp
+[[0,0.0,0.0],true]
 load --table Logs_20150203
 [
 {
@@ -78,6 +88,18 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
+load --table Logs_20150331
+[
+{
+  "timestamp": "2015-03-31 12:49:00",
+  "memo":      "2015-03-31 12:49:00"
+},
+{
+  "timestamp": "2015-03-31 23:59:59",
+  "memo":      "2015-03-31 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
 logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "include"
 [
   [
@@ -88,7 +110,7 @@ logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "incl
   [
     [
       [
-        7
+        9
       ],
       [
         [
@@ -138,6 +160,16 @@ logical_select Logs timestamp   --min "2015-02-04 00:00:00"   --min_border "incl
         4,
         "2015-02-05 13:52:00",
         1423111920.0
+      ],
+      [
+        1,
+        "2015-03-31 12:49:00",
+        1427773740.0
+      ],
+      [
+        2,
+        "2015-03-31 23:59:59",
+        1427813999.0
       ]
     ]
   ]

--- a/test/command/suite/sharding/logical_select/no_condition/min_include.test
+++ b/test/command/suite/sharding/logical_select/no_condition/min_include.test
@@ -20,6 +20,12 @@ column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 table_create Times_20150205 TABLE_PAT_KEY Time
 column_create Times_20150205 timestamp_index COLUMN_INDEX Logs_20150205 timestamp
 
+table_create Logs_20150331 TABLE_NO_KEY
+column_create Logs_20150331 timestamp COLUMN_SCALAR Time
+column_create Logs_20150331 memo COLUMN_SCALAR ShortText
+table_create Times_20150331 TABLE_PAT_KEY Time
+column_create Times_20150331 timestamp_index COLUMN_INDEX Logs_20150331 timestamp
+
 load --table Logs_20150203
 [
 {
@@ -65,6 +71,17 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00"
+}
+]
+load --table Logs_20150331
+[
+{
+  "timestamp": "2015-03-31 12:49:00",
+  "memo":      "2015-03-31 12:49:00"
+},
+{
+  "timestamp": "2015-03-31 23:59:59",
+  "memo":      "2015-03-31 23:59:59"
 }
 ]
 


### PR DESCRIPTION
`logical_table`で指定したテーブルのテーブル名に月の最終日が含まれていてかつ、`logical_select`を`min`オプション付きで実行した際に`logical_select`が`argument out of range`で失敗する問題を修正しました。