### PR TITLE
Remove a needless enum

### DIFF
--- a/lib/grn_com.h
+++ b/lib/grn_com.h
@@ -98,14 +98,6 @@ typedef struct _grn_com_addr grn_com_addr;
 typedef void grn_com_callback(grn_ctx *ctx, grn_com_event *, grn_com *);
 typedef void grn_msg_handler(grn_ctx *ctx, grn_obj *msg);
 
-enum {
-  grn_com_ok = 0,
-  grn_com_emem,
-  grn_com_erecv_head,
-  grn_com_erecv_body,
-  grn_com_eproto,
-};
-
 struct _grn_com_addr {
   uint32_t addr;
   uint16_t port;


### PR DESCRIPTION
This enum has already unused.