### PR TITLE
normalize: don't output "" on error

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1088,7 +1088,6 @@ proc_normalize(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
   flag_names = VAR(2);
   if (GRN_TEXT_LEN(normalizer_name) == 0) {
     ERR(GRN_INVALID_ARGUMENT, "normalizer name is missing");
-    GRN_OUTPUT_CSTR("");
     return NULL;
   }
 
@@ -1108,7 +1107,6 @@ proc_normalize(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
           "[normalize] nonexistent normalizer: <%.*s>",
           (int)GRN_TEXT_LEN(normalizer_name),
           GRN_TEXT_VALUE(normalizer_name));
-      GRN_OUTPUT_CSTR("");
       return NULL;
     }
 
@@ -1121,7 +1119,6 @@ proc_normalize(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data
           (int)GRN_TEXT_LEN(&inspected),
           GRN_TEXT_VALUE(&inspected));
       GRN_OBJ_FIN(ctx, &inspected);
-      GRN_OUTPUT_CSTR("");
       grn_obj_unlink(ctx, normalizer);
       return NULL;
     }


### PR DESCRIPTION
#### Description

The command `normalize` returns `normalized_text` on success.
See http://groonga.org/ja/docs/reference/commands/normalize.html for details.

The expected format is as follows.

```
> normalize NormalizerAuto 'String' --output_pretty yes
[
  [
    0,
    1499398853.852021,
    0.0001425743103027344
  ],
  {
    "normalized": "string",
    "types": [
    ],
    "checks": [
    ]
  }
]
```

However, `normalize` returns an empty string on error.

```
> normalize NoSuchNormalizer 'String' --output_pretty yes
[
  [
    -22,
    1499398844.332195,
    8.940696716308594e-05,
    "[normalize] nonexistent normalizer: <NoSuchNormalizer>",
    [
      [
        "proc_normalize",
        "proc.c",
        1110
      ]
    ]
  ],
  ""
]
```

After applying this patch, `normalize` returns nothing on error.
See the following example.

```
> normalize NoSuchNormalizer 'String' --output_pretty yes
[
  [
    -22,
    1499399034.379015,
    0.001290321350097656,
    "[normalize] nonexistent normalizer: <NoSuchNormalizer>",
    [
      [
        "proc_normalize",
        "proc.c",
        1110
      ]
    ]
  ]
]
```
