### PR TITLE
between: accept between() without borders

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -2590,32 +2590,33 @@ static grn_rc
 between_parse_args(grn_ctx *ctx, int nargs, grn_obj **args, between_data *data)
 {
   grn_rc rc = GRN_SUCCESS;
-  grn_obj *min_border;
-  grn_obj *max_border;
-
-  if (nargs != 5) {
-    ERR(GRN_INVALID_ARGUMENT,
-        "between(): wrong number of arguments (%d for 5)", nargs);
-    rc = ctx->rc;
-    goto exit;
-  }
 
   data->value = args[0];
   data->min   = args[1];
-  min_border  = args[2];
-  data->max   = args[3];
-  max_border  = args[4];
-
-  data->min_border_type =
-    between_parse_border(ctx, min_border, "the 3rd argument (min_border)");
-  if (data->min_border_type == BETWEEN_BORDER_INVALID) {
-    rc = ctx->rc;
-    goto exit;
-  }
-
-  data->max_border_type =
-    between_parse_border(ctx, max_border, "the 5th argument (max_border)");
-  if (data->max_border_type == BETWEEN_BORDER_INVALID) {
+  switch (nargs) {
+  case 3 :
+    data->min_border_type = BETWEEN_BORDER_INCLUDE;
+    data->max = args[2];
+    data->max_border_type = BETWEEN_BORDER_INCLUDE;
+    break;
+  case 5 :
+    data->min_border_type =
+      between_parse_border(ctx, args[2], "the 3rd argument (min_border)");
+    if (data->min_border_type == BETWEEN_BORDER_INVALID) {
+      rc = ctx->rc;
+      goto exit;
+    }
+    data->max = args[3];
+    data->max_border_type =
+      between_parse_border(ctx, args[4], "the 5th argument (max_border)");
+    if (data->max_border_type == BETWEEN_BORDER_INVALID) {
+      rc = ctx->rc;
+      goto exit;
+    }
+    break;
+  default :
+    ERR(GRN_INVALID_ARGUMENT,
+        "between(): wrong number of arguments (%d for 3 or 5)", nargs);
     rc = ctx->rc;
     goto exit;
   }

--- a/test/command/suite/select/function/between/with_index/without_borders.expected
+++ b/test/command/suite/select/function/between/with_index/without_borders.expected
@@ -1,0 +1,61 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+table_create Ages TABLE_PAT_KEY Int32
+[[0,0.0,0.0],true]
+column_create Ages users_age COLUMN_INDEX Users age
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 18, 20)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/with_index/without_borders.test
+++ b/test/command/suite/select/function/between/with_index/without_borders.test
@@ -1,0 +1,16 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+table_create Ages TABLE_PAT_KEY Int32
+column_create Ages users_age COLUMN_INDEX Users age
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 18, 20)'

--- a/test/command/suite/select/function/between/without_index/without_borders.expected
+++ b/test/command/suite/select/function/between/without_index/without_borders.expected
@@ -1,0 +1,57 @@
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users age COLUMN_SCALAR Int32
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+[[0,0.0,0.0],5]
+select Users --filter 'between(age, 18, 20)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "age",
+          "Int32"
+        ]
+      ],
+      [
+        2,
+        "bob",
+        18
+      ],
+      [
+        3,
+        "calros",
+        19
+      ],
+      [
+        4,
+        "dave",
+        20
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/between/without_index/without_borders.test
+++ b/test/command/suite/select/function/between/without_index/without_borders.test
@@ -1,0 +1,13 @@
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users age COLUMN_SCALAR Int32
+
+load --table Users
+[
+{"_key": "alice",  "age": 17},
+{"_key": "bob",    "age": 18},
+{"_key": "calros", "age": 19},
+{"_key": "dave",   "age": 20},
+{"_key": "eric",   "age": 21}
+]
+
+select Users --filter 'between(age, 18, 20)'


### PR DESCRIPTION
If the number of arguments passed to between() is 3, the 2nd and 3rd arguments are handled as the inclusive edges.

GitHub: fix #685 

----

I'm not sure this change is acceptable.
