### PR TITLE
Fix build error on macOS

### DIFF
--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -742,9 +742,10 @@ grn_arrow_load(grn_ctx *ctx,
   std::shared_ptr<arrow::io::MemoryMappedFile> input;
   auto status =
     arrow::io::MemoryMappedFile::Open(path, arrow::io::FileMode::READ, &input);
+  std::ostringstream context;
   if (!grnarrow::check_status(ctx,
                               status,
-                              std::ostringstream() <<
+                              context <<
                               "[arrow][load] failed to open path: " <<
                               "<" << path << ">")) {
     GRN_API_RETURN(ctx->rc);
@@ -763,9 +764,10 @@ grn_arrow_load(grn_ctx *ctx,
   for (int i = 0; i < n_record_batches; ++i) {
     std::shared_ptr<arrow::RecordBatch> record_batch;
     status = reader->ReadRecordBatch(i, &record_batch);
+    std::ostringstream context;
     if (!grnarrow::check_status(ctx,
                                 status,
-                                std::ostringstream("") <<
+                                context <<
                                 "[arrow][load] failed to get " <<
                                 "the " << i << "-th " << "record")) {
       break;
@@ -830,9 +832,10 @@ grn_arrow_dump_columns(grn_ctx *ctx,
 #ifdef GRN_WITH_ARROW
   std::shared_ptr<arrow::io::FileOutputStream> output;
   auto status = arrow::io::FileOutputStream::Open(path, &output);
+  std::stringstream context;
   if (!grnarrow::check_status(ctx,
                               status,
-                              std::stringstream() <<
+                              context <<
                               "[arrow][dump] failed to open path: " <<
                               "<" << path << ">")) {
     GRN_API_RETURN(ctx->rc);


### PR DESCRIPTION
I read http://groonga.org/ja/docs/contribution/development/build/unix_autotools.html.
I run `make` on macOS Mojave 10.14.3.
I got the following result.
```
arrow.cpp:745:8: error: no matching function for call to 'check_status'
  if (!grnarrow::check_status(ctx,
       ^~~~~~~~~~~~~~~~~~~~~~
arrow.cpp:55:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_ostringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'const char *' for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
           ^
arrow.cpp:68:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_ostringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'std::ostream &'
      (aka 'basic_ostream<char> &') for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
           ^
arrow.cpp:766:10: error: no matching function for call to 'check_status'
    if (!grnarrow::check_status(ctx,
         ^~~~~~~~~~~~~~~~~~~~~~
arrow.cpp:55:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_ostringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'const char *' for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
           ^
arrow.cpp:68:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_ostringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'std::ostream &'
      (aka 'basic_ostream<char> &') for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
           ^
arrow.cpp:833:8: error: no matching function for call to 'check_status'
  if (!grnarrow::check_status(ctx,
       ^~~~~~~~~~~~~~~~~~~~~~
arrow.cpp:55:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_stringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'const char *' for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
           ^
arrow.cpp:68:12: note: candidate function not viable: no known conversion from
      'std::__1::basic_stringstream<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >' to 'std::ostream &'
      (aka 'basic_ostream<char> &') for 3rd argument
  grn_bool check_status(grn_ctx *ctx,
```
This PR fixes it.
