### PR TITLE
index_column_source_records: fix memory leak

### DIFF
--- a/plugins/functions/index_column.c
+++ b/plugins/functions/index_column.c
@@ -315,6 +315,7 @@ func_index_column_source_records(grn_ctx *ctx,
           }
 #undef KEY_EQUAL
         }
+        grn_hash_cursor_close(ctx, cursor);
       }
       break;
     default :


### PR DESCRIPTION
Sorry. I missed it.