### PR TITLE
Fix returning wrong result ater the client closed accidentally

### DIFF
--- a/lib/ctx.c
+++ b/lib/ctx.c
@@ -346,6 +346,12 @@ grn_ctx_set_keep_command(grn_ctx *ctx, grn_obj *command)
   ctx->impl->command.keep.version = ctx->impl->command.version;
 }
 
+void
+grn_ctx_clear_keep_command(grn_ctx *ctx)
+{
+  ctx->impl->command.keep.command = NULL;
+}
+
 static void
 grn_ctx_impl_clear_n_same_error_messagges(grn_ctx *ctx)
 {

--- a/lib/grn_ctx.h
+++ b/lib/grn_ctx.h
@@ -435,6 +435,7 @@ void grn_log_reopen(grn_ctx *ctx);
 
 GRN_API grn_rc grn_ctx_sendv(grn_ctx *ctx, int argc, char **argv, int flags);
 void grn_ctx_set_keep_command(grn_ctx *ctx, grn_obj *command);
+void grn_ctx_clear_keep_command(grn_ctx *ctx);
 
 grn_content_type grn_get_ctype(grn_obj *var);
 grn_content_type grn_content_type_parse(grn_ctx *ctx,

--- a/src/groonga.c
+++ b/src/groonga.c
@@ -1593,9 +1593,11 @@ do_htreq_post(grn_ctx *ctx, ht_context *hc)
         int recv_flags = 0;
         recv_length = recv(fd, buffer, POST_BUFFER_SIZE, recv_flags);
         if (recv_length == 0) {
+	  grn_ctx_clear_keep_command(ctx);
           break;
         }
         if (recv_length == -1) {
+	  grn_ctx_clear_keep_command(ctx);
           SOERR("recv");
           break;
         }


### PR DESCRIPTION
When a client closed just after sending a request and just before receiving the corresponding result,
another client occasionally receives the results which should have been sent to the former client.
Apparently, this problem started after `ctx->impl->command.keep.command` implemented.
This patch fixes the problem.