### PR TITLE
appveyor: install groonga-admin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ init:
 install:
   - set PATH=C:\Ruby25-x64\bin;%PATH%
   - set PATH=C:\msys64\usr\bin;%PATH%
+  - choco install -y curl 7zip.commandline
   - if "%VS_VERSION%" == "15" if "%ARCH%" == "x86" set VS2017_X86=TRUE
   - if "%VS_VERSION%" == "15" if "%ARCH%" == "amd64" set VS2017_AMD64=TRUE
   - if "%VS2017_X86%" == "TRUE"
@@ -89,6 +90,11 @@ build_script:
   - set CMAKE_BUILD_PARALLEL_LEVEL=4
   - cmake --build . --config RelWithDebInfo
   - cmake --build . --config RelWithDebInfo --target Install
+  - move %FULL_GROONGA_INSTALL_FOLDER%\share\groonga\html\admin %FULL_GROONGA_INSTALL_FOLDER%\share\groonga\html\admin.old
+  - curl -O http://packages.groonga.org/source/groonga-admin/groonga-admin.tar.gz
+  - 7z x groonga-admin.tar.gz
+  - 7z x groonga-admin.tar
+  - move groonga-admin-*\html %FULL_GROONGA_INSTALL_FOLDER%\share\groonga\html\admin
 
 before_test:
   - git clone --depth 1


### PR DESCRIPTION
Because MinGW bundles groonga-admin.