### PR TITLE
NormalizerNFKC100: add a unify_to_katakana option

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -46,6 +46,7 @@ typedef struct {
   grn_bool unify_katakana_v_sounds;
   grn_bool unify_katakana_bu_sound;
   grn_bool unify_to_romaji;
+  grn_bool unify_to_katakana;
   grn_bool remove_blank;
 } grn_nfkc_normalize_options;
 

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -64,6 +64,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->unify_katakana_v_sounds = GRN_FALSE;
   options->unify_katakana_bu_sound = GRN_FALSE;
   options->unify_to_romaji = GRN_FALSE;
+  options->unify_to_katakana = GRN_FALSE;
   options->remove_blank = GRN_FALSE;
 }
 
@@ -173,6 +174,12 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->unify_to_romaji);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_to_katakana")) {
+      options->unify_to_katakana =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_to_katakana);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "remove_blank")) {
       options->remove_blank =
         grn_vector_get_element_bool(ctx,

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1188,6 +1188,17 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
       }
     }
 
+    if (data->options->unify_to_katakana &&
+        GRN_CHAR_TYPE(char_type) == GRN_CHAR_HIRAGANA &&
+        unified_char_length == 3) {
+      unifying = grn_nfkc_normalize_unify_to_katakana(unifying,
+                                                      unified_katakana,
+                                                      unified_char_length);
+      if (unifying == unified_katakana) {
+        char_type = GRN_CHAR_KATAKANA | (char_type & GRN_CHAR_BLANK);
+      }
+    }
+
     if (data->options->unify_kana_case) {
       switch (GRN_CHAR_TYPE(char_type)) {
       case GRN_CHAR_HIRAGANA :
@@ -1259,17 +1270,6 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
         unifying = unified_middle_dot;
         unified_char_length = sizeof(unified_middle_dot);
         char_type = GRN_CHAR_SYMBOL | (char_type & GRN_CHAR_BLANK);
-      }
-    }
-
-    if (data->options->unify_to_katakana &&
-        GRN_CHAR_TYPE(char_type) == GRN_CHAR_HIRAGANA &&
-        unified_char_length == 3) {
-      unifying = grn_nfkc_normalize_unify_to_katakana(unifying,
-                                                      unified_katakana,
-                                                      unified_char_length);
-      if (unifying == unified_katakana) {
-        char_type = GRN_CHAR_KATAKANA | (char_type & GRN_CHAR_BLANK);
       }
     }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1131,7 +1131,7 @@ grn_nfkc_normalize_unify_to_katakana(const unsigned char *utf8_char,
                utf8_char[2] >= 0x80 && utf8_char[2] <= 0x9f) {
       /* U+3041 HIRAGANA LETTER MU ..
        * U+305F HIRAGANA LETTER YORI */
-      if ( utf8_char[2] >= 0x97 && utf8_char[2] <= 0x9c ) {
+      if (utf8_char[2] >= 0x97 && utf8_char[2] <= 0x9c) {
         /* This character code isn't assigned character */
         return utf8_char;
       } else if (utf8_char[2] == 0x9f) {

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1272,7 +1272,9 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
       unifying = grn_nfkc_normalize_unify_to_katakana(unifying,
                                                       unified_katakana,
                                                       unified_char_length);
-      char_type = GRN_CHAR_KATAKANA | (char_type & GRN_CHAR_BLANK);
+      if (unifying == unified_katakana) {
+        char_type = GRN_CHAR_KATAKANA | (char_type & GRN_CHAR_BLANK);
+      }
     }
 
     if (unify->d + unified_char_length >= unify->dest_end) {

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1109,41 +1109,39 @@ grn_nfkc_normalize_unify_to_katakana(const unsigned char *utf8_char,
                                      unsigned char *unified,
                                      size_t length)
 {
-  if (length == 3) {
-    if (utf8_char[0] == 0xe3) {
-      if (utf8_char[1] == 0x81 && utf8_char[2] == 0x80) {
+  if (utf8_char[0] == 0xe3) {
+    if (utf8_char[1] == 0x81 && utf8_char[2] == 0x80) {
+      /* This character code isn't assigned character */
+      return utf8_char;
+    } else if (utf8_char[1] == 0x81 &&
+               utf8_char[2] >= 0x81 && utf8_char[2] <= 0x9f) {
+      /* U+3041 HIRAGANA LETTER SMALL A ..
+       * U+305F HIRAGANA LETTER TA */
+      unified[0] = utf8_char[0];
+      unified[1] = utf8_char[1] + 0x01;
+      unified[2] = utf8_char[2] + 0x20;
+    } else if (utf8_char[1] == 0x81 &&
+               utf8_char[2] >= 0xa0 && utf8_char[2] <= 0xbf) {
+      /* U+3060 HIRAGANA LETTER DA ..
+       * U+305F HIRAGANA LETTER MI */
+      unified[0] = utf8_char[0];
+      unified[1] = utf8_char[1] + 0x02;
+      unified[2] = utf8_char[2] - 0x20;
+    } else if (utf8_char[1] == 0x82 &&
+               utf8_char[2] >= 0x80 && utf8_char[2] <= 0x9f) {
+      /* U+3041 HIRAGANA LETTER MU ..
+       * U+305F HIRAGANA LETTER YORI */
+      if ( utf8_char[2] >= 0x97 && utf8_char[2] <= 0x9c ) {
         /* This character code isn't assigned character */
-        return utf8_char; 
-      } else if (utf8_char[1] == 0x81 &&
-                 utf8_char[2] >= 0x81 && utf8_char[2] <= 0x9f) {
-        /* U+3041 HIRAGANA LETTER SMALL A ..
-         * U+305F HIRAGANA LETTER TA */
-        unified[0] = utf8_char[0];
-        unified[1] = utf8_char[1] + 0x01;
-        unified[2] = utf8_char[2] + 0x20;
-      } else if (utf8_char[1] == 0x81 &&
-                 utf8_char[2] >= 0xa0 && utf8_char[2] <= 0xbf) {
-        /* U+3060 HIRAGANA LETTER DA ..
-         * U+305F HIRAGANA LETTER MI */
-        unified[0] = utf8_char[0];
-        unified[1] = utf8_char[1] + 0x02;
-        unified[2] = utf8_char[2] - 0x20;
-      } else if (utf8_char[1] == 0x82 &&
-                 utf8_char[2] >= 0x80 && utf8_char[2] <= 0x9f) {
-        /* U+3041 HIRAGANA LETTER MU ..
-         * U+305F HIRAGANA LETTER YORI */
-        if ( utf8_char[2] >= 0x97 && utf8_char[2] <= 0x9c ) {
-          /* This character code isn't assigned character */
-          return utf8_char;
-        } else if (utf8_char[2] == 0x9f) {
-          /* This character code has not been inputted into this function.
-           * Because this character already decomposes in grn_nfkc100_decompose */
-          return utf8_char;
-        }
-        unified[0] = utf8_char[0];
-        unified[1] = utf8_char[1] + 0x01;
-        unified[2] = utf8_char[2] + 0x20;
+        return utf8_char;
+      } else if (utf8_char[2] == 0x9f) {
+        /* This character code has not been inputted into this function.
+         * Because this character already decomposes in grn_nfkc100_decompose */
+        return utf8_char;
       }
+      unified[0] = utf8_char[0];
+      unified[1] = utf8_char[1] + 0x01;
+      unified[2] = utf8_char[2] + 0x20;
     }
   }
   return unified;

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1110,16 +1110,14 @@ grn_nfkc_normalize_unify_to_katakana(const unsigned char *utf8_char,
                                      size_t length)
 {
   if (utf8_char[0] == 0xe3) {
-    if (utf8_char[1] == 0x81 && utf8_char[2] == 0x80) {
-      /* This character code isn't assigned character */
-      return utf8_char;
-    } else if (utf8_char[1] == 0x81 &&
-               utf8_char[2] >= 0x81 && utf8_char[2] <= 0x9f) {
+    if (utf8_char[1] == 0x81 &&
+        utf8_char[2] >= 0x81 && utf8_char[2] <= 0x9f) {
       /* U+3041 HIRAGANA LETTER SMALL A ..
        * U+305F HIRAGANA LETTER TA */
       unified[0] = utf8_char[0];
       unified[1] = utf8_char[1] + 0x01;
       unified[2] = utf8_char[2] + 0x20;
+      return unified;
     } else if (utf8_char[1] == 0x81 &&
                utf8_char[2] >= 0xa0 && utf8_char[2] <= 0xbf) {
       /* U+3060 HIRAGANA LETTER DA ..
@@ -1127,24 +1125,22 @@ grn_nfkc_normalize_unify_to_katakana(const unsigned char *utf8_char,
       unified[0] = utf8_char[0];
       unified[1] = utf8_char[1] + 0x02;
       unified[2] = utf8_char[2] - 0x20;
-    } else if (utf8_char[1] == 0x82 &&
-               utf8_char[2] >= 0x80 && utf8_char[2] <= 0x9f) {
-      /* U+3041 HIRAGANA LETTER MU ..
-       * U+305F HIRAGANA LETTER YORI */
-      if (utf8_char[2] >= 0x97 && utf8_char[2] <= 0x9c) {
-        /* This character code isn't assigned character */
-        return utf8_char;
-      } else if (utf8_char[2] == 0x9f) {
-        /* This character code has not been inputted into this function.
-         * Because this character already decomposes in grn_nfkc100_decompose */
-        return utf8_char;
+      return unified;
+    } else if (utf8_char[1] == 0x82) {
+      if ((utf8_char[2] >= 0x80 && utf8_char[2] <= 0x96)
+          || (utf8_char[2] >= 0x9d && utf8_char[2] <= 0x9e)) {
+        /* U+3041 HIRAGANA LETTER MU ..
+         * U+3096 HIRAGANA LETTER KE
+         * U+309D HIRAGANA ITERATION MARK
+         * U+309E HIRAGANA VOICED ITERATION MARK */
+        unified[0] = utf8_char[0];
+        unified[1] = utf8_char[1] + 0x01;
+        unified[2] = utf8_char[2] + 0x20;
+        return unified;
       }
-      unified[0] = utf8_char[0];
-      unified[1] = utf8_char[1] + 0x01;
-      unified[2] = utf8_char[2] + 0x20;
     }
   }
-  return unified;
+  return utf8_char;
 }
 
 static void

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/a.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/a.expected
@@ -1,0 +1,67 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "あぁいぃうぅえぇおぉ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "アァイィウゥエェオォ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      18,
+      21,
+      24,
+      27
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/a.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/a.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "あぁいぃうぅえぇおぉ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ba.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ba.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ばびぶべぼ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "バビブベボ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ba.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ba.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "ばびぶべぼ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_semi_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_semi_voiced_sound_mark.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "゚"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゚",
+    "types": [
+      "hiragana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_semi_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_semi_voiced_sound_mark.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_to_katakana", true, \
                      "report_source_offset", true)' \
-  "ゔゕゖゝゞゟ" \
+  "゚" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_voiced_sound_mark.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "゙"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゙",
+    "types": [
+      "hiragana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/combining_katakana_hiragana_voiced_sound_mark.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_to_katakana", true, \
                      "report_source_offset", true)' \
-  "ゔゕゖゝゞゟ" \
+  "゙" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/da.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/da.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "だぢづでど"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ダヂヅデド",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/da.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/da.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "だぢづでど" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
@@ -1,0 +1,52 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ゔゕゖゝゞゟ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ヴヵヶヽヾヨリ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      -1,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ゔゕゖゝゞゟ"   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ゔゕゖゝゞゟ ゙ ゚゛゜"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,7 +6,7 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
     0.0
   ],
   {
-    "normalized": "ヴヵヶヽヾヨリ",
+    "normalized": "ヴヵヶヽヾヨリ ゙ ゚゛゜",
     "types": [
       "katakana",
       "katakana",
@@ -14,7 +14,11 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       "katakana",
       "katakana",
       "katakana",
-      "katakana"
+      "katakana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana"
     ],
     "checks": [
       3,
@@ -38,6 +42,18 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       -1,
       0,
       0
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
     ],
     "offsets": [
       0,
@@ -46,7 +62,11 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       9,
       12,
       15,
-      15
+      15,
+      18,
+      21,
+      24,
+      27
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ゔゕゖゝゞゟ ゙ ゚゛゜"   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ゔゕゖゝゞゟ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,7 +6,7 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
     0.0
   ],
   {
-    "normalized": "ヴヵヶヽヾヨリ ゙ ゚゛゜",
+    "normalized": "ヴヵヶヽヾヨリ",
     "types": [
       "katakana",
       "katakana",
@@ -14,11 +14,7 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       "katakana",
       "katakana",
       "katakana",
-      "katakana",
-      "hiragana",
-      "hiragana",
-      "hiragana",
-      "hiragana"
+      "katakana"
     ],
     "checks": [
       3,
@@ -42,18 +38,6 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       -1,
       0,
       0
-      3,
-      0,
-      0,
-      3,
-      0,
-      0,
-      3,
-      0,
-      0,
-      3,
-      0,
-      0
     ],
     "offsets": [
       0,
@@ -62,11 +46,7 @@ normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "
       9,
       12,
       15,
-      15,
-      18,
-      21,
-      24,
-      27
+      15
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "ゔゕゖゝゞゟ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/etc.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_to_katakana", true, \
                      "report_source_offset", true)' \
-  "ゔゕゖゝゞゟ" \
+  "ゔゕゖゝゞゟ ゙ ゚゛゜" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ga.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ga.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "がぎぐげご"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ガギグゲゴ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ga.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ga.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "がぎぐげご" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ha.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ha.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "はひふへほ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ハヒフヘホ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ha.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ha.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "はひふへほ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ka.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ka.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "かきくけこ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "カキクケコ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ka.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ka.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "かきくけこ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "゜"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゚",
+    "types": [
+      "hiragana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_to_katakana", true, \
                      "report_source_offset", true)' \
-  "ゔゕゖゝゞゟ" \
+  "゜" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_voiced_sound_mark.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "゛"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゙",
+    "types": [
+      "hiragana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/katakana_hiragana_voiced_sound_mark.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_to_katakana", true, \
                      "report_source_offset", true)' \
-  "ゔゕゖゝゞゟ" \
+  "゛" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ma.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ma.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "まみむめも"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "マミムメモ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ma.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ma.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "まみむめも" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/na.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/na.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "なにぬねの"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ナニヌネノ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/na.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/na.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "なにぬねの" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/pa.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/pa.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ぱぴぷぺぽ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "パピプペポ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/pa.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/pa.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "ぱぴぷぺぽ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ra.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ra.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "らりるれろ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ラリルレロ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ra.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ra.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "らりるれろ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/sa.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/sa.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "さしすせそ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "サシスセソ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/sa.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/sa.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "さしすせそ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ta.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ta.expected
@@ -1,0 +1,47 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "たちつってと"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "タチツッテト",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ta.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ta.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "たちつってと" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/wa.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/wa.expected
@@ -1,0 +1,47 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "わゎゐゑをん"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ワヮヰヱヲン",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/wa.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/wa.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "わゎゐゑをん" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ya.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ya.expected
@@ -1,0 +1,47 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "やゃゆゅよょ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ヤャユュヨョ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/ya.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/ya.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "やゃゆゅよょ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/za.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/za.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_to_katakana", true,                      "report_source_offset", true)'   "ざじずぜぞ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_to_katakana/za.test
+++ b/test/command/suite/normalizers/nfkc100/unify_to_katakana/za.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_to_katakana", true, \
+                     "report_source_offset", true)' \
+  "ざじずぜぞ" \
+  WITH_CHECKS|WITH_TYPES


### PR DESCRIPTION
This option normalize hiragana to katakana.
For example, `ゔぁゔぃゔゔぇゔぉ` normalize to `ヴァヴィヴヴェヴォ`.

We can identify below terms by `unify_to_katakana` and `unify_katakana_v_sounds`.

* ゔぁゔぃゔゔぇゔぉ
* ばびぶべぼ
* ヴァヴィヴヴェヴォ
* バビブベボ

---

* First, we apply `unify_to_katakana`.
  * ゔぁゔぃゔゔぇゔぉ -> ヴァヴィヴヴェヴォ
  * ばびぶべぼ -> バビブベボ
  * ヴァヴィヴヴェヴォ -> ヴァヴィヴヴェヴォ
  * バビブベボ -> バビブベボ

* Second, we apply `unify_katakana_v_sounds`.
  * ヴァヴィヴヴェヴォ -> バビブベボ
  * バビブベボ -> バビブベボ