### PR TITLE
Generational lock

### DIFF
--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -110,4 +110,6 @@ libgroonga_c_sources =				\
 	window_function.c			\
 	grn_window_function.h			\
 	window_functions.c			\
-	grn_window_functions.h
+	grn_window_functions.h \
+  gen.c \
+  grn_gen.h

--- a/lib/ctx.c
+++ b/lib/ctx.c
@@ -35,6 +35,7 @@
 #include "grn_logger.h"
 #include "grn_cache.h"
 #include "grn_expr.h"
+#include "grn_gen.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <time.h>
@@ -1545,6 +1546,7 @@ grn_ctx_use(grn_ctx *ctx, grn_obj *db)
         grn_obj_get_info(ctx, db, GRN_INFO_ENCODING, &buf);
         ctx->encoding = *(grn_encoding *)GRN_BULK_HEAD(&buf);
         grn_obj_close(ctx, &buf);
+        ctx->rc = grn_gen_init(ctx, db);
       }
     }
   }

--- a/lib/db.c
+++ b/lib/db.c
@@ -217,6 +217,7 @@ grn_db_create(grn_ctx *ctx, const char *path, grn_db_create_optarg *optarg)
   s->specs = NULL;
   s->config = NULL;
   s->cache = NULL;
+  s->gen = NULL;
 
   {
     grn_bool use_default_db_key = GRN_TRUE;
@@ -335,6 +336,7 @@ grn_db_open(grn_ctx *ctx, const char *path)
   s->specs = NULL;
   s->config = NULL;
   s->cache = NULL;
+  s->gen = NULL;
 
   {
     uint32_t type = grn_io_detect_type(ctx, path);
@@ -448,6 +450,9 @@ grn_db_close(grn_ctx *ctx, grn_obj *db)
   GRN_API_ENTER;
 
   ctx_used_db = ctx->impl && ctx->impl->db == db;
+  if (ctx_used_db) {
+    grn_gen_fin(ctx, s);
+  }
   if (ctx_used_db) {
     grn_ctx_loader_clear(ctx);
     if (ctx->impl->parser) {

--- a/lib/file_lock.c
+++ b/lib/file_lock.c
@@ -42,7 +42,7 @@ grn_file_lock_init(grn_ctx *ctx,
                    grn_file_lock *file_lock,
                    const char *path)
 {
-  file_lock->path = path;
+  grn_strcpy(file_lock->path, PATH_MAX, path);
 #ifdef WIN32
   file_lock->handle = INVALID_HANDLE_VALUE;
 #else /* WIN32 */
@@ -109,7 +109,7 @@ grn_file_lock_release(grn_ctx *ctx, grn_file_lock *file_lock)
 
   file_lock->fd = -1;
 #endif /* WIN32 */
-  file_lock->path = NULL;
+  grn_strcpy(file_lock->path, PATH_MAX, "");
 }
 
 void

--- a/lib/file_lock.c
+++ b/lib/file_lock.c
@@ -165,7 +165,7 @@ grn_file_lock_close(grn_ctx *ctx, grn_file_lock *file_lock)
   close(file_lock->fd);
   file_lock->fd = -1;
 #endif /* WIN32 */
-  file_lock->path = NULL;
+  grn_strcpy(file_lock->path, PATH_MAX, "");
 }
 
 void

--- a/lib/gen.c
+++ b/lib/gen.c
@@ -36,7 +36,7 @@
 int
 gen_file_is_valid(grn_gen *gen)
 {
-#ifdef _WIN32
+#ifdef WIN32
   return gen->hFile != INVALID_HANDLE_VALUE;
 #else
   return gen->fd != -1;
@@ -56,7 +56,7 @@ gen_id_is_newer(grn_gen *gen, int id)
 void
 gen_flock(grn_gen *gen)
 {
-#ifdef _WIN32
+#ifdef WIN32
   LockFileEx((gen)->hFile, LOCKFILE_EXCLUSIVE_LOCK, 0, TESTSTRLEN, 0, 0);
 #else
   flock((gen)->fd, LOCK_EX);
@@ -66,13 +66,13 @@ gen_flock(grn_gen *gen)
 int
 gen_file_open(grn_gen *gen, const char *path)
 {
-#ifdef _WIN32
+#ifdef WIN32
     gen->hFile = OpenFile(path, NULL, OF_READWRITE);
 #else
     gen->fd = open(path, O_RDWR);
 #endif
     if (!gen_file_is_valid(gen)) return 0;
-#ifdef _WIN32
+#ifdef WIN32
     return LockFileEx(gen->hFile,
         LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY,
         0, TESTSTRLEN, 0, 0);
@@ -84,7 +84,7 @@ gen_file_open(grn_gen *gen, const char *path)
 void
 gen_file_close(grn_gen *gen)
 {
-#ifdef _WIN32
+#ifdef WIN32
   CloseHandle(gen->hFile);
 #else
   close(gen->fd);
@@ -94,7 +94,7 @@ gen_file_close(grn_gen *gen)
 int
 gen_file_exist(const char *path)
 {
-#ifdef _WIN32
+#ifdef WIN32
   return GetFileAttributes(path) != INVALID_FILE_ATTRIBUTES;
 #else
   return access(path, F_OK) == 0;
@@ -104,7 +104,7 @@ gen_file_exist(const char *path)
 int
 gen_file_new(grn_gen *gen, const char *path)
 {
-#ifdef _WIN32
+#ifdef WIN32
     gen->hFile = CreateFile(path, GENERIC_READ|GENERIC_WRITE, 0,
         NULL, CREATE_NEW, 0, 0, 0, NULL);
     return gen->hFile != INVALID_HANDLE_VALUE;

--- a/lib/gen.c
+++ b/lib/gen.c
@@ -27,6 +27,16 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+/*
+ * bit layout of generational lock
+ *
+ * [sggggggg ggggcccc cccccccc cccccccc] uint32_t
+ *
+ * s: sign 1 bit
+ * g: generation id 11 bits
+ * c: lock count 20 bits
+ */
+
 #define LOCK_COUNT_MASK   ((1 << (31 - 11)) - 1) // 20 bits
 #define GEN_ID_MASK       (0xFFF00000) // 11 bits and sign bit
 #define GEN_ID_SHIFT      (20)

--- a/lib/gen.c
+++ b/lib/gen.c
@@ -30,10 +30,12 @@
 /*
  * bit layout of generational lock
  *
- * [sggggggg ggggcccc cccccccc cccccccc] uint32_t
+ * [sGGGGGGG Ggggcccc cccccccc cccccccc] uint32_t
  *
  * s: sign 1 bit
- * g: generation id 11 bits
+ * G, g: generation id 11 bits
+ *   G: table index 8 bits
+ *   g: position in the table 3 bits
  * c: lock count 20 bits
  */
 

--- a/lib/gen.c
+++ b/lib/gen.c
@@ -1,0 +1,156 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2015 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "grn_gen.h"
+#include "grn_ctx.h"
+#include "grn_db.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+void
+gen_flock(grn_gen *gen)
+{
+#ifdef _WIN32
+  LockFileEx((gen)->hFile, LOCKFILE_EXCLUSIVE_LOCK, 0, TESTSTRLEN, 0, 0);
+#else
+  flock((gen)->fd, LOCK_EX);
+#endif
+}
+
+int
+gen_flock_nb(grn_gen *gen)
+{
+#ifdef _WIN32
+  return LockFileEx((gen)->hFile,
+      LOCKFILE_EXCLUSIVE_LOCK|LOCKFILE_FAIL_IMMEDIATELY, 0, TESTSTRLEN, 0, 0);
+#else
+  return flock((gen)->fd, LOCK_EX|LOCK_NB) != -1;
+#endif
+}
+
+int
+gen_open_file(grn_gen *gen, const char *path)
+{
+#ifdef _WIN32
+    gen->hFile = OpenFile(path, NULL, OF_READWRITE);
+    return gen->hFile != HFILE_ERROR;
+#else
+    gen->fd = open(path, O_RDWR);
+    return gen->fd != -1;
+#endif
+}
+
+void
+gen_close_file(grn_gen *gen)
+{
+#ifdef _WIN32
+  CloseHandle(gen->hFile);
+#else
+  close(gen->fd);
+#endif
+}
+
+int
+gen_new_file(grn_gen *gen, const char *path)
+{
+#ifdef _WIN32
+    gen->hFile = CreateFile(path, GENERIC_READ|GENERIC_WRITE, 0,
+        NULL, CREATE_NEW, 0, FILE_FLAG_DELETE_ON_CLOSE, 0, NULL);
+    return gen->hFile != INVALID_HANDLE_VALUE;
+#else
+    gen->fd = open(path, O_RDWR|O_CREAT|O_EXCL);
+    return gen->fd != -1;
+#endif
+}
+
+int
+gen_is_valid_file(grn_gen *gen)
+{
+#ifdef _WIN32
+  return gen->hFile != INVALID_HANDLE_VALUE;
+#else
+  return gen->fd != -1;
+#endif
+}
+
+void
+grn_gen_path_fill(grn_ctx *ctx, grn_db *db, int id, char *path)
+{
+  const char *db_path = grn_obj_path(ctx, (grn_obj*)db);
+  grn_snprintf(path, PATH_MAX, PATH_MAX, "%s.gen.%03X", db_path, id);
+}
+
+grn_rc
+grn_gen_init(grn_ctx *ctx, grn_db *db)
+{
+  if (db->gen) {
+    return GRN_SUCCESS;
+  }
+
+  grn_gen *gen = GRN_MALLOC(sizeof(grn_gen));
+  char gen_path[PATH_MAX];
+  uint16_t min = GRN_GEN_SIZE - 1, max = 0;
+  for(int i = 0; i < GRN_GEN_SIZE; i++){
+    int n = i>>3, m = i&0x7, o = 1<<m;
+    if (m == 0) {
+      gen->table[n] = 0;
+    }
+    grn_gen_path_fill(ctx, db, i, gen_path);
+    printf("****%s\n", gen_path);
+    if (gen_open_file(gen, gen_path)) {
+      if (i < min) min = i;
+      if (i > max) max = i;
+      if (!gen_flock_nb(gen)) { // alive
+        gen->table[n] |= o;
+      } else { // crashed
+        gen_close_file(gen);
+        unlink(gen_path);
+      }
+    }
+  }
+  gen->id = (max - min < GRN_GEN_SIZE/2) ? max : min;
+  for(int i = 0; i < GRN_GEN_SIZE/2; i++) {
+    gen->id = (gen->id + 1) % GRN_GEN_SIZE;
+    grn_gen_path_fill(ctx, db, gen->id, gen_path);
+    if (gen_new_file(gen, gen_path)) break;
+  }
+  if (!gen_is_valid_file(gen)) {
+    GRN_FREE(gen);
+    return GRN_TOO_MANY_OPEN_FILES;
+  }
+  gen_flock(gen);
+  db->gen = gen;
+  return GRN_SUCCESS;
+}
+
+grn_rc
+grn_gen_fin(grn_ctx *ctx, grn_db *db)
+{
+  if (db->gen) {
+    char gen_path[PATH_MAX];
+    grn_gen_path_fill(ctx, db, db->gen->id, gen_path);
+    gen_close_file(db->gen);
+    unlink(gen_path);
+    GRN_FREE(db->gen);
+    db->gen = NULL;
+  }
+  return GRN_SUCCESS;
+}

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -40,6 +40,7 @@ extern "C" {
 
 typedef struct _grn_db grn_db;
 typedef struct _grn_proc grn_proc;
+typedef struct _grn_gen grn_gen;
 
 struct _grn_db {
   grn_db_obj obj;
@@ -49,6 +50,7 @@ struct _grn_db {
   grn_tiny_array values;
   grn_critical_section lock;
   grn_cache *cache;
+  grn_gen *gen;
 };
 
 #define GRN_SERIALIZED_SPEC_INDEX_SPEC   0

--- a/lib/grn_file_lock.h
+++ b/lib/grn_file_lock.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
 
 typedef struct {
-  const char *path;
+  char path[PATH_MAX];
 #ifdef WIN32
   HANDLE handle;
 #else /* WIN32 */

--- a/lib/grn_file_lock.h
+++ b/lib/grn_file_lock.h
@@ -42,6 +42,10 @@ grn_bool grn_file_lock_acquire(grn_ctx *ctx,
                                const char *error_message_tag);
 void grn_file_lock_release(grn_ctx *ctx, grn_file_lock *file_lock);
 void grn_file_lock_fin(grn_ctx *ctx, grn_file_lock *file_lock);
+grn_bool grn_file_lock_exist(grn_ctx *ctx, grn_file_lock *file_lock);
+grn_bool grn_file_lock_takeover(grn_ctx *ctx, grn_file_lock *file_lock);
+void grn_file_lock_close(grn_ctx *ctx, grn_file_lock *file_lock);
+void grn_file_lock_exclusive(grn_ctx *ctx, grn_file_lock *file_lock);
 
 #ifdef __cplusplus
 }

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -29,7 +29,7 @@ extern "C" {
 
 struct _grn_gen {
   int id;
-  uint8_t table[GRN_GEN_SIZE];
+  uint8_t table[GRN_GEN_SIZE/8];
 #ifdef _WIN32
   HFILE hFile;
 #else

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "grn_db.h"
+#include "grn_io.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,6 +40,8 @@ typedef struct _grn_gen grn_gen;
 
 grn_rc grn_gen_init(grn_ctx *ctx, grn_db *db);
 grn_rc grn_gen_fin(grn_ctx *ctx, grn_db *db);
+int grn_gen_lock(grn_ctx *ctx, grn_io *io);
+int grn_gen_unlock(grn_io *io);
 
 #ifdef __cplusplus
 }

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -30,7 +30,7 @@ extern "C" {
 struct _grn_gen {
   int id;
   uint8_t table[GRN_GEN_SIZE/8];
-#ifdef _WIN32
+#ifdef WIN32
   HFILE hFile;
 #else
   int fd;

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -20,6 +20,7 @@
 
 #include "grn_db.h"
 #include "grn_io.h"
+#include "grn_file_lock.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,11 +31,7 @@ extern "C" {
 struct _grn_gen {
   int id;
   uint8_t table[GRN_GEN_SIZE/8];
-#ifdef WIN32
-  HFILE hFile;
-#else
-  int fd;
-#endif
+  grn_file_lock file_lock;
 };
 typedef struct _grn_gen grn_gen;
 

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -1,0 +1,45 @@
+/* -*- c-basic-offset: 2 -*- */
+/*
+  Copyright(C) 2009-2016 Brazil
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "grn_db.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GRN_GEN_SIZE  (256*8)
+
+struct _grn_gen {
+  int id;
+  uint8_t table[GRN_GEN_SIZE];
+#ifdef _WIN32
+  HFILE hFile;
+#else
+  int fd;
+#endif
+};
+typedef struct _grn_gen grn_gen;
+
+grn_rc grn_gen_init(grn_ctx *ctx, grn_db *db);
+grn_rc grn_gen_fin(grn_ctx *ctx, grn_db *db);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/grn_gen.h
+++ b/lib/grn_gen.h
@@ -40,7 +40,7 @@ typedef struct _grn_gen grn_gen;
 
 grn_rc grn_gen_init(grn_ctx *ctx, grn_db *db);
 grn_rc grn_gen_fin(grn_ctx *ctx, grn_db *db);
-int grn_gen_lock(grn_ctx *ctx, grn_io *io);
+int grn_gen_lock(grn_ctx *ctx, grn_io *io, uint32_t count);
 int grn_gen_unlock(grn_io *io);
 
 #ifdef __cplusplus

--- a/lib/grn_io.h
+++ b/lib/grn_io.h
@@ -108,6 +108,7 @@ struct _grn_io {
   uint32_t count;
   uint8_t flags;
   uint32_t *lock;
+  grn_ctx *locker;
 };
 
 GRN_API grn_io *grn_io_create(grn_ctx *ctx, const char *path,

--- a/lib/io.c
+++ b/lib/io.c
@@ -1377,7 +1377,7 @@ grn_io_lock(grn_ctx *ctx, grn_io *io, int timeout)
   _ncalls++;
   if (!io) { return GRN_INVALID_ARGUMENT; }
   for (count = 0;; count++) {
-    if (!grn_gen_lock(ctx, io)) {
+    if (!grn_gen_lock(ctx, io, count)) {
       if (count == count_log_border) {
         GRN_LOG(ctx, GRN_LOG_NOTICE,
                 "io(%s) collisions(%d/%d): lock failed %d times",

--- a/lib/io.c
+++ b/lib/io.c
@@ -1377,10 +1377,7 @@ grn_io_lock(grn_ctx *ctx, grn_io *io, int timeout)
   _ncalls++;
   if (!io) { return GRN_INVALID_ARGUMENT; }
   for (count = 0;; count++) {
-    uint32_t lock;
-    GRN_ATOMIC_ADD_EX(io->lock, 1, lock);
-    if (lock) {
-      GRN_ATOMIC_ADD_EX(io->lock, -1, lock);
+    if (!grn_gen_lock(ctx, io)) {
       if (count == count_log_border) {
         GRN_LOG(ctx, GRN_LOG_NOTICE,
                 "io(%s) collisions(%d/%d): lock failed %d times",
@@ -1419,9 +1416,7 @@ void
 grn_io_unlock(grn_io *io)
 {
   if (io) {
-    uint32_t lock;
-    GRN_ATOMIC_ADD_EX(io->lock, -1, lock);
-    if (lock == 1) {
+    if (grn_gen_unlock(io)) {
       io->locker = NULL;
     }
   }


### PR DESCRIPTION
This PR wants to introduce a more robust way to recovery from crash in comparision to `lock_clear`.

Unfortunately, all software systems complicated enough can crash. Groonga is too.
Crashed Groonga processes could remain some locks in its database. Previously, so we have to unlock them by calling `lock_clear`.
In production system, it is not acceptable there to be down time even while clearing locks manually.
By this PR, we can automatically recover the dead lock by introducting generantional lock to the io lock.

Every `grn_io_lock`/`grn_io_unlock` works with generation ID which is uniquely related with a process.
generation ID is only effective while a process is alive. It is achieved by using `flock`/`LockFileEx`.

At the starting up, check running processes and its generation IDs.
If lock failed, extract the generation ID from the lock and test if the ID is in the available ID table. If not, the lock was made by crashed process, so we clear it.