### PR TITLE
package windows: use the latest pcre

### DIFF
--- a/packages/windows/Rakefile
+++ b/packages/windows/Rakefile
@@ -301,7 +301,7 @@ namespace :build do
     tmp_dir = base_tmp_dir + "pcre"
     rm_rf(tmp_dir)
     mkdir_p(tmp_dir)
-    pcre_version = "8.39"
+    pcre_version = "8.41"
     pcre_base = "pcre-#{pcre_version}"
     pcre_tar_gz_url_base =
       "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre"


### PR DESCRIPTION
`pcre-8.39` had not been exist in `ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre`
So, I modified to use `pcre-8.41` instead `pcre-8.39`.