### PR TITLE
appveyor: add UCRT runtime

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -152,12 +152,16 @@ on_success:
           $Env:VCREDIST_VCRUNTIME = "$Env:VCREDIST_DIR\Microsoft.VC141.CRT\vcruntime140.dll"
           $Env:VCREDIST_MSVCP = "$Env:VCREDIST_DIR\Microsoft.VC141.CRT\msvcp140.dll"
           $Env:LICENSE_FILE = $Env:APPVEYOR_BUILD_FOLDER + "\packages\windows\vcruntime\vs2017\readme.txt"
+          $Env:UCRT_REDIST_DIR = "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\$Env:ARCH"
+          $Env:UCRT_LICENSE_FILE = $Env:APPVEYOR_BUILD_FOLDER + "\packages\windows\vcruntime\ucrt-readme.txt"
         }
         "14" {
           $Env:VCREDIST_DIR = "C:\Program Files (x86)\Microsoft Visual Studio $Env:VS_VERSION.0\VC\redist\$Env:ARCH"
           $Env:VCREDIST_VCRUNTIME = "$Env:VCREDIST_DIR\Microsoft.VC140.CRT\vcruntime140.dll"
           $Env:VCREDIST_MSVCP = "$Env:VCREDIST_DIR\Microsoft.VC140.CRT\msvcp140.dll"
           $Env:LICENSE_FILE = $Env:APPVEYOR_BUILD_FOLDER + "\packages\windows\vcruntime\vs2015\readme.txt"
+          $Env:UCRT_REDIST_DIR = "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\$Env:ARCH"
+          $Env:UCRT_LICENSE_FILE = $Env:APPVEYOR_BUILD_FOLDER + "\packages\windows\vcruntime\ucrt-readme.txt"
         }
         "12" {
           $Env:VCREDIST_DIR = "C:\Program Files (x86)\Microsoft Visual Studio $Env:VS_VERSION.0\VC\redist\$Env:ARCH"
@@ -169,6 +173,11 @@ on_success:
   - copy "%VCREDIST_VCRUNTIME%" "%FULL_GROONGA_INSTALL_FOLDER%\bin"
   - copy "%VCREDIST_MSVCP%" "%FULL_GROONGA_INSTALL_FOLDER%\bin"
   - copy "%LICENSE_FILE%" "%FULL_GROONGA_INSTALL_FOLDER%\share\groonga\vcruntime"
+  - ps: |
+      if ($Env:UCRT_REDIST_DIR -ne "") {
+        Copy-Item $Env:UCRT_REDIST_DIR\*.dll -Destination $Env:FULL_GROONGA_INSTALL_FOLDER\bin\
+        Copy-Item $Env:UCRT_LICENSE_FILE -Destination $Env:FULL_GROONGA_INSTALL_FOLDER\share\groonga\vcruntime\
+      }
   - set ARTIFACT=%GROONGA_INSTALL_FOLDER%-with-vcruntime.zip
   - 7z a %ARTIFACT% %FULL_GROONGA_INSTALL_FOLDER%
   - ps: Push-AppveyorArtifact $Env:ARTIFACT

--- a/packages/windows/vcruntime/ucrt-readme.txt
+++ b/packages/windows/vcruntime/ucrt-readme.txt
@@ -1,0 +1,53 @@
+Subject to MICROSOFT WINDOWS SOFTWARE DEVELOPMENT KIT (SDK) FOR WINDOWS 10 [1], This package
+ contains Universal C Runtime files as redistributable code:
+
+[1] https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk
+
+See sdk_license.rtf in SDK section 2.a DISTRIBUTABLE CODE, "ii. Distribution Requirements" and
+"iii. Distribution Restrictions" for distribution.
+
+These files are bundled with this package without modification.
+
+* bin/api-ms-win-core-console-l1-1-0.dll
+* bin/api-ms-win-core-datetime-l1-1-0.dll
+* bin/api-ms-win-core-debug-l1-1-0.dll
+* bin/api-ms-win-core-errorhandling-l1-1-0.dll
+* bin/api-ms-win-core-file-l1-1-0.dll
+* bin/api-ms-win-core-file-l1-2-0.dll
+* bin/api-ms-win-core-file-l2-1-0.dll
+* bin/api-ms-win-core-handle-l1-1-0.dll
+* bin/api-ms-win-core-heap-l1-1-0.dll
+* bin/api-ms-win-core-interlocked-l1-1-0.dll
+* bin/api-ms-win-core-libraryloader-l1-1-0.dll
+* bin/api-ms-win-core-localization-l1-2-0.dll
+* bin/api-ms-win-core-memory-l1-1-0.dll
+* bin/api-ms-win-core-namedpipe-l1-1-0.dll
+* bin/api-ms-win-core-processenvironment-l1-1-0.dll
+* bin/api-ms-win-core-processthreads-l1-1-0.dll
+* bin/api-ms-win-core-processthreads-l1-1-1.dll
+* bin/api-ms-win-core-profile-l1-1-0.dll
+* bin/api-ms-win-core-rtlsupport-l1-1-0.dll
+* bin/api-ms-win-core-string-l1-1-0.dll
+* bin/api-ms-win-core-synch-l1-1-0.dll
+* bin/api-ms-win-core-synch-l1-2-0.dll
+* bin/api-ms-win-core-sysinfo-l1-1-0.dll
+* bin/api-ms-win-core-timezone-l1-1-0.dll
+* bin/api-ms-win-core-util-l1-1-0.dll
+* bin/api-ms-win-crt-conio-l1-1-0.dll
+* bin/api-ms-win-crt-convert-l1-1-0.dll
+* bin/api-ms-win-crt-environment-l1-1-0.dll
+* bin/api-ms-win-crt-filesystem-l1-1-0.dll
+* bin/api-ms-win-crt-heap-l1-1-0.dll
+* bin/api-ms-win-crt-locale-l1-1-0.dll
+* bin/api-ms-win-crt-math-l1-1-0.dll
+* bin/api-ms-win-crt-multibyte-l1-1-0.dll
+* bin/api-ms-win-crt-private-l1-1-0.dll
+* bin/api-ms-win-crt-process-l1-1-0.dll
+* bin/api-ms-win-crt-runtime-l1-1-0.dll
+* bin/api-ms-win-crt-stdio-l1-1-0.dll
+* bin/api-ms-win-crt-string-l1-1-0.dll
+* bin/api-ms-win-crt-time-l1-1-0.dll
+* bin/api-ms-win-crt-utility-l1-1-0.dll
+* bin/ucrtbase.dll
+
+See https://docs.microsoft.com/en-us/legal/windows-sdk/redist about above redistributable code details.


### PR DESCRIPTION
Usually UCRT runtime is automatically installed, but there is a case that it doesn't installed yet.
For such a specific environment, we use local-deployment.