### PR TITLE
test: remove needless flag

### DIFF
--- a/test/command/suite/load/index/offline/vector/text_without_section.expected
+++ b/test/command/suite/load/index/offline/vector/text_without_section.expected
@@ -11,7 +11,7 @@ load --table Docs
 [[0,0.0,0.0],1]
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
 [[0,0.0,0.0],true]
-column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
+column_create Words docs_sentences COLUMN_INDEX Docs sentences
 [[0,0.0,0.0],true]
 select Words   --limit -1   --sort_keys _key   --output_columns '_key, index_column_source_records("docs_sentences")'
 [

--- a/test/command/suite/load/index/offline/vector/text_without_section.test
+++ b/test/command/suite/load/index/offline/vector/text_without_section.test
@@ -9,7 +9,7 @@ load --table Docs
 ]
 
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
-column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
+column_create Words docs_sentences COLUMN_INDEX Docs sentences
 
 select Words \
   --limit -1 \

--- a/test/command/suite/load/index/online/vector/text_without_section.expected
+++ b/test/command/suite/load/index/online/vector/text_without_section.expected
@@ -6,7 +6,7 @@ column_create Docs sentences COLUMN_VECTOR Text
 [[0,0.0,0.0],true]
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
 [[0,0.0,0.0],true]
-column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
+column_create Words docs_sentences COLUMN_INDEX Docs sentences
 [[0,0.0,0.0],true]
 load --table Docs
 [

--- a/test/command/suite/load/index/online/vector/text_without_section.test
+++ b/test/command/suite/load/index/online/vector/text_without_section.test
@@ -4,7 +4,7 @@ table_create Docs TABLE_NO_KEY
 column_create Docs sentences COLUMN_VECTOR Text
 
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
-column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
+column_create Words docs_sentences COLUMN_INDEX Docs sentences
 
 load --table Docs
 [


### PR DESCRIPTION
Because it does not have to be a full-text search index.