### PR TITLE
windows: remove extended path prefix \\?\

### DIFF
--- a/lib/grn_windows.h
+++ b/lib/grn_windows.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "grn.h"
+#include "wchar.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -440,7 +440,7 @@ grn_plugin_open(grn_ctx *ctx, const char *filename)
   } else {
     const char *label;
     label = grn_dl_open_error_label();
-    SERR("%s", label);
+    SERR("%s: <%.*s>", label, filename_size, filename);
   }
 
 exit:

--- a/lib/windows.c
+++ b/lib/windows.c
@@ -43,6 +43,12 @@ grn_windows_base_dir(void)
 
         absolute_dll_filename[absolute_dll_filename_size] = L'\0';
 
+        if (wcsncmp(absolute_dll_filename, L"\\\\?\\", 4) == 0) {
+          wmemmove(absolute_dll_filename, &absolute_dll_filename[4], absolute_dll_filename_size - 4);
+          absolute_dll_filename[absolute_dll_filename_size - 4] = L'\0';
+          absolute_dll_filename_size -= 4;
+        }
+
         for (i = 0; i < absolute_dll_filename_size; i++) {
           if (absolute_dll_filename[i] == L'\\') {
             absolute_dll_filename[i] = L'/';


### PR DESCRIPTION
There is a case that GetModuleFileNameW returns path which contains
extended path prefix \\?\ as module filename. It causes a bug that
plugin can't be found correctly because of this kind of extended path
prefix.

TODO: Support long path correctly on Windows. (Drop MAX_PATH limitation)

GitHub:#958

Reported by @yagisumi Thanks!!!