### PR TITLE
httpd: put groonga-httpd.pid under /var/run/groonga/

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1551,7 +1551,7 @@ AM_CONDITIONAL(WITH_GROONGA_HTTPD, test "$enable_groonga_httpd" = "yes")
 
 GROONGA_HTTPD_PID_PATH="`
   test \"$prefix\" = NONE && prefix=/usr/local
-  eval echo ${localstatedir}/run/groonga-httpd.pid
+  eval echo ${localstatedir}/run/groonga/groonga-httpd.pid
 `"
 AC_SUBST(GROONGA_HTTPD_PID_PATH)
 


### PR DESCRIPTION
The default pid path (/var/run/groonga-httpd.pid) and pid path of
groonga-httpd-restart (/var/run/groonga/groonga-httpd.pid) are
different.

This mismatch blocks restarting groonga-httpd.

GitHub: #743

Reported by sozaki. Thanks!!!