### PR TITLE
functions/time: add test for overflow interval case

### DIFF
--- a/test/command/suite/select/function/time/time_classify_month/overflow_interval.expected
+++ b/test/command/suite/select/function/time/time_classify_month/overflow_interval.expected
@@ -1,0 +1,67 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Timestamps TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+load --table Timestamps
+[
+{"_key": "2016-04-30 23:59:59.999999"},
+{"_key": "2016-05-01 00:00:00.000000"},
+{"_key": "2016-05-01 00:00:00.000001"},
+{"_key": "2016-06-30 23:59:59.999999"},
+{"_key": "2016-07-01 00:00:00.000000"},
+{"_key": "2016-07-01 00:00:00.000001"}
+]
+[[0,0.0,0.0],6]
+select Timestamps   --sortby _id   --limit -1   --output_columns '_key, time_classify_month(_key, 4294967296)'
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "time_classify_month(): the second argument must not be zero: <4294967296>"
+  ],
+  [
+    [
+      [
+        6
+      ],
+      [
+        [
+          "_key",
+          "Time"
+        ],
+        [
+          "time_classify_month",
+          null
+        ]
+      ],
+      [
+        1462060799.999999,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ],
+      [
+        1462060800.0,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ],
+      [
+        1462060800.000001,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ],
+      [
+        1467331199.999999,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ],
+      [
+        1467331200.0,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ],
+      [
+        1467331200.000001,
+        "time_classify_month(): the second argument must not be zero: <4294967296>"
+      ]
+    ]
+  ]
+]
+#|e| time_classify_month(): the second argument must not be zero: <4294967296>

--- a/test/command/suite/select/function/time/time_classify_month/overflow_interval.test
+++ b/test/command/suite/select/function/time/time_classify_month/overflow_interval.test
@@ -1,0 +1,18 @@
+plugin_register functions/time
+
+table_create Timestamps TABLE_PAT_KEY Time
+
+load --table Timestamps
+[
+{"_key": "2016-04-30 23:59:59.999999"},
+{"_key": "2016-05-01 00:00:00.000000"},
+{"_key": "2016-05-01 00:00:00.000001"},
+{"_key": "2016-06-30 23:59:59.999999"},
+{"_key": "2016-07-01 00:00:00.000000"},
+{"_key": "2016-07-01 00:00:00.000001"}
+]
+
+select Timestamps \
+  --sortby _id \
+  --limit -1 \
+  --output_columns '_key, time_classify_month(_key, 4294967296)'


### PR DESCRIPTION
I added test case base on the comment of #733.
I thought it doesn't need because it is invalid case.
