### PR TITLE
doc logical_select: fix a typo

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference.po
+++ b/doc/locale/ja/LC_MESSAGES/reference.po
@@ -223,6 +223,12 @@ msgstr ""
 "Groongaを全文検索ライブラリとして使うことができます。この節ではGroongaが提供"
 "しているAPIを示します。"
 
+msgid "パラメータ"
+msgstr ""
+
+msgid "戻り値"
+msgstr ""
+
 msgid "Global configurations"
 msgstr "全体設定"
 
@@ -4478,12 +4484,6 @@ msgstr ""
 "``HEADER`` については :doc:`/reference/command/output_format` を参照してくだ"
 "さい。"
 
-msgid ""
-"The number of kinds of index target data and the number of handleable "
-"records in a small index column"
-msgstr ""
-"インデックス対象データの種類数と小さなインデックスカラムで扱えるレコード数"
-
 msgid "``column_create``"
 msgstr ""
 
@@ -5022,6 +5022,12 @@ msgstr ""
 "``2`` 、 ``3`` というデータが入っていたとすると、種類数は ``3`` （ ``1`` と "
 "``2`` と ``3`` ）になります。以下の表はインデックス対象データの種類数と扱える"
 "最大レコード数の関係を示しています。"
+
+msgid ""
+"The number of kinds of index target data and the number of handleable "
+"records in a small index column"
+msgstr ""
+"インデックス対象データの種類数と小さなインデックスカラムで扱えるレコード数"
 
 msgid "The number of kinds of index target data"
 msgstr "インデックス対象のデータの種類数"
@@ -8163,10 +8169,10 @@ msgstr ""
 "ものなら、論理テーブル名は ``Entries`` です。"
 
 msgid ""
-"You can show 10 records by specifying ``logical_table`` and ``shard_key`` "
+"You can show 5 records by specifying ``logical_table`` and ``shard_key`` "
 "parameters. They are required parameters."
 msgstr ""
-"``logical_table`` と ``shard_key`` 引数を指定すると10レコード表示できます。こ"
+"``logical_table`` と ``shard_key`` 引数を指定すると5レコード表示できます。こ"
 "れらの引数は必須の引数です。"
 
 msgid "See :ref:`logical-select-logical-table` how to specify ``shard_key``."
@@ -25817,9 +25823,6 @@ msgid ""
 "records are fetched."
 msgstr ""
 
-msgid "Characteristics of all tables"
-msgstr "全テーブルの特徴"
-
 msgid "Tables"
 msgstr "テーブル"
 
@@ -25852,6 +25855,9 @@ msgid ""
 msgstr ""
 "以下はGroongaにあるすべてのテーブルの特性表です。（この表の中では ``TABLE_`` "
 "プレフィックスは省略しています。）"
+
+msgid "Characteristics of all tables"
+msgstr "全テーブルの特徴"
 
 msgid "Item"
 msgstr ""

--- a/doc/source/reference/commands/logical_select.rst
+++ b/doc/source/reference/commands/logical_select.rst
@@ -283,7 +283,7 @@ Specifies logical table name. It means table name without
 ``Entries_20150708``, ``Entries_20150709`` and so on, logical table
 name is ``Entries``.
 
-You can show 10 records by specifying ``logical_table`` and
+You can show 5 records by specifying ``logical_table`` and
 ``shard_key`` parameters. They are required parameters.
 
 .. groonga-command


### PR DESCRIPTION
Because the number of records is different from the example.