### PR TITLE
load: support surrogate pairs

### DIFF
--- a/lib/grn_ctx_impl.h
+++ b/lib/grn_ctx_impl.h
@@ -85,6 +85,7 @@ typedef struct {
   grn_obj *ifexists;
   grn_obj *each;
   uint32_t unichar;
+  uint32_t unichar_hi;
   uint32_t values_size;
   uint32_t nrecords;
   uint32_t n_record_errors;

--- a/test/command/suite/load/surrogate_pair/emoji.expected
+++ b/test/command/suite/load/surrogate_pair/emoji.expected
@@ -1,0 +1,38 @@
+table_create Characters TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Characters unicode COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Characters
+[
+{"_key": "\uD83C\uDF7A", "unicode": "U+1F37A BEER MUG"}
+]
+[[0,0.0,0.0],1]
+select Characters --output_columns _key,unicode
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "unicode",
+          "ShortText"
+        ]
+      ],
+      [
+        "🍺",
+        "U+1F37A BEER MUG"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/load/surrogate_pair/emoji.test
+++ b/test/command/suite/load/surrogate_pair/emoji.test
@@ -1,0 +1,9 @@
+table_create Characters TABLE_HASH_KEY ShortText
+column_create Characters unicode COLUMN_SCALAR ShortText
+
+load --table Characters
+[
+{"_key": "\uD83C\uDF7A", "unicode": "U+1F37A BEER MUG"}
+]
+
+select Characters --output_columns _key,unicode

--- a/test/command/suite/load/surrogate_pair/normalize.expected
+++ b/test/command/suite/load/surrogate_pair/normalize.expected
@@ -1,0 +1,38 @@
+table_create Characters TABLE_HASH_KEY|KEY_NORMALIZE ShortText
+[[0,0.0,0.0],true]
+column_create Characters unicode COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Characters
+[
+{"_key": "\uD835\uDC00", "unicode": "U+1D400 MATHEMATICAL BOLD CAPITAL A"}
+]
+[[0,0.0,0.0],1]
+select Characters --filter '_key == "A"' --output_columns _key,unicode
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "unicode",
+          "ShortText"
+        ]
+      ],
+      [
+        "a",
+        "U+1D400 MATHEMATICAL BOLD CAPITAL A"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/load/surrogate_pair/normalize.test
+++ b/test/command/suite/load/surrogate_pair/normalize.test
@@ -1,0 +1,9 @@
+table_create Characters TABLE_HASH_KEY|KEY_NORMALIZE ShortText
+column_create Characters unicode COLUMN_SCALAR ShortText
+
+load --table Characters
+[
+{"_key": "\uD835\uDC00", "unicode": "U+1D400 MATHEMATICAL BOLD CAPITAL A"}
+]
+
+select Characters --filter '_key == "A"' --output_columns _key,unicode

--- a/test/command/suite/load/surrogate_pair/raw.expected
+++ b/test/command/suite/load/surrogate_pair/raw.expected
@@ -1,0 +1,38 @@
+table_create Characters TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Characters unicode COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Characters
+[
+{"_key": "\uD835\uDC00", "unicode": "U+1D400 MATHEMATICAL BOLD CAPITAL A"}
+]
+[[0,0.0,0.0],1]
+select Characters --output_columns _key,unicode
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "unicode",
+          "ShortText"
+        ]
+      ],
+      [
+        "𝐀",
+        "U+1D400 MATHEMATICAL BOLD CAPITAL A"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/load/surrogate_pair/raw.test
+++ b/test/command/suite/load/surrogate_pair/raw.test
@@ -1,0 +1,9 @@
+table_create Characters TABLE_HASH_KEY ShortText
+column_create Characters unicode COLUMN_SCALAR ShortText
+
+load --table Characters
+[
+{"_key": "\uD835\uDC00", "unicode": "U+1D400 MATHEMATICAL BOLD CAPITAL A"}
+]
+
+select Characters --output_columns _key,unicode


### PR DESCRIPTION
#### Description

This commit supports surrogate pairs in a `load` body.
For example, `\uD83C\uDF7A` is decoded to `🍺`.
