### PR TITLE
travis: supress warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons_linux_build: &addons_linux_build
     packages:
       - autotools-dev
       - autoconf-archive
+      - automake1.11
       - zlib1g-dev
       - libmsgpack-dev
       - libevent-dev


### PR DESCRIPTION
Currently, Travis raises the following warning.
Because automake1.11 is not installed.

```
/home/travis/build/groonga/groonga/vendor/onigmo-source/missing: line 52: aclocal-1.11: command not found
WARNING: `aclocal-1.11' is missing on your system.  You should only need it if
         you modified `acinclude.m4' or `configure.ac'.  You might want
         to install the `Automake' and `Perl' packages.  Grab them from
         any GNU archive site.
/home/travis/build/groonga/groonga/vendor/onigmo-source/missing: line 52: automake-1.11: command not found
WARNING: `automake-1.11' is missing on your system.  You should only need it if
         you modified `Makefile.am', `acinclude.m4' or `configure.ac'.
         You might want to install the `Automake' and `Perl' packages.
         Grab them from any GNU archive site.
```