### PR TITLE
grndb: recover locked objects in --force-truncate mode

### DIFF
--- a/lib/mrb/mrb_column.c
+++ b/lib/mrb/mrb_column.c
@@ -111,6 +111,17 @@ mrb_grn_column_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_column_clear_lock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_column_get_table(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -163,6 +174,8 @@ grn_mrb_column_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_column_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "clear_lock",
+                    mrb_grn_column_clear_lock, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "table",
                     mrb_grn_column_get_table, MRB_ARGS_NONE());

--- a/lib/mrb/mrb_database.c
+++ b/lib/mrb/mrb_database.c
@@ -97,6 +97,17 @@ mrb_grn_database_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_database_clear_lock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_database_get_last_modified(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -196,6 +207,8 @@ grn_mrb_database_init(grn_ctx *ctx)
                     mrb_grn_database_recover, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_database_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "clear_lock",
+                    mrb_grn_database_clear_lock, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "last_modified",
                     mrb_grn_database_get_last_modified, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "dirty?",

--- a/lib/mrb/mrb_table.c
+++ b/lib/mrb/mrb_table.c
@@ -177,6 +177,17 @@ mrb_grn_table_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_table_clear_lock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_table_get_size(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -466,6 +477,8 @@ grn_mrb_table_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_table_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "clear_lock",
+                    mrb_grn_table_clear_lock, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "size",
                     mrb_grn_table_get_size, MRB_ARGS_NONE());


### PR DESCRIPTION
In the previous versions, grndb recover --force-truncate doesn't work if there are locked objects.
This PR supports it.