### PR TITLE
Fix crash when ruby_eval returned syntax error

### DIFF
--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_dot.expected
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_dot.expected
@@ -1,0 +1,15 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval "."
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "exception": {
+      "message": "line 1:1: syntax error, unexpected '.'"
+    }
+  }
+]

--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_dot.test
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_dot.test
@@ -1,0 +1,5 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+ruby_eval "."

--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_end.expected
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_end.expected
@@ -1,0 +1,15 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval "begin"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "exception": {
+      "message": "line 1:5: syntax error, unexpected $end"
+    }
+  }
+]

--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_end.test
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_end.test
@@ -1,0 +1,5 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+ruby_eval "begin"

--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_equal.expected
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_equal.expected
@@ -1,0 +1,15 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval "="
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "exception": {
+      "message": "line 1:1: syntax error, unexpected '='"
+    }
+  }
+]

--- a/test/command/suite/ruby/eval/syntaxerror/unexpected_equal.test
+++ b/test/command/suite/ruby/eval/syntaxerror/unexpected_equal.test
@@ -1,0 +1,5 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+ruby_eval "="


### PR DESCRIPTION
Fixed crash when ruby_eval returned syntax error. (e.g. #751)