### PR TITLE
grndb: add --force-lock-clear option

### DIFF
--- a/lib/mrb/mrb_column.c
+++ b/lib/mrb/mrb_column.c
@@ -111,6 +111,16 @@ mrb_grn_column_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_column_unlock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_column_get_table(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -163,11 +173,14 @@ grn_mrb_column_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_column_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "unlock",
+                    mrb_grn_column_unlock, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "table",
                     mrb_grn_column_get_table, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "truncate",
                     mrb_grn_column_truncate, MRB_ARGS_NONE());
+
 }
 #endif

--- a/lib/mrb/mrb_database.c
+++ b/lib/mrb/mrb_database.c
@@ -97,6 +97,17 @@ mrb_grn_database_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_database_unlock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_database_get_last_modified(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -196,6 +207,8 @@ grn_mrb_database_init(grn_ctx *ctx)
                     mrb_grn_database_recover, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_database_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "unlock",
+                    mrb_grn_database_unlock, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "last_modified",
                     mrb_grn_database_get_last_modified, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "dirty?",

--- a/lib/mrb/mrb_table.c
+++ b/lib/mrb/mrb_table.c
@@ -177,6 +177,16 @@ mrb_grn_table_is_locked(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_table_unlock(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_obj_clear_lock(ctx, DATA_PTR(self));
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_table_get_size(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -466,6 +476,8 @@ grn_mrb_table_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "locked?",
                     mrb_grn_table_is_locked, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "unlock",
+                    mrb_grn_table_unlock, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "size",
                     mrb_grn_table_get_size, MRB_ARGS_NONE());

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -61,6 +61,27 @@ object corrupt: <[db][recover] column may be broken: <Users.age>: please truncat
     assert_equal("", result.error_output)
   end
 
+  def test_force_clear_locked_database
+    groonga("lock_acquire")
+    result = grndb("recover", "--force-lock-clear")
+    assert_equal("", result.error_output)
+  end
+
+  def test_force_clear_locked_table
+    groonga("table_create", "Users", "TABLE_HASH_KEY", "ShortText")
+    groonga("lock_acquire", "Users")
+    result = grndb("recover", "--force-lock-clear")
+    assert_equal("", result.error_output)
+  end
+
+  def test_force_clear_locked_data_column
+    groonga("table_create", "Users", "TABLE_HASH_KEY", "ShortText")
+    groonga("column_create", "Users", "age", "COLUMN_SCALAR", "UInt8")
+    groonga("lock_acquire", "Users.age")
+    result = grndb("recover", "--force-lock-clear")
+    assert_equal("", result.error_output)
+  end
+
   def test_empty_file
     groonga("table_create", "Users", "TABLE_HASH_KEY", "ShortText")
     _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][1]


### PR DESCRIPTION
This option force to clear lock of object(Database, Column, Table).
You can use if you want to database recover even if remain locked of database.

But this option very risky.
Because can not safty recover database if remain locked of database.

Usage:
  grndb recover --force-lock-clear DB_PATH