### PR TITLE
expr optimize: add support for accessor estimation

### DIFF
--- a/lib/mrb/scripts/expression_tree/binary_operation.rb
+++ b/lib/mrb/scripts/expression_tree/binary_operation.rb
@@ -203,7 +203,8 @@ module Groonga
         when Groonga::IndexColumn
           indexes << column
         when Groonga::Accessor
-          return estimate_size_query_accessor(table)
+          # TODO Implement this
+          return table.size
         else
           index_info = column.find_index(@operator)
           return table.size if index_info.nil?

--- a/lib/mrb/scripts/expression_tree/binary_operation.rb
+++ b/lib/mrb/scripts/expression_tree/binary_operation.rb
@@ -113,10 +113,6 @@ module Groonga
         end
       end
 
-      def estimate_size_query_accessor(table)
-        return table.size
-      end
-
       def estimate_size_range(table)
         return table.size unless @left.is_a?(Variable)
         return table.size unless @right.is_a?(Constant)

--- a/lib/mrb/scripts/expression_tree/binary_operation.rb
+++ b/lib/mrb/scripts/expression_tree/binary_operation.rb
@@ -113,6 +113,10 @@ module Groonga
         end
       end
 
+      def estimate_size_query_accessor(table)
+        return table.size
+      end
+
       def estimate_size_range(table)
         return table.size unless @left.is_a?(Variable)
         return table.size unless @right.is_a?(Constant)
@@ -198,6 +202,8 @@ module Groonga
           end
         when Groonga::IndexColumn
           indexes << column
+        when Groonga::Accessor
+          return estimate_size_query_accessor(table)
         else
           index_info = column.find_index(@operator)
           return table.size if index_info.nil?

--- a/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.expected
+++ b/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.expected
@@ -1,0 +1,83 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Users TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170315 User COLUMN_SCALAR Users
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170316 User COLUMN_SCALAR Users
+[[0,0.0,0.0],true]
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "User": "Suzuki"},
+{"timestamp": "2017/03/15 01:00:00", "User": "Yamada"},
+{"timestamp": "2017/03/15 02:00:00", "User": "Sato"}
+]
+[[0,0.0,0.0],3]
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "User":  "Yamada"},
+{"timestamp": "2017/03/16 11:00:00", "User":  "Yamada"},
+{"timestamp": "2017/03/16 12:00:00", "User":  "Yamamoto"}
+]
+[[0,0.0,0.0],3]
+column_create Users logs_20170315_index COLUMN_INDEX|WITH_POSITION Logs_20170315 User
+[[0,0.0,0.0],true]
+column_create Users logs_20170316_index COLUMN_INDEX|WITH_POSITION Logs_20170316 User
+[[0,0.0,0.0],true]
+logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        4
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "User",
+          "Users"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        2,
+        "yamada",
+        1489507200.0
+      ],
+      [
+        1,
+        "yamada",
+        1489626000.0
+      ],
+      [
+        2,
+        "yamada",
+        1489629600.0
+      ],
+      [
+        3,
+        "yamamoto",
+        1489633200.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.expected
+++ b/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.expected
@@ -1,38 +1,50 @@
 plugin_register sharding
 [[0,0.0,0.0],true]
-table_create Users TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+table_create Users TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
 table_create Logs_20170315 TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Logs_20170315 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-column_create Logs_20170315 User COLUMN_SCALAR Users
+column_create Logs_20170315 user COLUMN_SCALAR Users
+[[0,0.0,0.0],true]
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+column_create Logs_20170315 n_purchases COLUMN_SCALAR UInt32
 [[0,0.0,0.0],true]
 table_create Logs_20170316 TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Logs_20170316 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-column_create Logs_20170316 User COLUMN_SCALAR Users
+column_create Logs_20170316 user COLUMN_SCALAR Users
+[[0,0.0,0.0],true]
+column_create Logs_20170316 price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+column_create Logs_20170316 n_purchases COLUMN_SCALAR UInt32
 [[0,0.0,0.0],true]
 load --table Logs_20170315
 [
-{"timestamp": "2017/03/15 00:00:00", "User": "Suzuki"},
-{"timestamp": "2017/03/15 01:00:00", "User": "Yamada"},
-{"timestamp": "2017/03/15 02:00:00", "User": "Sato"}
+{"timestamp": "2017/03/15 00:00:00", "user": "Suzuki", "price": 100, "n_purchases": 3},
+{"timestamp": "2017/03/15 01:00:00", "user": "Yamada", "price": 300, "n_purchases": 3},
+{"timestamp": "2017/03/15 02:00:00", "user": "Sato", "price": 200, "n_purchases": 1}
 ]
 [[0,0.0,0.0],3]
 load --table Logs_20170316
 [
-{"timestamp": "2017/03/16 10:00:00", "User":  "Yamada"},
-{"timestamp": "2017/03/16 11:00:00", "User":  "Yamada"},
-{"timestamp": "2017/03/16 12:00:00", "User":  "Yamamoto"}
+{"timestamp": "2017/03/16 10:00:00", "user":  "Yamada", "price": 500, "n_purchases": 6},
+{"timestamp": "2017/03/16 11:00:00", "user":  "Yamada", "price": 600, "n_purchases": 6},
+{"timestamp": "2017/03/16 12:00:00", "user":  "Yamamoto", "price": 1000, "n_purchases": 3}
 ]
 [[0,0.0,0.0],3]
-column_create Users logs_20170315_index COLUMN_INDEX|WITH_POSITION Logs_20170315 User
+column_create Users logs_20170315_index COLUMN_INDEX Logs_20170315 user
 [[0,0.0,0.0],true]
-column_create Users logs_20170316_index COLUMN_INDEX|WITH_POSITION Logs_20170316 User
+column_create Users logs_20170316_index COLUMN_INDEX Logs_20170316 user
 [[0,0.0,0.0],true]
-logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'
+column_create Terms users_key COLUMN_INDEX|WITH_POSITION Users _key
+[[0,0.0,0.0],true]
+logical_select Logs   --shard_key timestamp   --filter "n_purchases>2"   --post_filter 'price>400 && (user._key @ "Yamamo")'
 [
   [
     0,
@@ -42,7 +54,7 @@ logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'
   [
     [
       [
-        4
+        1
       ],
       [
         [
@@ -50,33 +62,28 @@ logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'
           "UInt32"
         ],
         [
-          "User",
-          "Users"
+          "n_purchases",
+          "UInt32"
+        ],
+        [
+          "price",
+          "UInt32"
         ],
         [
           "timestamp",
           "Time"
+        ],
+        [
+          "user",
+          "Users"
         ]
       ],
       [
-        2,
-        "yamada",
-        1489507200.0
-      ],
-      [
-        1,
-        "yamada",
-        1489626000.0
-      ],
-      [
-        2,
-        "yamada",
-        1489629600.0
-      ],
-      [
         3,
-        "yamamoto",
-        1489633200.0
+        3,
+        1000,
+        1489633200.0,
+        "Yamamoto"
       ]
     ]
   ]

--- a/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.test
+++ b/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.test
@@ -1,0 +1,35 @@
+#$GRN_EXPR_OPTIMIZE=yes
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Users TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+
+table_create Logs_20170315 TABLE_NO_KEY
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+column_create Logs_20170315 User COLUMN_SCALAR Users
+
+table_create Logs_20170316 TABLE_NO_KEY
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+column_create Logs_20170316 User COLUMN_SCALAR Users
+
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "User": "Suzuki"},
+{"timestamp": "2017/03/15 01:00:00", "User": "Yamada"},
+{"timestamp": "2017/03/15 02:00:00", "User": "Sato"}
+]
+
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 10:00:00", "User":  "Yamada"},
+{"timestamp": "2017/03/16 11:00:00", "User":  "Yamada"},
+{"timestamp": "2017/03/16 12:00:00", "User":  "Yamamoto"}
+]
+
+column_create Users logs_20170315_index COLUMN_INDEX|WITH_POSITION Logs_20170315 User
+column_create Users logs_20170316_index COLUMN_INDEX|WITH_POSITION Logs_20170316 User
+
+logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'

--- a/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.test
+++ b/test/command/suite/sharding/logical_select/post_filter/accessor_optimize.test
@@ -1,35 +1,48 @@
+#TODO: Implement this
+
 #$GRN_EXPR_OPTIMIZE=yes
 #@on-error omit
 plugin_register sharding
 #@on-error default
 
-table_create Users TABLE_PAT_KEY ShortText \
+table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
   --normalizer NormalizerAuto
 
+table_create Users TABLE_PAT_KEY ShortText
+
 table_create Logs_20170315 TABLE_NO_KEY
 column_create Logs_20170315 timestamp COLUMN_SCALAR Time
-column_create Logs_20170315 User COLUMN_SCALAR Users
+column_create Logs_20170315 user COLUMN_SCALAR Users
+column_create Logs_20170315 price COLUMN_SCALAR UInt32
+column_create Logs_20170315 n_purchases COLUMN_SCALAR UInt32
 
 table_create Logs_20170316 TABLE_NO_KEY
 column_create Logs_20170316 timestamp COLUMN_SCALAR Time
-column_create Logs_20170316 User COLUMN_SCALAR Users
+column_create Logs_20170316 user COLUMN_SCALAR Users
+column_create Logs_20170316 price COLUMN_SCALAR UInt32
+column_create Logs_20170316 n_purchases COLUMN_SCALAR UInt32
 
 load --table Logs_20170315
 [
-{"timestamp": "2017/03/15 00:00:00", "User": "Suzuki"},
-{"timestamp": "2017/03/15 01:00:00", "User": "Yamada"},
-{"timestamp": "2017/03/15 02:00:00", "User": "Sato"}
+{"timestamp": "2017/03/15 00:00:00", "user": "Suzuki", "price": 100, "n_purchases": 3},
+{"timestamp": "2017/03/15 01:00:00", "user": "Yamada", "price": 300, "n_purchases": 3},
+{"timestamp": "2017/03/15 02:00:00", "user": "Sato", "price": 200, "n_purchases": 1}
 ]
 
 load --table Logs_20170316
 [
-{"timestamp": "2017/03/16 10:00:00", "User":  "Yamada"},
-{"timestamp": "2017/03/16 11:00:00", "User":  "Yamada"},
-{"timestamp": "2017/03/16 12:00:00", "User":  "Yamamoto"}
+{"timestamp": "2017/03/16 10:00:00", "user":  "Yamada", "price": 500, "n_purchases": 6},
+{"timestamp": "2017/03/16 11:00:00", "user":  "Yamada", "price": 600, "n_purchases": 6},
+{"timestamp": "2017/03/16 12:00:00", "user":  "Yamamoto", "price": 1000, "n_purchases": 3}
 ]
 
-column_create Users logs_20170315_index COLUMN_INDEX|WITH_POSITION Logs_20170315 User
-column_create Users logs_20170316_index COLUMN_INDEX|WITH_POSITION Logs_20170316 User
+column_create Users logs_20170315_index COLUMN_INDEX Logs_20170315 user
+column_create Users logs_20170316_index COLUMN_INDEX Logs_20170316 user
 
-logical_select Logs   --shard_key timestamp   --post_filter 'User._key @ "Yama"'
+column_create Terms users_key COLUMN_INDEX|WITH_POSITION Users _key
+
+logical_select Logs \
+  --shard_key timestamp \
+  --filter "n_purchases>2" \
+  --post_filter 'price>400 && (user._key @ "Yamamo")'


### PR DESCRIPTION
However, currently, this estimation is provisional.
It always returns table size.
We should estimate the number of hits.