### PR TITLE
dat: limit the number of nodes per key

### DIFF
--- a/lib/dat/dat.hpp
+++ b/lib/dat/dat.hpp
@@ -126,6 +126,7 @@ const UInt64 MIN_FILE_SIZE              = 1 << 16;
 const UInt64 DEFAULT_FILE_SIZE          = 1 << 20;
 const UInt64 MAX_FILE_SIZE              = (UInt64)1 << 40;
 const double DEFAULT_NUM_NODES_PER_KEY  = 4.0;
+const double MAX_NUM_NODES_PER_KEY      = 16.0;
 const double DEFAULT_AVERAGE_KEY_LENGTH = 16.0;
 const UInt32 MAX_KEY_BUF_SIZE           = 0x80000000U;
 const UInt32 MAX_TOTAL_KEY_LENGTH       = 0xFFFFFFFFU;

--- a/lib/dat/trie.cpp
+++ b/lib/dat/trie.cpp
@@ -67,7 +67,11 @@ void Trie::create(const char *file_name,
   if (num_nodes_per_key < 1.0) {
     num_nodes_per_key = DEFAULT_NUM_NODES_PER_KEY;
   }
+  if (num_nodes_per_key > MAX_NUM_NODES_PER_KEY) {
+    num_nodes_per_key = MAX_NUM_NODES_PER_KEY;
+  }
   GRN_DAT_THROW_IF(PARAM_ERROR, num_nodes_per_key < 1.0);
+  GRN_DAT_THROW_IF(PARAM_ERROR, num_nodes_per_key > MAX_NUM_NODES_PER_KEY);
 
   if (average_key_length < 1.0) {
     average_key_length = DEFAULT_AVERAGE_KEY_LENGTH;
@@ -105,9 +109,13 @@ void Trie::create(const Trie &trie,
       num_nodes_per_key = DEFAULT_NUM_NODES_PER_KEY;
     } else {
       num_nodes_per_key = 1.0 * trie.num_nodes() / trie.num_keys();
+      if (num_nodes_per_key > MAX_NUM_NODES_PER_KEY) {
+        num_nodes_per_key = MAX_NUM_NODES_PER_KEY;
+      }
     }
   }
   GRN_DAT_THROW_IF(PARAM_ERROR, num_nodes_per_key < 1.0);
+  GRN_DAT_THROW_IF(PARAM_ERROR, num_nodes_per_key > MAX_NUM_NODES_PER_KEY);
 
   if (average_key_length < 1.0) {
     if (trie.num_keys() == 0) {


### PR DESCRIPTION
#### Description

This change limits the number of nodes per key of a dat trie.
If it is unlimited, `grn_dat_rebuild_trie` creates a huge file in the worst case.
