### PR TITLE
normalizer: use GRN_CHAR_TYPE

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1141,7 +1141,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
     }
 
     if (data->options->unify_kana &&
-        char_type == GRN_CHAR_KATAKANA &&
+        GRN_CHAR_TYPE(char_type) == GRN_CHAR_KATAKANA &&
         unified_char_length == 3) {
       unifying = grn_nfkc_normalize_unify_kana(unifying, unified_kana);
       if (unifying == unified_kana) {
@@ -1150,7 +1150,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
     }
 
     if (data->options->unify_kana_case) {
-      switch (char_type) {
+      switch (GRN_CHAR_TYPE(char_type)) {
       case GRN_CHAR_HIRAGANA :
         if (unified_char_length == 3) {
           unifying = grn_nfkc_normalize_unify_hiragana_case(unifying,
@@ -1169,7 +1169,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
     }
 
     if (data->options->unify_kana_voiced_sound_mark) {
-      switch (char_type) {
+      switch (GRN_CHAR_TYPE(char_type)) {
       case GRN_CHAR_HIRAGANA :
         if (unified_char_length == 3) {
           unifying = grn_nfkc_normalize_unify_hiragana_voiced_sound_mark(

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1145,7 +1145,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
         unified_char_length == 3) {
       unifying = grn_nfkc_normalize_unify_kana(unifying, unified_kana);
       if (unifying == unified_kana) {
-        char_type = GRN_CHAR_HIRAGANA;
+        char_type = GRN_CHAR_HIRAGANA | (char_type & GRN_CHAR_BLANK);
       }
     }
 
@@ -1191,7 +1191,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
       if (grn_nfkc_normalize_is_hyphen_famity(unifying, unified_char_length)) {
         unifying = unified_hyphen;
         unified_char_length = sizeof(unified_hyphen);
-        char_type = GRN_CHAR_SYMBOL;
+        char_type = GRN_CHAR_SYMBOL | (char_type & GRN_CHAR_BLANK);
       }
     }
 
@@ -1200,7 +1200,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
                                                             unified_char_length)) {
         unifying = unified_prolonged_sound_mark;
         unified_char_length = sizeof(unified_prolonged_sound_mark);
-        char_type = GRN_CHAR_KATAKANA;
+        char_type = GRN_CHAR_KATAKANA | (char_type & GRN_CHAR_BLANK);
       }
     }
 
@@ -1210,7 +1210,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
                                                             unified_char_length)) {
         unifying = unified_hyphen;
         unified_char_length = sizeof(unified_hyphen);
-        char_type = GRN_CHAR_SYMBOL;
+        char_type = GRN_CHAR_SYMBOL | (char_type & GRN_CHAR_BLANK);
       }
     }
 
@@ -1219,7 +1219,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
                                                   unified_char_length)) {
         unifying = unified_middle_dot;
         unified_char_length = sizeof(unified_middle_dot);
-        char_type = GRN_CHAR_SYMBOL;
+        char_type = GRN_CHAR_SYMBOL | (char_type & GRN_CHAR_BLANK);
       }
     }
 

--- a/test/command/suite/select/filter/index/match/normalizer_nfkc100_unify_kana.expected
+++ b/test/command/suite/select/filter/index/match/normalizer_nfkc100_unify_kana.expected
@@ -1,0 +1,45 @@
+table_create Memos --flags TABLE_HASH_KEY --key_type ShortText
+[[0,0.0,0.0],true]
+column_create --table Memos --name content --type LongText
+[[0,0.0,0.0],true]
+table_create   --name Term   --flags TABLE_PAT_KEY   --key_type ShortText   --default_tokenizer TokenBigram   --normalizer "NormalizerNFKC100(\"unify_kana\", true)"
+[[0,0.0,0.0],true]
+column_create   --table Term   --name content   --flags COLUMN_INDEX|WITH_POSITION   --type Memos   --source content
+[[0,0.0,0.0],true]
+load --table Memos
+{"_key":"1", "content":"ヤマダ です"}
+[[0,0.0,0.0],1]
+select Memos --filter 'content @ "やまだ"'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "content",
+          "LongText"
+        ]
+      ],
+      [
+        1,
+        "1",
+        "ヤマダ です"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/index/match/normalizer_nfkc100_unify_kana.test
+++ b/test/command/suite/select/filter/index/match/normalizer_nfkc100_unify_kana.test
@@ -1,0 +1,20 @@
+table_create Memos --flags TABLE_HASH_KEY --key_type ShortText
+column_create --table Memos --name content --type LongText
+
+table_create \
+  --name Term \
+  --flags TABLE_PAT_KEY \
+  --key_type ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer "NormalizerNFKC100(\"unify_kana\", true)"
+column_create \
+  --table Term \
+  --name content \
+  --flags COLUMN_INDEX|WITH_POSITION \
+  --type Memos \
+  --source content
+
+load --table Memos
+{"_key":"1", "content":"ヤマダ です"}
+
+select Memos --filter 'content @ "やまだ"'


### PR DESCRIPTION
Because char_type is sometimes OR operated with GRN_CHAR_BLANK.

Therefore, when load data that there is whitespace after KATAKANA,
load data are not normalize.
Because KATAKANA before whitespace is operated OR with GRN_CHAR_BLANK,
it can not be decided as KATAKANA.

Fix issues #912