### PR TITLE
logger windows: avoid confusion about pid and thread id

### DIFF
--- a/lib/logger.c
+++ b/lib/logger.c
@@ -551,7 +551,7 @@ grn_logger_putv(grn_ctx *ctx,
                      "%s%08x", prefix, (uint32_t)pthread_self());
 #elif defined(WIN32) /* HAVE_PTHREAD_H */
         grn_snprintf(lbuf_current, lbuf_rest_size, lbuf_rest_size,
-                     "%s%ld", prefix, GetCurrentThreadId());
+                     "%s%08ld", prefix, GetCurrentThreadId());
 #endif /* HAVE_PTHREAD_H */
         lbuf_size = strlen(lbuf_current);
         lbuf_current += lbuf_size;


### PR DESCRIPTION
It makes clear which is process_id or thread_id.

Before:

  |2436|1032:

After:
  |2436|00001032: