### PR TITLE
file_lock: Copy path to buffer to avoid storing a pointer to a local buffer.

### DIFF
--- a/lib/file_lock.c
+++ b/lib/file_lock.c
@@ -42,7 +42,7 @@ grn_file_lock_init(grn_ctx *ctx,
                    grn_file_lock *file_lock,
                    const char *path)
 {
-  file_lock->path = path;
+  grn_strcpy(file_lock->path, PATH_MAX, path);
 #ifdef WIN32
   file_lock->handle = INVALID_HANDLE_VALUE;
 #else /* WIN32 */
@@ -109,7 +109,7 @@ grn_file_lock_release(grn_ctx *ctx, grn_file_lock *file_lock)
 
   file_lock->fd = -1;
 #endif /* WIN32 */
-  file_lock->path = NULL;
+  grn_strcpy(file_lock->path, PATH_MAX, "");
 }
 
 void

--- a/lib/grn_file_lock.h
+++ b/lib/grn_file_lock.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 typedef struct {
-  const char *path;
+  char path[PATH_MAX];
 #ifdef WIN32
   HANDLE handle;
 #else /* WIN32 */


### PR DESCRIPTION
`grn_file_lock` should have path buffer in its struct to prevent storing a pointer to a stack local buffer.