### PR TITLE
Add Groonga docker installation document

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install.po
+++ b/doc/locale/ja/LC_MESSAGES/install.po
@@ -176,6 +176,32 @@ msgstr ""
 "Debian stretchでGroongaをビルドするために必要なパッケージをインストールしま"
 "す::"
 
+msgid "Docker"
+msgstr ""
+
+msgid ""
+"This section describes how to install Groonga on Docker. You can install "
+"Groonga image via DockerHub."
+msgstr ""
+"このセクションではDockerでGroongaをインストールする方法を説明します。"
+"GroongaイメージはDockerHub経由でインストールできます。"
+
+msgid "We distribute Alpine Linux Groonga docker image on DockerHub."
+msgstr ""
+"DockerHubにおいて、Alpine LinuxのGroongaのDockerイメージを配布しています。"
+
+msgid "Pulling image"
+msgstr "イメージの取得"
+
+msgid "Then run it with the following command::"
+msgstr "次のコマンドで実行します::"
+
+msgid "With docker-compose"
+msgstr "docker-composeを用いる場合"
+
+msgid "Create docker-compose.yml as follows::"
+msgstr "docker-compose.ymlを次のように作成します::"
+
 msgid "Fedora"
 msgstr ""
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -25,4 +25,5 @@ size data.
    install/centos
    install/fedora
    install/solaris
+   install/docker
    install/others

--- a/doc/source/install/docker.rst
+++ b/doc/source/install/docker.rst
@@ -1,0 +1,43 @@
+.. -*- rst -*-
+.. Groonga Project
+
+.. highlightlang:: none
+
+Docker
+=======
+
+This section describes how to install Groonga on Docker. You can
+install Groonga image via DockerHub.
+
+We distribute Alpine Linux Groonga docker image on DockerHub.
+
+Pulling image
+-------------
+
+Install::
+
+  % docker pull groonga/groonga:latest
+
+Then run it with the following command::
+
+  % docker run -v /mnt/db:/path/to/db groonga/groonga /mnt/db
+
+
+With docker-compose
+-------------------
+
+Create docker-compose.yml as follows::
+
+  version: '3'
+  services:
+    groonga:
+      image: groonga/groonga
+      volumes:
+        - ./groonga:/mnt/db
+      ports:
+        - "10041:10041"
+      command: ["-n", "/mnt/db/data.db"]
+
+Then run it with the following command::
+
+  % docker-compose run groonga


### PR DESCRIPTION
Groonga Alpine Linux minimal image is distributed on DockerHub.
Should we describe this minimal image on document?