### PR TITLE
fix memory leak when logical_range_filter returns no records.

### DIFF
--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -198,6 +198,7 @@ module Groonga
             @context.dynamic_columns.each_filtered do |dynamic_column|
               dynamic_column.apply(result_set)
             end
+            @context.temporary_tables << result_set
             @context.result_sets << result_set
           end
         end


### PR DESCRIPTION
logical_range_filterで結果が0件だった場合に作成する一時テーブルがtemporary_tablesに追加されておらず、context.close時の解放対象になっていなかったため、temporary_tablesに追加するよう修正。