### PR TITLE
[WIP] Support index expression

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -322,6 +322,7 @@ typedef uint32_t grn_column_flags;
 #define GRN_OBJ_WITH_WEIGHT            (0x01<<8)
 #define GRN_OBJ_WITH_POSITION          (0x01<<9)
 #define GRN_OBJ_RING_BUFFER            (0x01<<10)
+#define GRN_OBJ_WITH_EXPRESSION        (0x01<<11)
 
 #define GRN_OBJ_UNIT_MASK              (0x0f<<8)
 #define GRN_OBJ_UNIT_DOCUMENT_NONE     (0x00<<8)
@@ -692,7 +693,8 @@ typedef enum {
 #define GRN_INFO_SUPPORT_LZO GRN_INFO_SUPPORT_LZ4
   GRN_INFO_NORMALIZER,
   GRN_INFO_TOKEN_FILTERS,
-  GRN_INFO_SUPPORT_ZSTD
+  GRN_INFO_SUPPORT_ZSTD,
+  GRN_INFO_EXPRESSION
 } grn_info_type;
 
 GRN_API grn_obj *grn_obj_get_info(grn_ctx *ctx, grn_obj *obj, grn_info_type type, grn_obj *valuebuf);

--- a/lib/dump.c
+++ b/lib/dump.c
@@ -83,6 +83,9 @@ grn_dump_column_create_flags(grn_ctx *ctx,
     if (flags & GRN_OBJ_WITH_POSITION) {
       GRN_TEXT_PUTS(ctx, buffer, "|WITH_POSITION");
     }
+    if (flags & GRN_OBJ_WITH_EXPRESSION) {
+      GRN_TEXT_PUTS(ctx, buffer, "|WITH_EXPRESSION");
+    }
     if (flags & GRN_OBJ_INDEX_SMALL) {
       GRN_TEXT_PUTS(ctx, buffer, "|INDEX_SMALL");
     }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -697,7 +697,9 @@ grn_expr_add_var(grn_ctx *ctx, grn_obj *expr, const char *name, unsigned int nam
       v->name_size = name_size;
       res = &v->value;
       GRN_VOID_INIT(res);
-      for (i = e->nvars, p = GRN_TEXT_VALUE(&e->name_buf), v = e->vars; i; i--, v++) {
+      for (i = e->nvars, p = GRN_TEXT_VALUE(&e->name_buf), v = e->vars;
+           i;
+           i--, v++) {
         v->name = p;
         p += v->name_size;
       }
@@ -709,31 +711,69 @@ grn_expr_add_var(grn_ctx *ctx, grn_obj *expr, const char *name, unsigned int nam
 grn_obj *
 grn_expr_get_var(grn_ctx *ctx, grn_obj *expr, const char *name, unsigned int name_size)
 {
-  uint32_t n;
   grn_obj *res = NULL;
-  grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
-  if (vars) { grn_hash_get(ctx, vars, name, name_size, (void **)&res); }
+  if (expr->header.type == GRN_EXPR &&
+      !(DB_OBJ(expr)->id & GRN_OBJ_TMP_OBJECT)) {
+    grn_expr *e = (grn_expr *)expr;
+    if (e->vars && e->nvars) {
+      uint32_t i;
+      grn_expr_var *v;
+      v = e->vars;
+      for (i = e->nvars, v = e->vars;
+           i;
+           i--, v++) {
+        if (v->name_size == name_size &&
+            !memcmp(v->name, name, name_size)) {
+          res = &(v->value);
+          break;
+        }
+      }
+    }
+  } else {
+    uint32_t n;
+    grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
+    if (vars) { grn_hash_get(ctx, vars, name, name_size, (void **)&res); }
+  }
   return res;
 }
 
 grn_obj *
 grn_expr_get_or_add_var(grn_ctx *ctx, grn_obj *expr, const char *name, unsigned int name_size)
 {
-  uint32_t n;
   grn_obj *res = NULL;
-  grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
-  if (vars) {
-    int added = 0;
-    char name_buf[16];
-    if (!name_size) {
-      char *rest;
-      name_buf[0] = '$';
-      grn_itoa((int)GRN_HASH_SIZE(vars) + 1, name_buf + 1, name_buf + 16, &rest);
-      name_size = rest - name_buf;
-      name = name_buf;
+  if (expr->header.type == GRN_EXPR &&
+      !(DB_OBJ(expr)->id & GRN_OBJ_TMP_OBJECT)) {
+    grn_expr *e = (grn_expr *)expr;
+    if (e->vars && e->nvars) {
+      char name_buf[16];
+      if (!name_size) {
+        char *rest;
+        name_buf[0] = '$';
+        grn_itoa(e->nvars + 1, name_buf + 1, name_buf + 16, &rest);
+        name_size = rest - name_buf;
+        name = name_buf;
+      }
+      res = grn_expr_get_var(ctx, expr, name, name_size);
     }
-    grn_hash_add(ctx, vars, name, name_size, (void **)&res, &added);
-    if (added) { GRN_TEXT_INIT(res, 0); }
+    if (!res) {
+      res = grn_expr_add_var(ctx, expr, name, name_size);
+    }
+  } else {
+    uint32_t n;
+    grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
+    if (vars) {
+      int added = 0;
+      char name_buf[16];
+      if (!name_size) {
+        char *rest;
+        name_buf[0] = '$';
+        grn_itoa((int)GRN_HASH_SIZE(vars) + 1, name_buf + 1, name_buf + 16, &rest);
+        name_size = rest - name_buf;
+        name = name_buf;
+      }
+      grn_hash_add(ctx, vars, name, name_size, (void **)&res, &added);
+      if (added) { GRN_TEXT_INIT(res, 0); }
+    }
   }
   return res;
 }
@@ -741,10 +781,28 @@ grn_expr_get_or_add_var(grn_ctx *ctx, grn_obj *expr, const char *name, unsigned 
 grn_obj *
 grn_expr_get_var_by_offset(grn_ctx *ctx, grn_obj *expr, unsigned int offset)
 {
-  uint32_t n;
   grn_obj *res = NULL;
-  grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
-  if (vars) { res = (grn_obj *)grn_hash_get_value_(ctx, vars, offset + 1, NULL); }
+  if (expr->header.type == GRN_EXPR &&
+      !(DB_OBJ(expr)->id & GRN_OBJ_TMP_OBJECT)) {
+    grn_expr *e = (grn_expr *)expr;
+    if (e->vars && e->nvars) {
+      grn_expr_var *v;
+      uint32_t i;
+      v = e->vars;
+      for (i = e->nvars, v = e->vars;
+           i;
+           i--, v++) {
+        if (e->nvars - offset == i) {
+          res = &(v->value);
+          break;
+        }
+      }
+    }
+  } else {
+    uint32_t n;
+    grn_hash *vars = grn_expr_get_vars(ctx, expr, &n);
+    if (vars) { res = (grn_obj *)grn_hash_get_value_(ctx, vars, offset + 1, NULL); }
+  }
   return res;
 }
 

--- a/lib/grn_ii.h
+++ b/lib/grn_ii.h
@@ -40,6 +40,8 @@ struct _grn_ii {
   uint32_t n_elements;   /* Number of elements in postings */
                          /* rid, [sid], tf, [weight] and [pos] */
   struct grn_ii_header *header;
+
+  grn_obj *expression;
 };
 
 /* BGQ is buffer garbage queue? */

--- a/lib/grn_proc.h
+++ b/lib/grn_proc.h
@@ -31,6 +31,10 @@ extern "C" {
 #define GRN_SELECT_INTERNAL_VAR_CONDITION_LEN           \
   (sizeof(GRN_SELECT_INTERNAL_VAR_CONDITION) - 1)
 
+#define GRN_COLUMN_EXPRESSION_RAW     "$expression_raw"
+#define GRN_COLUMN_EXPRESSION_RAW_LEN           \
+  (sizeof(GRN_COLUMN_EXPRESSION_RAW) - 1)
+
 void grn_proc_init_from_env(void);
 
 GRN_VAR const char *grn_document_root;

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -4442,9 +4442,6 @@ grn_ii_close(grn_ctx *ctx, grn_ii *ii)
   if (!ii) { return GRN_INVALID_ARGUMENT; }
   if ((rc = grn_io_close(ctx, ii->seg))) { return rc; }
   if ((rc = grn_io_close(ctx, ii->chunk))) { return rc; }
-  if (ii->expression) {
-    if ((rc = grn_obj_close(ctx, ii->expression))) { return rc; }
-  }
   
   GRN_FREE(ii);
   /*

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -4306,6 +4306,7 @@ _grn_ii_create(grn_ctx *ctx, grn_ii *ii, const char *path, grn_obj *lexicon, uin
   if ((flags & GRN_OBJ_WITH_SECTION)) { ii->n_elements++; }
   if ((flags & GRN_OBJ_WITH_WEIGHT)) { ii->n_elements++; }
   if ((flags & GRN_OBJ_WITH_POSITION)) { ii->n_elements++; }
+  ii->expression = NULL;
   return ii;
 }
 
@@ -4430,6 +4431,7 @@ grn_ii_open(grn_ctx *ctx, const char *path, grn_obj *lexicon)
   if ((header->flags & GRN_OBJ_WITH_SECTION)) { ii->n_elements++; }
   if ((header->flags & GRN_OBJ_WITH_WEIGHT)) { ii->n_elements++; }
   if ((header->flags & GRN_OBJ_WITH_POSITION)) { ii->n_elements++; }
+  ii->expression = NULL;
   return ii;
 }
 
@@ -4440,6 +4442,10 @@ grn_ii_close(grn_ctx *ctx, grn_ii *ii)
   if (!ii) { return GRN_INVALID_ARGUMENT; }
   if ((rc = grn_io_close(ctx, ii->seg))) { return rc; }
   if ((rc = grn_io_close(ctx, ii->chunk))) { return rc; }
+  if (ii->expression) {
+    if ((rc = grn_obj_close(ctx, ii->expression))) { return rc; }
+  }
+  
   GRN_FREE(ii);
   /*
   {
@@ -6288,6 +6294,106 @@ grn_uvector2updspecs(grn_ctx *ctx, grn_ii *ii, grn_id rid,
   }
 }
 
+inline static grn_obj *
+grn_ii_expr_exec_with_update_value(grn_ctx *ctx,
+                                   grn_ii *ii,
+                                   grn_id rid,
+                                   unsigned int section,
+                                   grn_obj *oldvalue,
+                                   grn_obj *newvalue)
+{
+  grn_obj *record;
+  grn_expr_code *code, *code_end;
+  grn_obj *original_code_value;
+  grn_obj *return_value;
+  grn_array *target_codes;
+  grn_id *source_ids = ii->obj.source;
+  grn_id source_id = source_ids[section - 1];
+  grn_obj *source_obj = grn_ctx_at(ctx, source_id);
+  grn_expr *expr = (grn_expr *)ii->expression;
+
+  target_codes = grn_array_create(ctx, NULL, sizeof(grn_expr_code *), 0);
+  if (!target_codes) {
+    ERR(GRN_NO_MEMORY_AVAILABLE,
+        "[ii][column][update] failed to create array for execute expression with update value");
+    goto exit;
+  }
+  code = expr->codes;
+  code_end = expr->codes + expr->codes_curr;
+  while (code < code_end) {
+    grn_bool is_found = GRN_FALSE;
+    if (code->op == GRN_OP_GET_VALUE) {
+      if (grn_obj_is_accessor(ctx, code->value)) {
+        grn_accessor *a;
+        for (a = (grn_accessor *)code->value; a->next; a = a->next) {
+          if (a->obj == source_obj) {
+            is_found = GRN_TRUE;
+            break;
+          }
+        }
+      } else {
+        if (code->value == source_obj) {
+          is_found = GRN_TRUE;
+        }
+      }
+      if (is_found) {
+        grn_expr_code **code_p;
+        if (grn_array_add(ctx, target_codes, (void **)&code_p)) {
+          *code_p = code;
+          original_code_value = code->value;
+          code->value = oldvalue;
+          code->op = GRN_OP_PUSH;
+        }
+      }
+    }
+    code++;
+  }
+  record = grn_expr_get_var_by_offset(ctx, (grn_obj *)expr, 0);
+  GRN_RECORD_SET(ctx, record, rid);
+
+  if (oldvalue &&
+      !grn_bulk_is_zero(ctx, oldvalue)) {
+    return_value = grn_expr_exec(ctx, (grn_obj *)expr, 0);
+    if (ctx->rc) {
+      goto exit;
+    }
+    grn_obj_reinit(ctx, oldvalue,
+                   return_value->header.domain,
+                   return_value->header.flags);
+    GRN_TEXT_SET(ctx, oldvalue,
+                 GRN_TEXT_VALUE(return_value),
+                 GRN_TEXT_LEN(return_value));
+  }
+
+  if (!grn_bulk_is_zero(ctx, newvalue)) {
+    grn_expr_code **key;
+    GRN_ARRAY_EACH(ctx, target_codes, 0, 0, id, &key, {
+      grn_expr_code *k = *key;
+      k->value = newvalue;
+    });
+    return_value = grn_expr_exec(ctx, (grn_obj *)expr, 0);
+    if (ctx->rc) {
+      goto exit;
+    }
+    newvalue = return_value;
+  }
+
+  {
+    grn_expr_code **key;
+    GRN_ARRAY_EACH(ctx, target_codes, 0, 0, id, &key, {
+      grn_expr_code *k = *key;
+      k->value = original_code_value;
+      k->op = GRN_OP_GET_VALUE;
+    });
+  }
+
+exit :
+  if (target_codes) {
+    grn_array_close(ctx, target_codes);
+  }
+  return newvalue;
+}
+
 grn_rc
 grn_ii_column_update(grn_ctx *ctx, grn_ii *ii, grn_id rid, unsigned int section,
                      grn_obj *oldvalue, grn_obj *newvalue, grn_obj *posting)
@@ -6315,6 +6421,18 @@ grn_ii_column_update(grn_ctx *ctx, grn_ii *ii, grn_id rid, unsigned int section,
     post = &buf;
   }
   if (grn_io_lock(ctx, ii->seg, grn_lock_timeout)) { return ctx->rc; }
+
+  if (ii->expression) {
+    newvalue = grn_ii_expr_exec_with_update_value(ctx,
+                                                  ii,
+                                                  rid,
+                                                  section,
+                                                  oldvalue,
+                                                  newvalue);
+    new = newvalue;
+    section = 1;
+  }
+
   if (new) {
     unsigned char type = (ii->obj.header.domain == new->header.domain)
       ? GRN_UVECTOR
@@ -12098,7 +12216,22 @@ grn_ii_builder_append_srcs(grn_ctx *ctx, grn_ii_builder *builder)
         }
         if (rc == GRN_SUCCESS) {
           uint32_t sid = (uint32_t)(i + 1);
-          rc = grn_ii_builder_append_obj(ctx, builder, rid, sid, obj);
+          if (builder->ii->obj.header.flags & GRN_OBJ_WITH_EXPRESSION) {
+            if (sid == 1) {
+              obj = grn_ii_expr_exec_with_update_value(ctx,
+                                                       builder->ii,
+                                                       rid,
+                                                       sid,
+                                                       NULL,
+                                                       obj);
+              rc = ctx->rc;
+              if (rc == GRN_SUCCESS) {
+                rc = grn_ii_builder_append_obj(ctx, builder, rid, sid, obj);
+              }
+            }
+          } else {
+            rc = grn_ii_builder_append_obj(ctx, builder, rid, sid, obj);
+          }
         }
       }
     }

--- a/lib/proc/proc_dump.c
+++ b/lib/proc/proc_dump.c
@@ -283,6 +283,30 @@ dump_index_column_sources(grn_ctx *ctx, grn_dumper *dumper, grn_obj *column)
 }
 
 static void
+dump_index_column_expression(grn_ctx *ctx, grn_dumper *dumper, grn_obj *column)
+{
+  grn_obj buf;
+  grn_obj *expression;
+  grn_obj *expression_raw;
+
+  GRN_OBJ_INIT(&buf, GRN_BULK, 0, GRN_ID_NIL);
+  expression = grn_obj_get_info(ctx, column, GRN_INFO_EXPRESSION, &buf);
+  expression_raw = grn_expr_get_var(ctx, expression,
+                                    GRN_COLUMN_EXPRESSION_RAW,
+                                    GRN_COLUMN_EXPRESSION_RAW_LEN);
+  if (expression_raw) {
+    GRN_TEXT_PUTC(ctx, dumper->output, ' ');
+    GRN_TEXT_PUTC(ctx, dumper->output, '\'');
+    GRN_TEXT_PUT(ctx,
+                 dumper->output,
+                 GRN_TEXT_VALUE(expression_raw),
+                 GRN_TEXT_LEN(expression_raw));
+    GRN_TEXT_PUTC(ctx, dumper->output, '\'');
+  }
+  grn_obj_close(ctx, &buf);
+}
+
+static void
 dump_column(grn_ctx *ctx, grn_dumper *dumper, grn_obj *table, grn_obj *column)
 {
   grn_id type_id;
@@ -316,6 +340,9 @@ dump_column(grn_ctx *ctx, grn_dumper *dumper, grn_obj *table, grn_obj *column)
   dump_obj_name(ctx, dumper, type);
   if (column->header.flags & GRN_OBJ_COLUMN_INDEX) {
     dump_index_column_sources(ctx, dumper, column);
+    if (column->header.flags & GRN_OBJ_WITH_EXPRESSION) {
+      dump_index_column_expression(ctx, dumper, column);
+    }
   }
   GRN_TEXT_PUTC(ctx, dumper->output, '\n');
 

--- a/test/command/suite/column_create/index/expression/function.expected
+++ b/test/command/suite/column_create/index/expression/function.expected
@@ -4,5 +4,5 @@ column_create Notes title COLUMN_SCALAR LongText
 [[0,0.0,0.0],true]
 table_create Titles TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title html_untag(title)
+column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title --expression 'html_untag(title)'
 [[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/expression/function.expected
+++ b/test/command/suite/column_create/index/expression/function.expected
@@ -1,0 +1,8 @@
+table_create Notes TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Notes title COLUMN_SCALAR LongText
+[[0,0.0,0.0],true]
+table_create Titles TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title html_untag(title)
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/expression/function.test
+++ b/test/command/suite/column_create/index/expression/function.test
@@ -2,4 +2,4 @@ table_create Notes TABLE_NO_KEY
 column_create Notes title COLUMN_SCALAR LongText
 
 table_create Titles TABLE_PAT_KEY ShortText
-column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title html_untag(title)
+column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title --expression 'html_untag(title)'

--- a/test/command/suite/column_create/index/expression/function.test
+++ b/test/command/suite/column_create/index/expression/function.test
@@ -1,0 +1,5 @@
+table_create Notes TABLE_NO_KEY
+column_create Notes title COLUMN_SCALAR LongText
+
+table_create Titles TABLE_PAT_KEY ShortText
+column_create Titles notes_title COLUMN_INDEX|WITH_EXPRESSION Notes title html_untag(title)

--- a/test/command/suite/column_create/index/expression/log.expected
+++ b/test/command/suite/column_create/index/expression/log.expected
@@ -1,0 +1,18 @@
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data value1 COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Data value2 COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Lexicon TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Lexicon data_values COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Data value1,value2   'value1 + value2'
+[[0,0.0,0.0],true]
+#|n| DDL:260:column_create Lexicon data_values
+#|n| spec:260:update:Lexicon.data_values:72(column:index):256(Data)
+#|n| DDL:260:set_expression value1 + value2
+#|n| spec:260:update:Lexicon.data_values:72(column:index):256(Data)
+#|n| DDL:260:set_source Lexicon.data_values Data.value1,Data.value2
+#|n| spec:257:update:Data.value1:65(column:var_size):15(Text)
+#|n| spec:258:update:Data.value2:65(column:var_size):15(Text)
+#|n| spec:260:update:Lexicon.data_values:72(column:index):256(Data)

--- a/test/command/suite/column_create/index/expression/log.expected
+++ b/test/command/suite/column_create/index/expression/log.expected
@@ -6,7 +6,7 @@ column_create Data value2 COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
 table_create Lexicon TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
 [[0,0.0,0.0],true]
-column_create Lexicon data_values COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Data value1,value2   'value1 + value2'
+column_create Lexicon data_values COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Data value1,value2   --expression 'value1 + value2'
 [[0,0.0,0.0],true]
 #|n| DDL:260:column_create Lexicon data_values
 #|n| spec:260:update:Lexicon.data_values:72(column:index):256(Data)

--- a/test/command/suite/column_create/index/expression/log.test
+++ b/test/command/suite/column_create/index/expression/log.test
@@ -9,5 +9,5 @@ table_create Lexicon TABLE_PAT_KEY ShortText \
 #@add-important-log-levels notice
 column_create Lexicon data_values COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION \
   Data value1,value2 \
-  'value1 + value2'
+  --expression 'value1 + value2'
 #@remove-important-log-levels notice

--- a/test/command/suite/column_create/index/expression/log.test
+++ b/test/command/suite/column_create/index/expression/log.test
@@ -1,0 +1,13 @@
+table_create Data TABLE_NO_KEY
+column_create Data value1 COLUMN_SCALAR Text
+column_create Data value2 COLUMN_SCALAR Text
+
+table_create Lexicon TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+
+#@add-important-log-levels notice
+column_create Lexicon data_values COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION \
+  Data value1,value2 \
+  'value1 + value2'
+#@remove-important-log-levels notice

--- a/test/command/suite/column_remove/index_expression.expected
+++ b/test/command/suite/column_remove/index_expression.expected
@@ -1,0 +1,25 @@
+table_create Users TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name 'html_untag(name)'
+[[0,0.0,0.0],true]
+dump
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name 'html_untag(name)'
+column_remove Terms users_name
+[[0,0.0,0.0],true]
+#|n| DDL:259:obj_remove Terms.users_name
+#|n| spec:257:update:Users.name:65(column:var_size):14(ShortText)
+#|n| spec:259:remove:Terms.users_name:72(column:index)
+dump
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText

--- a/test/command/suite/column_remove/index_expression.expected
+++ b/test/command/suite/column_remove/index_expression.expected
@@ -4,7 +4,7 @@ column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
 [[0,0.0,0.0],true]
-column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name 'html_untag(name)'
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name  --expression 'html_untag(name)'
 [[0,0.0,0.0],true]
 dump
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto

--- a/test/command/suite/column_remove/index_expression.test
+++ b/test/command/suite/column_remove/index_expression.test
@@ -1,0 +1,15 @@
+table_create Users TABLE_PAT_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name 'html_untag(name)'
+
+dump
+
+#@add-important-log-levels notice
+column_remove Terms users_name
+#@remove-important-log-levels notice
+
+dump

--- a/test/command/suite/column_remove/index_expression.test
+++ b/test/command/suite/column_remove/index_expression.test
@@ -4,7 +4,8 @@ column_create Users name COLUMN_SCALAR ShortText
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
   --normalizer NormalizerAuto
-column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name 'html_untag(name)'
+column_create Terms users_name COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION Users name \
+ --expression 'html_untag(name)'
 
 dump
 

--- a/test/command/suite/dump/schema/column/index/with_expression.expected
+++ b/test/command/suite/dump/schema/column/index/with_expression.expected
@@ -1,0 +1,15 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Names TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name 'html_untag(name)'
+[[0,0.0,0.0],true]
+dump
+table_create Names TABLE_HASH_KEY ShortText
+
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name 'html_untag(name)'

--- a/test/command/suite/dump/schema/column/index/with_expression.expected
+++ b/test/command/suite/dump/schema/column/index/with_expression.expected
@@ -4,7 +4,7 @@ column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Names TABLE_HASH_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name 'html_untag(name)'
+column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name --expression 'html_untag(name)'
 [[0,0.0,0.0],true]
 dump
 table_create Names TABLE_HASH_KEY ShortText

--- a/test/command/suite/dump/schema/column/index/with_expression.test
+++ b/test/command/suite/dump/schema/column/index/with_expression.test
@@ -1,0 +1,7 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users name COLUMN_SCALAR ShortText
+
+table_create Names TABLE_HASH_KEY ShortText
+column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name 'html_untag(name)'
+
+dump

--- a/test/command/suite/dump/schema/column/index/with_expression.test
+++ b/test/command/suite/dump/schema/column/index/with_expression.test
@@ -2,6 +2,6 @@ table_create Users TABLE_HASH_KEY ShortText
 column_create Users name COLUMN_SCALAR ShortText
 
 table_create Names TABLE_HASH_KEY ShortText
-column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name 'html_untag(name)'
+column_create Names users COLUMN_INDEX|WITH_EXPRESSION Users name --expression 'html_untag(name)'
 
 dump

--- a/test/command/suite/select/index/expression/function.expected
+++ b/test/command/suite/select/index/expression/function.expected
@@ -4,7 +4,7 @@ column_create Memos content COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
 [[0,0.0,0.0],true]
-column_create Terms memos_content   COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Memos content   'html_untag(content)'
+column_create Terms memos_content   COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Memos content   --expression 'html_untag(content)'
 [[0,0.0,0.0],true]
 load --table Memos
 [

--- a/test/command/suite/select/index/expression/function.expected
+++ b/test/command/suite/select/index/expression/function.expected
@@ -1,0 +1,47 @@
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms memos_content   COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION   Memos content   'html_untag(content)'
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"content": "G<b>roonga</b> is fast fulltext search engine"},
+{"content": "Mroonga is MySQL stroage engine using Groonga"}
+]
+[[0,0.0,0.0],2]
+select Memos --filter 'content @ "Groonga"'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "content",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "G<b>roonga</b> is fast fulltext search engine"
+      ],
+      [
+        2,
+        "Mroonga is MySQL stroage engine using Groonga"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/expression/function.test
+++ b/test/command/suite/select/index/expression/function.test
@@ -8,7 +8,7 @@ table_create Terms TABLE_PAT_KEY ShortText \
 column_create Terms memos_content \
   COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION \
   Memos content \
-  'html_untag(content)'
+  --expression 'html_untag(content)'
 
 load --table Memos
 [

--- a/test/command/suite/select/index/expression/function.test
+++ b/test/command/suite/select/index/expression/function.test
@@ -1,0 +1,19 @@
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+
+column_create Terms memos_content \
+  COLUMN_INDEX|WITH_POSITION|WITH_EXPRESSION \
+  Memos content \
+  'html_untag(content)'
+
+load --table Memos
+[
+{"content": "G<b>roonga</b> is fast fulltext search engine"},
+{"content": "Mroonga is MySQL stroage engine using Groonga"}
+]
+
+select Memos --filter 'content @ "Groonga"'

--- a/test/command/suite/select/index/expression/multi_source.expected
+++ b/test/command/suite/select/index/expression/multi_source.expected
@@ -1,0 +1,55 @@
+table_create Patents TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Patents app_date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Patents priority_date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+table_create Dates TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   'min(app_date,priority_date)'
+[[0,0.0,0.0],true]
+load --table Patents
+[
+{"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+]
+[[0,0.0,0.0],2]
+select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --output_columns _id,_key,app_date,priority_date
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "app_date",
+          "Time"
+        ],
+        [
+          "priority_date",
+          "Time"
+        ]
+      ],
+      [
+        2,
+        "JP20000123456",
+        976460400.0,
+        253402182000.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/expression/multi_source.expected
+++ b/test/command/suite/select/index/expression/multi_source.expected
@@ -6,12 +6,12 @@ column_create Patents priority_date COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 table_create Dates TABLE_PAT_KEY Time
 [[0,0.0,0.0],true]
-column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   'min(app_date,priority_date)'
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   --expression 'min(app_date,priority_date)'
 [[0,0.0,0.0],true]
 load --table Patents
 [
 {"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
-{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "2099-12-31 00:00:00"}
 ]
 [[0,0.0,0.0],2]
 select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --output_columns _id,_key,app_date,priority_date
@@ -48,7 +48,7 @@ select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --outp
         2,
         "JP20000123456",
         976460400.0,
-        253402182000.0
+        4102326000.0
       ]
     ]
   ]

--- a/test/command/suite/select/index/expression/multi_source.test
+++ b/test/command/suite/select/index/expression/multi_source.test
@@ -6,12 +6,12 @@ table_create Dates TABLE_PAT_KEY Time
 
 column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION \
   Patents app_date,priority_date \
-  'min(app_date,priority_date)'
+  --expression 'min(app_date,priority_date)'
 
 load --table Patents
 [
 {"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
-{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "2099-12-31 00:00:00"}
 ]
 
 select Patents \

--- a/test/command/suite/select/index/expression/multi_source.test
+++ b/test/command/suite/select/index/expression/multi_source.test
@@ -1,0 +1,19 @@
+table_create Patents TABLE_HASH_KEY ShortText
+column_create Patents app_date COLUMN_SCALAR Time
+column_create Patents priority_date COLUMN_SCALAR Time
+
+table_create Dates TABLE_PAT_KEY Time
+
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION \
+  Patents app_date,priority_date \
+  'min(app_date,priority_date)'
+
+load --table Patents
+[
+{"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+]
+
+select Patents \
+  --filter 'Dates.earliest_date > "2000-12-10 00:00:00"' \
+  --output_columns _id,_key,app_date,priority_date

--- a/test/command/suite/select/index/expression/offline_index_construction.expected
+++ b/test/command/suite/select/index/expression/offline_index_construction.expected
@@ -9,10 +9,10 @@ table_create Dates TABLE_PAT_KEY Time
 load --table Patents
 [
 {"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
-{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "2099-12-31 00:00:00"}
 ]
 [[0,0.0,0.0],2]
-column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   'min(app_date,priority_date)'
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   --expression 'min(app_date,priority_date)'
 [[0,0.0,0.0],true]
 select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --output_columns _id,_key,app_date,priority_date
 [
@@ -48,7 +48,7 @@ select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --outp
         2,
         "JP20000123456",
         976460400.0,
-        253402182000.0
+        4102326000.0
       ]
     ]
   ]

--- a/test/command/suite/select/index/expression/offline_index_construction.expected
+++ b/test/command/suite/select/index/expression/offline_index_construction.expected
@@ -1,0 +1,55 @@
+table_create Patents TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Patents app_date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Patents priority_date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+table_create Dates TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+load --table Patents
+[
+{"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+]
+[[0,0.0,0.0],2]
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION   Patents app_date,priority_date   'min(app_date,priority_date)'
+[[0,0.0,0.0],true]
+select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"'   --output_columns _id,_key,app_date,priority_date
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "app_date",
+          "Time"
+        ],
+        [
+          "priority_date",
+          "Time"
+        ]
+      ],
+      [
+        2,
+        "JP20000123456",
+        976460400.0,
+        253402182000.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/index/expression/offline_index_construction.test
+++ b/test/command/suite/select/index/expression/offline_index_construction.test
@@ -1,0 +1,19 @@
+table_create Patents TABLE_HASH_KEY ShortText
+column_create Patents app_date COLUMN_SCALAR Time
+column_create Patents priority_date COLUMN_SCALAR Time
+
+table_create Dates TABLE_PAT_KEY Time
+
+load --table Patents
+[
+{"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+]
+
+column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION \
+  Patents app_date,priority_date \
+  'min(app_date,priority_date)'
+
+select Patents \
+  --filter 'Dates.earliest_date > "2000-12-10 00:00:00"' \
+  --output_columns _id,_key,app_date,priority_date

--- a/test/command/suite/select/index/expression/offline_index_construction.test
+++ b/test/command/suite/select/index/expression/offline_index_construction.test
@@ -7,12 +7,12 @@ table_create Dates TABLE_PAT_KEY Time
 load --table Patents
 [
 {"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
-{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
+{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "2099-12-31 00:00:00"}
 ]
 
 column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION \
   Patents app_date,priority_date \
-  'min(app_date,priority_date)'
+  --expression 'min(app_date,priority_date)'
 
 select Patents \
   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"' \


### PR DESCRIPTION
どちらかの日付のうち最先の日付といった計算結果をインデックスできるようにしたく、式インデックスを使いたいと考えています。（この他、HTMLタグ除去など全文インデックスの前処理等にも使えると考えています。）
そこで、式インデックスを実装しました。``WITH_EXPRESSION``フラグと式を渡してカラムを構築することによりインデックスに式を持たせられるようにしています。

* ``grn_expr``は、TokenFilterと同様にDBのspecに保存しており、``ii->expression``にそのポインタを持たせるようにしています。
* 永続化させた``grn_expr_var``から値を取得できるよう関数を修正しました。
* ``grn_expr_var``中の``grn_accessor``の永続化を対応させました。
* インデックス更新時に保存した``grn_expr``中の更新対象と同じカラムオブジェクトを、更新前の値、および更新後の値に置き換えて``grn_expr``を評価するようにしました。

なお、今のところ、範囲や比較の場合、自動で式インデックスを見つけることはできません。

この実装は受け入れ可能でしょうか？

```
table_create Patents TABLE_HASH_KEY ShortText
column_create Patents app_date COLUMN_SCALAR Time
column_create Patents priority_date COLUMN_SCALAR Time
table_create Dates TABLE_PAT_KEY Time
column_create Dates earliest_date COLUMN_INDEX|WITH_EXPRESSION ¥
  Patents app_date,priority_date   'min(app_date,priority_date)'
load --table Patents
[
{"_key": "JP20010123456", "app_date": "2001-01-01 00:00:00", "priority_date": "2000-12-01 00:00:00"},
{"_key": "JP20000123456", "app_date": "2000-12-11 00:00:00", "priority_date": "9999-12-31 00:00:00"}
]
[[0,0.0,0.0],2]
select Patents   --filter 'Dates.earliest_date > "2000-12-10 00:00:00"' ¥
  --output_columns _id,_key,app_date,priority_date
[
   ...
      [
        2,
        "JP20000123456",
        976492800.0,
        253402214400.0
      ]
    ]
  ]
]
```
