### PR TITLE
table_tokenize: add a missing error

### DIFF
--- a/lib/proc/proc_tokenize.c
+++ b/lib/proc/proc_tokenize.c
@@ -264,8 +264,11 @@ command_table_tokenize(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *u
     }
 
     lexicon = grn_ctx_get(ctx, GRN_TEXT_VALUE(table_name), GRN_TEXT_LEN(table_name));
-
     if (!lexicon) {
+      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+                       "[table_tokenize] nonexistent lexicon: <%.*s>",
+                       (int)GRN_TEXT_LEN(table_name),
+                       GRN_TEXT_VALUE(table_name));
       return NULL;
     }
 


### PR DESCRIPTION
#### Description

`table_tokenize` returns nothing if the specified table does not exist.

```
> table_tokenize no_such_table 'あいうえお'
```

This patch updates `table_tokenize` to return an error as follows.

```
> table_tokenize no_such_table 'あいうえお'
[[-22,1499412795.316891,0.001605749130249023,"[table_tokenize] nonexistent lexicon: <no_such_table>",[["command_table_tokenize","proc_tokenize.c",271]]]]
```
