### PR TITLE
Add index_column_source_records() function

### DIFF
--- a/include/groonga/plugin.h
+++ b/include/groonga/plugin.h
@@ -212,6 +212,9 @@ GRN_API grn_obj *grn_plugin_command_create(grn_ctx *ctx,
                                            grn_expr_var *vars);
 
 
+GRN_API int64_t grn_plugin_proc_func_arg_int64(grn_ctx *ctx, grn_obj *arg,
+                                               const char *context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/grn_proc.h
+++ b/lib/grn_proc.h
@@ -94,6 +94,8 @@ grn_operator grn_proc_option_value_mode(grn_ctx *ctx,
                                         grn_operator default_mode,
                                         const char *context);
 
+int64_t grn_proc_func_arg_int64(grn_ctx *ctx, grn_obj *arg,
+                                const char *context);
 
 void grn_proc_output_object_name(grn_ctx *ctx, grn_obj *obj);
 void grn_proc_output_object_id_name(grn_ctx *ctx, grn_id id);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -1394,3 +1394,11 @@ grn_plugin_command_create(grn_ctx *ctx,
                          func, NULL, NULL, n_vars, vars);
   return proc;
 }
+
+
+int64_t
+grn_plugin_proc_func_arg_int64(grn_ctx *ctx, grn_obj *arg,
+                               const char *context)
+{
+  return grn_proc_func_arg_int64(ctx, arg, context);
+}

--- a/plugins/functions/index_column.c
+++ b/plugins/functions/index_column.c
@@ -247,6 +247,76 @@ func_index_column_df_ratio(grn_ctx *ctx,
   }
 }
 
+static grn_obj *
+func_index_column_source_records(grn_ctx *ctx,
+                                 int n_args,
+                                 grn_obj **args,
+                                 grn_user_data *user_data)
+{
+  grn_ii *ii;
+  caller_index_info caller_index_info;
+  int64_t limit = -1;
+
+  if (n_args < 1 || n_args > 2) {
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
+                     "index_column_source_records(): "
+                     "wrong number of arguments (%d for 1..2)", n_args - 1);
+    return NULL;
+  }
+
+  memset(&caller_index_info, 0, sizeof(caller_index_info));
+
+  if (get_caller_index_info(ctx,
+                            args[0],
+                            user_data,
+                            &caller_index_info,
+                            "index_column_source_records()") != GRN_SUCCESS) {
+    return NULL;
+  }
+
+  if (n_args == 2) {
+    limit = grn_plugin_proc_func_arg_int64(ctx, args[1],
+                                           "index_column_source_records()");
+    if (ctx->rc != GRN_SUCCESS) {
+      return NULL;
+    }
+  }
+
+  ii = (grn_ii *)caller_index_info.index_column;
+
+  {
+    grn_obj *records;
+
+    records = grn_plugin_proc_alloc(ctx, user_data,
+                                    grn_obj_get_range(ctx, caller_index_info.index_column),
+                                    GRN_OBJ_VECTOR);
+    if (!records) {
+      return NULL;
+    }
+
+    {
+      grn_ii_cursor *ii_cursor;
+      grn_posting *posting;
+      int64_t n_records = 0;
+      ii_cursor = grn_ii_cursor_open(ctx, ii, caller_index_info.term_id,
+                                     GRN_ID_NIL, GRN_ID_MAX,
+                                     grn_ii_get_n_elements(ctx, ii), 0);
+      if (ii_cursor) {
+        while ((posting = grn_ii_cursor_next(ctx, ii_cursor))) {
+          if (limit > 0 && n_records >= limit) {
+            break;
+          }
+          GRN_RECORD_PUT(ctx, records, posting->rid);
+          n_records++;
+        }
+        grn_ii_cursor_close(ctx, ii_cursor);
+      }
+    }
+    return records;
+  }
+}
+
 grn_rc
 GRN_PLUGIN_INIT(grn_ctx *ctx)
 {
@@ -268,6 +338,10 @@ GRN_PLUGIN_REGISTER(grn_ctx *ctx)
   grn_proc_create(ctx, "index_column_df_ratio", -1,
                   GRN_PROC_FUNCTION,
                   func_index_column_df_ratio, NULL, NULL, 0, NULL);
+
+  grn_proc_create(ctx, "index_column_source_records", -1,
+                  GRN_PROC_FUNCTION,
+                  func_index_column_source_records, NULL, NULL, 0, NULL);
 
   return ctx->rc;
 }

--- a/plugins/functions/index_column.c
+++ b/plugins/functions/index_column.c
@@ -105,17 +105,103 @@ exit :
   return rc;
 }
 
+typedef struct {
+  grn_id term_id;
+  grn_obj *term_table;
+  grn_obj *index_column;
+} caller_index_info;
+
+grn_rc
+get_caller_index_info(grn_ctx *ctx,
+                      grn_obj *index_column_name,
+                      grn_user_data *user_data,
+                      caller_index_info *caller_index_info,
+                      const char *error_message_label)
+{
+  {
+    grn_obj *expr;
+    grn_obj *variable;
+
+    expr = grn_plugin_proc_get_caller(ctx, user_data);
+    if (!expr) {
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "%s: "
+                       "called directly", error_message_label);
+      return ctx->rc;
+    }
+
+    variable = grn_expr_get_var_by_offset(ctx, expr, 0);
+    if (!variable) {
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
+                       "%s: "
+                       "caller expression must have target record information",
+                       error_message_label);
+      return ctx->rc;
+    }
+
+    caller_index_info->term_table = grn_ctx_at(ctx, variable->header.domain);
+    caller_index_info->term_id = GRN_RECORD_VALUE(variable);
+    while (GRN_TRUE) {
+      grn_obj *key_type;
+
+      key_type = grn_ctx_at(ctx, caller_index_info->term_table->header.domain);
+      if (!grn_obj_is_table(ctx, key_type)) {
+        break;
+      }
+
+      grn_table_get_key(ctx,
+                        caller_index_info->term_table,
+                        caller_index_info->term_id,
+                        &(caller_index_info->term_id),
+                        sizeof(grn_id));
+      caller_index_info->term_table = key_type;
+    }
+  }
+
+  if (!grn_obj_is_text_family_bulk(ctx, index_column_name)) {
+    grn_obj inspected;
+    GRN_TEXT_INIT(&inspected, 0);
+    grn_inspect(ctx, &inspected, index_column_name);
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
+                     "%s: "
+                     "the first argument must be index column name: %.*s",
+                     error_message_label,
+                     (int)GRN_TEXT_LEN(&inspected),
+                     GRN_TEXT_VALUE(&inspected));
+    GRN_OBJ_FIN(ctx, &inspected);
+    return ctx->rc;
+  }
+
+  caller_index_info->index_column = grn_obj_column(ctx,
+                                                   caller_index_info->term_table,
+                                                   GRN_TEXT_VALUE(index_column_name),
+                                                   GRN_TEXT_LEN(index_column_name));
+  if (!caller_index_info->index_column) {
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
+                     "%s: "
+                     "nonexistent object: <%.*s>",
+                     error_message_label,
+                     (int)GRN_TEXT_LEN(index_column_name),
+                     GRN_TEXT_VALUE(index_column_name));
+    return ctx->rc;
+  }
+
+  return GRN_SUCCESS;
+}
+
+
 static grn_obj *
 func_index_column_df_ratio(grn_ctx *ctx,
                            int n_args,
                            grn_obj **args,
                            grn_user_data *user_data)
 {
-  grn_obj *term_table;
-  grn_obj *index_column_name;
-  grn_obj *index_column;
   grn_ii *ii;
-  grn_id term_id;
+  caller_index_info caller_index_info;
 
   if (n_args != 1) {
     GRN_PLUGIN_ERROR(ctx,
@@ -125,90 +211,17 @@ func_index_column_df_ratio(grn_ctx *ctx,
     return NULL;
   }
 
-  {
-    grn_obj *expr;
-    grn_obj *variable;
+  memset(&caller_index_info, 0, sizeof(caller_index_info));
 
-    expr = grn_plugin_proc_get_caller(ctx, user_data);
-    if (!expr) {
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "index_column_df_ratio(): "
-                       "called directly");
-      return NULL;
-    }
-
-    variable = grn_expr_get_var_by_offset(ctx, expr, 0);
-    if (!variable) {
-      GRN_PLUGIN_ERROR(ctx,
-                       GRN_INVALID_ARGUMENT,
-                       "index_column_df_ratio(): "
-                       "caller expression must have target record information");
-      return NULL;
-    }
-
-    term_table = grn_ctx_at(ctx, variable->header.domain);
-    term_id = GRN_RECORD_VALUE(variable);
-    while (GRN_TRUE) {
-      grn_obj *key_type;
-
-      key_type = grn_ctx_at(ctx, term_table->header.domain);
-      if (!grn_obj_is_table(ctx, key_type)) {
-        break;
-      }
-
-      grn_table_get_key(ctx, term_table, term_id, &term_id, sizeof(grn_id));
-      term_table = key_type;
-    }
-  }
-
-  index_column_name = args[0];
-  if (!grn_obj_is_text_family_bulk(ctx, index_column_name)) {
-    grn_obj inspected;
-    GRN_TEXT_INIT(&inspected, 0);
-    grn_inspect(ctx, &inspected, index_column_name);
-    GRN_PLUGIN_ERROR(ctx,
-                     GRN_INVALID_ARGUMENT,
-                     "index_column_df_ratio(): "
-                     "the first argument must be index column name: %.*s",
-                     (int)GRN_TEXT_LEN(&inspected),
-                     GRN_TEXT_VALUE(&inspected));
-    GRN_OBJ_FIN(ctx, &inspected);
+  if (get_caller_index_info(ctx,
+                            args[0],
+                            user_data,
+                            &caller_index_info,
+                            "index_column_df_ratio()") != GRN_SUCCESS) {
     return NULL;
   }
 
-  index_column = grn_obj_column(ctx,
-                                term_table,
-                                GRN_TEXT_VALUE(index_column_name),
-                                GRN_TEXT_LEN(index_column_name));
-  if (!index_column) {
-    GRN_PLUGIN_ERROR(ctx,
-                     GRN_INVALID_ARGUMENT,
-                     "index_column_df_ratio(): "
-                     "nonexistent object: <%.*s>",
-                     (int)GRN_TEXT_LEN(index_column_name),
-                     GRN_TEXT_VALUE(index_column_name));
-    return NULL;
-  }
-
-  if (!grn_obj_is_index_column(ctx, index_column)) {
-    grn_obj inspected;
-    GRN_TEXT_INIT(&inspected, 0);
-    grn_inspect(ctx, &inspected, index_column);
-    GRN_PLUGIN_ERROR(ctx,
-                     GRN_INVALID_ARGUMENT,
-                     "index_column_df_ratio(): "
-                     "the first argument must be index column: %.*s",
-                     (int)GRN_TEXT_LEN(&inspected),
-                     GRN_TEXT_VALUE(&inspected));
-    GRN_OBJ_FIN(ctx, &inspected);
-    if (grn_obj_is_accessor(ctx, index_column)) {
-      grn_obj_unlink(ctx, index_column);
-    }
-    return NULL;
-  }
-
-  ii = (grn_ii *)index_column;
+  ii = (grn_ii *)caller_index_info.index_column;
 
   {
     grn_obj *source_table;
@@ -217,9 +230,9 @@ func_index_column_df_ratio(grn_ctx *ctx,
     double df_ratio;
     grn_obj *df_ratio_value;
 
-    source_table = grn_ctx_at(ctx, grn_obj_get_range(ctx, index_column));
+    source_table = grn_ctx_at(ctx, grn_obj_get_range(ctx, caller_index_info.index_column));
     n_documents = grn_table_size(ctx, source_table);
-    n_match_documents = grn_ii_estimate_size(ctx, ii, term_id);
+    n_match_documents = grn_ii_estimate_size(ctx, ii, caller_index_info.term_id);
     if (n_match_documents > n_documents) {
       n_match_documents = n_documents;
     }

--- a/test/command/suite/select/function/index_column/index_column_source_records/default.expected
+++ b/test/command/suite/select/function/index_column/index_column_source_records/default.expected
@@ -1,0 +1,179 @@
+plugin_register functions/index_column
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos _key
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is a fast full text search engine."},
+{"_key": "Mroonga is a MySQL storage engine based on Groonga."},
+{"_key": "Rroonga is a Ruby bindings for Groonga."}
+]
+[[0,0.0,0.0],3]
+select Terms   --limit -1   --sort_keys _id   --columns[index_records].stage output   --columns[index_records].type Memos   --columns[index_records].flags COLUMN_VECTOR   --columns[index_records].value 'index_column_source_records("index")'   --output_columns '_id, _key, index_records'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        18
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "index_records",
+          "Memos"
+        ]
+      ],
+      [
+        1,
+        "groonga",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga.",
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        2,
+        "is",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga.",
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        3,
+        "a",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga.",
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        4,
+        "fast",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        5,
+        "full",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        6,
+        "text",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        7,
+        "search",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        8,
+        "engine",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        9,
+        ".",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga.",
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        10,
+        "mroonga",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        11,
+        "mysql",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        12,
+        "storage",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        13,
+        "based",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        14,
+        "on",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        15,
+        "rroonga",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        16,
+        "ruby",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        17,
+        "bindings",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        18,
+        "for",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/index_column/index_column_source_records/default.test
+++ b/test/command/suite/select/function/index_column/index_column_source_records/default.test
@@ -1,0 +1,24 @@
+plugin_register functions/index_column
+
+table_create Memos TABLE_HASH_KEY ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos _key
+
+load --table Memos
+[
+{"_key": "Groonga is a fast full text search engine."},
+{"_key": "Mroonga is a MySQL storage engine based on Groonga."},
+{"_key": "Rroonga is a Ruby bindings for Groonga."}
+]
+
+select Terms \
+  --limit -1 \
+  --sort_keys _id \
+  --columns[index_records].stage output \
+  --columns[index_records].type Memos \
+  --columns[index_records].flags COLUMN_VECTOR \
+  --columns[index_records].value 'index_column_source_records("index")' \
+  --output_columns '_id, _key, index_records'

--- a/test/command/suite/select/function/index_column/index_column_source_records/limit.expected
+++ b/test/command/suite/select/function/index_column/index_column_source_records/limit.expected
@@ -1,0 +1,175 @@
+plugin_register functions/index_column
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos _key
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is a fast full text search engine."},
+{"_key": "Mroonga is a MySQL storage engine based on Groonga."},
+{"_key": "Rroonga is a Ruby bindings for Groonga."}
+]
+[[0,0.0,0.0],3]
+select Terms   --limit -1   --sort_keys _id   --columns[index_records].stage output   --columns[index_records].type Memos   --columns[index_records].flags COLUMN_VECTOR   --columns[index_records].value 'index_column_source_records("index", 2)'   --output_columns '_id, _key, index_records'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        18
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "index_records",
+          "Memos"
+        ]
+      ],
+      [
+        1,
+        "groonga",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        2,
+        "is",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        3,
+        "a",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        4,
+        "fast",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        5,
+        "full",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        6,
+        "text",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        7,
+        "search",
+        [
+          "Groonga is a fast full text search engine."
+        ]
+      ],
+      [
+        8,
+        "engine",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        9,
+        ".",
+        [
+          "Groonga is a fast full text search engine.",
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        10,
+        "mroonga",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        11,
+        "mysql",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        12,
+        "storage",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        13,
+        "based",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        14,
+        "on",
+        [
+          "Mroonga is a MySQL storage engine based on Groonga."
+        ]
+      ],
+      [
+        15,
+        "rroonga",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        16,
+        "ruby",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        17,
+        "bindings",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ],
+      [
+        18,
+        "for",
+        [
+          "Rroonga is a Ruby bindings for Groonga."
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/index_column/index_column_source_records/limit.test
+++ b/test/command/suite/select/function/index_column/index_column_source_records/limit.test
@@ -1,0 +1,24 @@
+plugin_register functions/index_column
+
+table_create Memos TABLE_HASH_KEY ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos _key
+
+load --table Memos
+[
+{"_key": "Groonga is a fast full text search engine."},
+{"_key": "Mroonga is a MySQL storage engine based on Groonga."},
+{"_key": "Rroonga is a Ruby bindings for Groonga."}
+]
+
+select Terms \
+  --limit -1 \
+  --sort_keys _id \
+  --columns[index_records].stage output \
+  --columns[index_records].type Memos \
+  --columns[index_records].flags COLUMN_VECTOR \
+  --columns[index_records].value 'index_column_source_records("index", 2)' \
+  --output_columns '_id, _key, index_records'


### PR DESCRIPTION
I would like to add function to retrieve source records of index column in order to efficiently get value of referenced column such as parent-child relationship.

Syntax:
```c
  index_column_source_records(index_column_name[, limit])
```

*  index_column_name: name of index columns as string
* limit(option): number of records to get (default: -1, -1 means all records)