### PR TITLE
grndb: truncate object in advance for force truncate mode

### DIFF
--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -416,10 +416,10 @@ module Groonga
         end
 
         def recover
-          @database.recover
           if @force_truncate
             truncate_corrupt_objects
           end
+          @database.recover
         end
 
         def truncate_corrupt_objects


### PR DESCRIPTION
Database#recover fails when corrupted object is locked.
so truncate such a object in advance.