### PR TITLE
cmake windows: enable USE_EXACT_ALLOC_COUNT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ if(WIN32)
 
   SET(PSAPI_LIBS "psapi.lib")
 
+  set(USE_EXACT_ALLOC_COUNT)
   set(USE_SELECT TRUE)
 else()
   ac_check_headers(sys/epoll.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ if(WIN32)
 
   SET(PSAPI_LIBS "psapi.lib")
 
-  set(USE_EXACT_ALLOC_COUNT)
+  set(USE_EXACT_ALLOC_COUNT TRUE)
   set(USE_SELECT TRUE)
 else()
   ac_check_headers(sys/epoll.h)

--- a/lib/grn.h
+++ b/lib/grn.h
@@ -135,6 +135,7 @@ typedef SOCKET grn_sock;
 
 # ifndef __GNUC__
 #  include <intrin.h>
+#  pragma intrinsic (_InterlockedExchangeAdd)
 #  include <sys/timeb.h>
 #  include <errno.h>
 # endif
@@ -466,7 +467,7 @@ typedef int grn_cond;
 #elif (defined(WIN32) || defined (_WIN64)) /* __GNUC__ */
 
 # define GRN_ATOMIC_ADD_EX(p,i,r) \
-  ((r) = InterlockedExchangeAdd((p), (i)))
+  ((r) = _InterlockedExchangeAdd((p), (i)))
 # if defined(_WIN64) /* ATOMIC 64BIT SET */
 #  define GRN_SET_64BIT(p,v) \
   (*(p) = (v))

--- a/lib/grn.h
+++ b/lib/grn.h
@@ -135,7 +135,7 @@ typedef SOCKET grn_sock;
 
 # ifndef __GNUC__
 #  include <intrin.h>
-#  pragma intrinsic (_InterlockedExchangeAdd)
+#  pragma intrinsic(_InterlockedExchangeAdd)
 #  include <sys/timeb.h>
 #  include <errno.h>
 # endif


### PR DESCRIPTION
WIP: Without USE_EXACT_ALLOC_COUNT, grn_fin(N) reports unexpected leaks.