### PR TITLE
between: support specifying index column

### DIFF
--- a/lib/mrb/scripts/expression_tree/function_call.rb
+++ b/lib/mrb/scripts/expression_tree/function_call.rb
@@ -21,9 +21,14 @@ module Groonga
 
         column, min, min_border, max, max_border = @arguments
 
-        index_info = column.column.find_index(Operator::CALL)
-        return table.size if index_info.nil?
-        index_column = index_info.index
+        if column.is_a?(Groonga::ExpressionTree::IndexColumn)
+          index_column = column.object
+        else
+          index_info = column.column.find_index(Operator::CALL)
+          return table.size if index_info.nil?
+          index_column = index_info.index
+        end
+
         while index_column.is_a?(Groonga::Accessor)
           if index_column.have_next?
             index_column = index_column.next

--- a/test/command/suite/select/function/between/with_index/index_column.expected
+++ b/test/command/suite/select/function/between/with_index/index_column.expected
@@ -1,0 +1,61 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+table_create Ages TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+column_create Ages users_age COLUMN_INDEX Users age
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(Ages.users_age, "18", "include", 20, "include")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/with_index/index_column.test
+++ b/test/command/suite/select/function/between/with_index/index_column.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+table_create Ages TABLE_PAT_KEY Int32
+column_create Ages users_age COLUMN_INDEX Users age
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(Ages.users_age, "18", "include", 20, "include")'


### PR DESCRIPTION
I would like to specify directly index column with ``between()``.