### PR TITLE
grndb: change log level from notice to info

### DIFF
--- a/src/grndb.c
+++ b/src/grndb.c
@@ -152,6 +152,7 @@ main(int argc, char **argv)
   }
 
   grn_default_logger_set_path(log_path);
+  grn_default_logger_set_max_level(GRN_LOG_INFO);
 
   if (grn_init() != GRN_SUCCESS) {
     return EXIT_FAILURE;


### PR DESCRIPTION
When physical file operation (add/remove) is now logged in info level,
so log level for grndb should be GRN_LOG_INFO because above logs are
not logged in notice level.