### PR TITLE
Support prefix match search using multiple indexes

### DIFF
--- a/test/command/suite/select/query/asterisk/multiple_indexes.expected
+++ b/test/command/suite/select/query/asterisk/multiple_indexes.expected
@@ -1,0 +1,23 @@
+table_create Docs TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Docs title COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Docs body COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+load --table Docs --columns 'title,body'
+[
+["Groonga overview","Full text search engine."],
+["Groonga indexes","Groonga uses inverted ind."],
+["Conclusion","Groonga is good."]
+]
+[[0,0.0,0.0],3]
+table_create Idx TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Idx title COLUMN_INDEX|WITH_POSITION Docs title
+[[0,0.0,0.0],true]
+column_create Idx body COLUMN_INDEX|WITH_POSITION Docs body
+[[0,0.0,0.0],true]
+select   --table Docs   --match_columns 'title||body'   --query 'Groo*'   --output_columns '_id,_score'   --match_escalation_threshold -1
+[[0,0.0,0.0],[[[3],[["_id","UInt32"],["_score","Int32"]],[1,1],[2,2],[3,1]]]]
+select   --table Docs   --match_columns 'body||title'   --query 'Groo*'   --output_columns '_id,_score'   --match_escalation_threshold -1
+[[0,0.0,0.0],[[[3],[["_id","UInt32"],["_score","Int32"]],[2,2],[3,1],[1,1]]]]

--- a/test/command/suite/select/query/asterisk/multiple_indexes.test
+++ b/test/command/suite/select/query/asterisk/multiple_indexes.test
@@ -1,0 +1,30 @@
+table_create Docs TABLE_NO_KEY
+column_create Docs title COLUMN_SCALAR ShortText
+column_create Docs body COLUMN_SCALAR Text
+
+load --table Docs --columns 'title,body'
+[
+["Groonga overview","Full text search engine."],
+["Groonga indexes","Groonga uses inverted ind."],
+["Conclusion","Groonga is good."]
+]
+
+table_create Idx TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Idx title COLUMN_INDEX|WITH_POSITION Docs title
+column_create Idx body COLUMN_INDEX|WITH_POSITION Docs body
+
+select \
+  --table Docs \
+  --match_columns 'title||body' \
+  --query 'Groo*' \
+  --output_columns '_id,_score' \
+  --match_escalation_threshold -1
+
+select \
+  --table Docs \
+  --match_columns 'body||title' \
+  --query 'Groo*' \
+  --output_columns '_id,_score' \
+  --match_escalation_threshold -1


### PR DESCRIPTION
#### Description

The current Groonga does not support prefix match search using multiple indexes.
The following is an example.

```
table_create Tbl TABLE_NO_KEY
# [[0,1501469829.300504,0.0007023811340332031],true]
column_create Tbl title COLUMN_SCALAR ShortText
# [[0,1501469829.30153,0.0002200603485107422],true]
column_create Tbl body COLUMN_SCALAR Text
# [[0,1501469829.302014,0.0001537799835205078],true]

load --table Tbl --columns 'title,body'
[
["Groonga overview","Groonga is a fast and accurate full text search engine based on inverted index."],
["Full text search and Instant update","Groonga also uses inverted indexes but supports instant updates."]
]
# [[0,1501469829.302454,0.00145721435546875],2]

table_create Idx TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
# [[0,1501469829.304491,0.0002417564392089844],true]
column_create Idx title COLUMN_INDEX|WITH_POSITION Tbl title
# [[0,1501469829.305091,0.004905223846435547],true]
column_create Idx body COLUMN_INDEX|WITH_POSITION Tbl body
# [[0,1501469829.310441,0.004695653915405273],true]


# The following select commands must return the same records,
# but the actual results are different.

select Tbl --match_columns 'title||body' --query 'Groo*' --output_columns '_id,_score' --match_escalation_threshold -1
# [[0,1501469829.315903,0.03078055381774902],
#  [[[1],[["_id","UInt32"],["_score","Int32"]],[1,1]]]]

select Tbl --match_columns 'body||title' --query 'Groo*' --output_columns '_id,_score' --match_escalation_threshold -1
# [[0,1501469829.346935,0.0007908344268798828],
#  [[[2],[["_id","UInt32"],["_score","Int32"]],[1,1],[2,1]]]]
```

This pull request changes the result as follows.

```
select Tbl --match_columns 'title||body' --query 'Groo*' --output_columns '_id,_score' --match_escalation_threshold -1
# [[0,1501568194.686332,0.02700471878051758],
#  [[[2],[["_id","UInt32"],["_score","Int32"]],[1,2],[2,1]]]]

select Tbl --match_columns 'body||title' --query 'Groo*' --output_columns '_id,_score' --match_escalation_threshold -1
# [[0,1501568194.713654,0.0007750988006591797],
#  [[[2],[["_id","UInt32"],["_score","Int32"]],[1,2],[2,1]]]]
```
