### PR TITLE
appveyor: enable testing with japanese directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,8 +53,8 @@ install:
   # - choco install -y imdisk-toolkit
   # - mkdir tmp
   # - imdisk -a -t file -m tmp -o awe -s 1G -p "/fs:ntfs /q /y"
-  # - set GROONGA_INSTALL_SUB_FOLDER=インストール
-  - set GROONGA_INSTALL_SUB_FOLDER=install
+  - set GROONGA_INSTALL_SUB_FOLDER=インストール
+  #- set GROONGA_INSTALL_SUB_FOLDER=install
   - ps: |
       $Env:GROONGA_VERSION = (Get-Content base_version)
       if ($Env:APPVEYOR_REPO_TAG -eq "false") {
@@ -122,7 +122,7 @@ test_script:
      --n-retries 2
      test\command\suite
   - ruby test\command_line\run-test.rb
-     --groonga-install-prefix=%FULL_GROONGA_INSTALL_FOLDER%
+     --groonga-install-prefix=%APPVEYOR_BUILD_FOLDER%\\\u7E67\uFF64\u7E5D\uFF73\u7E67\uFF79\u7E5D\u533B\u30FB\u7E5D\uFF6B\\%GROONGA_INSTALL_FOLDER%
 
 on_success:
   - cd %GROONGA_INSTALL_SUB_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,8 +121,10 @@ test_script:
      --timeout 60
      --n-retries 2
      test\command\suite
+  # On Appveyor, インストール directory is recognized unicode escape sequence.
+  - set GROONGA_INSTALL_SUB_FOLDER_ESCAPED=\u7E67\uFF64\u7E5D\uFF73\u7E67\uFF79\u7E5D\u533B\u30FB\u7E5D\uFF6B
   - ruby test\command_line\run-test.rb
-     --groonga-install-prefix=%APPVEYOR_BUILD_FOLDER%\\\u7E67\uFF64\u7E5D\uFF73\u7E67\uFF79\u7E5D\u533B\u30FB\u7E5D\uFF6B\\%GROONGA_INSTALL_FOLDER%
+     --groonga-install-prefix=%APPVEYOR_BUILD_FOLDER%\\%GROONGA_INSTALL_SUB_FOLDER_ESCAPED%\\%GROONGA_INSTALL_FOLDER%
 
 on_success:
   - cd %GROONGA_INSTALL_SUB_FOLDER%

--- a/test/command_line/run-test.rb
+++ b/test/command_line/run-test.rb
@@ -21,8 +21,10 @@ if (ARGV[0] || "").start_with?("--groonga-install-prefix=")
 end
 
 if groonga_install_prefix
+  unescaped_prefix = groonga_install_prefix.gsub(/\\u([\da-fA-F]{4})/) { [$1].pack('H*').unpack('n*').pack("U*")}
   ENV["PATH"] = [
     [groonga_install_prefix, "bin"].join(File::ALT_SEPARATOR || File::SEPARATOR),
+    [unescaped_prefix, "bin"].join(File::ALT_SEPARATOR || File::SEPARATOR),
     ENV["PATH"],
   ].join(File::PATH_SEPARATOR)
 else


### PR DESCRIPTION
On Appveyor,  directory name is recognized unicode escape
sequence. so it should be unescaped correctly.