### PR TITLE
cmake: install missing *.hpp

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -14,9 +14,13 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-install(FILES groonga.h DESTINATION "${GRN_INCLUDE_DIR}")
+install(FILES groonga.h groonga.hpp DESTINATION "${GRN_INCLUDE_DIR}")
 install(DIRECTORY groonga DESTINATION "${GRN_INCLUDE_DIR}"
-  FILES_MATCHING PATTERN "*.h")
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/groonga"
   DESTINATION "${GRN_INCLUDE_DIR}"
-  FILES_MATCHING PATTERN "*.h")
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp")


### PR DESCRIPTION
groonga.hpp and arrow.hpp are missing.