### PR TITLE
Modify for suppressing a warning that C4018

### DIFF
--- a/src/groonga.c
+++ b/src/groonga.c
@@ -961,7 +961,7 @@ run_server_loop(grn_ctx *ctx, grn_com_event *ev)
   }
   running_event_loop = GRN_FALSE;
   for (;;) {
-    int i;
+    uint32_t i;
     CRITICAL_SECTION_ENTER(q_critical_section);
     for (i = 0; i < n_floating_threads; i++) {
       COND_SIGNAL(q_cond);


### PR DESCRIPTION
A type of variable "i" is int and a type of variable "n_floating_threads" is uint32_t.
So, if the size of the value of "n_floating_threads" over the size of "int", "i" occurs overflow.