### PR TITLE
Support --default-command-version 3

### DIFF
--- a/src/groonga.c
+++ b/src/groonga.c
@@ -3601,18 +3601,7 @@ main(int argc, char **argv)
               default_command_version_arg);
       return EXIT_FAILURE;
     }
-    switch (value) {
-    case 1 :
-      default_command_version = GRN_COMMAND_VERSION_1;
-      break;
-    case 2 :
-      default_command_version = GRN_COMMAND_VERSION_2;
-      break;
-    default :
-      fprintf(stderr, "invalid command version: <%s>\n",
-              default_command_version_arg);
-      return EXIT_FAILURE;
-    }
+    default_command_version = value;
   } else {
     default_command_version = default_default_command_version;
   }


### PR DESCRIPTION
In the previous versions, --default-command-version 3 is not supported.

Before:

  % groonga --default-command-version 3 -n db/db
  invalid command version: <3>

After:

  % groonga --default-command-version 3 -n db/db
  >