### PR TITLE
NormalizerNFKC100: Add unify_kana_v_sounds option

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -39,6 +39,7 @@ typedef struct {
   grn_bool unify_kana;
   grn_bool unify_kana_case;
   grn_bool unify_kana_voiced_sound_mark;
+  grn_bool unify_kana_v_sounds;
   grn_bool unify_hyphen;
   grn_bool unify_prolonged_sound_mark;
   grn_bool unify_hyphen_and_prolonged_sound_mark;

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -57,6 +57,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->unify_kana = GRN_FALSE;
   options->unify_kana_case = GRN_FALSE;
   options->unify_kana_voiced_sound_mark = GRN_FALSE;
+  options->unify_kana_v_sounds = GRN_FALSE;
   options->unify_hyphen = GRN_FALSE;
   options->unify_prolonged_sound_mark = GRN_FALSE;
   options->unify_hyphen_and_prolonged_sound_mark = GRN_FALSE;
@@ -119,6 +120,12 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->unify_kana_voiced_sound_mark);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_kana_v_sounds")) {
+      options->unify_kana_v_sounds =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_kana_v_sounds);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_hyphen")) {
       options->unify_hyphen = grn_vector_get_element_bool(ctx,
                                                           raw_options,

--- a/test/command/suite/normalizers/nfkc100/unify_kana_v_sounds.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_kana_v_sounds.expected
@@ -1,0 +1,22 @@
+normalize   --normalizer 'NormalizerNFKC100("unify_kana_v_sounds", true)'   --string "ゔぁゔぃゔゔぇゔぉゔ"   --flags WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ばびぶべぼぶ",
+    "types": [
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_kana_v_sounds.test
+++ b/test/command/suite/normalizers/nfkc100/unify_kana_v_sounds.test
@@ -1,0 +1,4 @@
+normalize \
+  --normalizer 'NormalizerNFKC100("unify_kana_v_sounds", true)' \
+  --string "ゔぁゔぃゔゔぇゔぉゔ" \
+  --flags WITH_TYPES


### PR DESCRIPTION
This options normalize `ゔぁゔぃゔゔぇゔぉ` to `ばびぶべぼ`.
If combined with the `unify_katakana_v_sounds` option, for example, we can below terms to classify as the same things.

* いゔぁんか
* いばんか
* イヴァンカ
* イバンカ