### PR TITLE
appveyor: check empty environment correctly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -170,7 +170,7 @@ on_success:
   - copy "%VCREDIST_MSVCP%" "%FULL_GROONGA_INSTALL_FOLDER%\bin"
   - copy "%LICENSE_FILE%" "%FULL_GROONGA_INSTALL_FOLDER%\share\groonga\vcruntime"
   - ps: |
-      if ($Env:UCRT_REDIST_DIR -ne "") {
+      if ($Env:UCRT_REDIST_DIR) {
         Copy-Item $Env:UCRT_REDIST_DIR\*.dll -Destination $Env:FULL_GROONGA_INSTALL_FOLDER\bin\
         Copy-Item $Env:UCRT_LICENSE_FILE -Destination $Env:FULL_GROONGA_INSTALL_FOLDER\share\groonga\vcruntime\
       }


### PR DESCRIPTION
In the previous version, when (null -eq "") condition
is evaluated, the following block is executed unexpectedly.