### PR TITLE
Use POSIX compatible futimens method

### DIFF
--- a/build/ac_macros/check_functions.m4
+++ b/build/ac_macros/check_functions.m4
@@ -3,6 +3,8 @@
 AC_CHECK_FUNCS(_gmtime64_s)
 AC_CHECK_FUNCS(_localtime64_s)
 AC_CHECK_FUNCS(_strtoui64)
+AC_CHECK_FUNCS(futimens)
+AC_CHECK_FUNCS(futimes)
 AC_CHECK_FUNCS(gmtime_r)
 AC_CHECK_FUNCS(localtime_r)
 AC_CHECK_FUNCS(mkstemp)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -139,6 +139,8 @@
 #cmakedefine HAVE_CLOCK
 #cmakedefine HAVE_CLOCK_GETTIME
 #cmakedefine HAVE_FPCLASSIFY
+#cmakedefine HAVE_FUTIMENS
+#cmakedefine HAVE_FUTIMES
 #cmakedefine HAVE_GMTIME_R
 #cmakedefine HAVE_LOCALTIME_R
 #cmakedefine HAVE_MKSTEMP


### PR DESCRIPTION
`futimes` (ie. without the 'n') is the non-POSIX compatible brother of the POSIX compatible method `futimens`. `futimes` Is only implemented on Linux and some of the BSD's. Other POSIX compliant platforms do not provide this method but do provide `futimens`.

This came up when I was trying to build groonga on SmartOS (ie. Illumos / Solaris).

See also: http://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html