### PR TITLE
Fix "unknown type name 'bool'" compilation error with musl libc

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -28,6 +28,12 @@
 # include <share.h>
 #endif /* WIN32 */
 
+#ifndef bool
+  #define false 0
+  #define true 1
+  #define bool int
+#endif
+
 #include "grn_ii.h"
 #include "grn_ctx_impl.h"
 #include "grn_token_cursor.h"


### PR DESCRIPTION
When building on an Alpine Linux system (with musl libc), I get the following error:

```
ii.c: In function 'buffer_flush':
ii.c:4491:11: error: unknown type name 'bool'; did you mean '_Bool'?
           bool need_chunk_free = true;
           ^~~~
           _Bool
ii.c:4491:34: error: 'true' undeclared (first use in this function); did you mean 'tee'?
           bool need_chunk_free = true;
                                  ^~~~
                                  tee
ii.c:4491:34: note: each undeclared identifier is reported only once for each function it appears in
ii.c:4508:33: error: 'false' undeclared (first use in this function); did you mean 'raise'?
               need_chunk_free = false;
                                 ^~~~~
                                 raise
ii.c: In function 'buffer_split':
ii.c:4886:13: error: unknown type name 'bool'; did you mean '_Bool'?
             bool need_db0_chunk_free = false;
             ^~~~
             _Bool
ii.c:4886:40: error: 'false' undeclared (first use in this function); did you mean 'raise'?
             bool need_db0_chunk_free = false;
                                        ^~~~~
                                        raise
ii.c:4890:39: error: 'true' undeclared (first use in this function); did you mean 'tee'?
                 need_db0_chunk_free = true;
                                       ^~~~
                                       tee
ii.c:4905:19: error: unknown type name 'bool'; did you mean '_Bool'?
                   bool need_db1_chunk_free = false;
                   ^~~~
                   _Bool
make[4]: *** [Makefile:982: ii.lo] Error 1
```

This PR fixes it.