### PR TITLE
doc: correct a description on protocols available in the client mode.

### DIFF
--- a/doc/source/reference/executables/groonga.rst
+++ b/doc/source/reference/executables/groonga.rst
@@ -150,7 +150,7 @@ protocol Groonga server. Its usage is similar to
 execute one command. You need to specify server address instead of
 local database.
 
-Note that you can use ``groonga`` executable file as a client for HTTP
+Note that you cannot use ``groonga`` executable file as a client for HTTP
 protocol Groonga server.
 
 Here is the syntax to run shell that executes Groonga command against


### PR DESCRIPTION
As far as I understand from a description as follows (and from source code and behavior),
the client mode only supports GQTP and HTTP is not supported.
Users cannot specify a protocol to access the server.

> In client mode, ``groonga`` executable file runs as a client for GQTP
> protocol Groonga server.

Sorry if my understanding is not correct.
Thanks!