### PR TITLE
test: fix parameter name in table_create

### DIFF
--- a/test/command/suite/io_flush/recursive/dependent/data_column/have_index.expected
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/have_index.expected
@@ -4,7 +4,7 @@ column_create Memos content COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
 column_create Memos timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --default_normalizer NormalizerNFKC100
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerNFKC100
 [[0,0.0,0.0],true]
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos content
 [[0,0.0,0.0],true]

--- a/test/command/suite/io_flush/recursive/dependent/data_column/have_index.test
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/have_index.test
@@ -4,7 +4,7 @@ column_create Memos timestamp COLUMN_SCALAR Time
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --default_normalizer NormalizerNFKC100
+  --normalizer NormalizerNFKC100
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos content
 column_create Terms is_stop_word COLUMN_SCALAR Bool
 

--- a/test/command/suite/io_flush/recursive/dependent/data_column/no_index.expected
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/no_index.expected
@@ -4,7 +4,7 @@ column_create Memos content COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
 column_create Memos timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --default_normalizer NormalizerNFKC100
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerNFKC100
 [[0,0.0,0.0],true]
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos _key
 [[0,0.0,0.0],true]

--- a/test/command/suite/io_flush/recursive/dependent/data_column/no_index.test
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/no_index.test
@@ -4,7 +4,7 @@ column_create Memos timestamp COLUMN_SCALAR Time
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --default_normalizer NormalizerNFKC100
+  --normalizer NormalizerNFKC100
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos _key
 column_create Terms is_stop_word COLUMN_SCALAR Bool
 

--- a/test/command/suite/io_flush/recursive/dependent/data_column/reference.expected
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/reference.expected
@@ -15,7 +15,7 @@ column_create Memos tags COLUMN_VECTOR Tags
 [[0,0.0,0.0],true]
 column_create Memos timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --default_normalizer NormalizerNFKC100
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerNFKC100
 [[0,0.0,0.0],true]
 column_create Terms tags_index   COLUMN_INDEX|WITH_POSITION|WITH_SECTION Tags _key,label
 [[0,0.0,0.0],true]

--- a/test/command/suite/io_flush/recursive/dependent/data_column/reference.test
+++ b/test/command/suite/io_flush/recursive/dependent/data_column/reference.test
@@ -12,7 +12,7 @@ column_create Memos timestamp COLUMN_SCALAR Time
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --default_normalizer NormalizerNFKC100
+  --normalizer NormalizerNFKC100
 column_create Terms tags_index \
   COLUMN_INDEX|WITH_POSITION|WITH_SECTION Tags _key,label
 column_create Terms is_stop_word COLUMN_SCALAR Bool

--- a/test/command/suite/io_flush/recursive/dependent/index_column/source_key.expected
+++ b/test/command/suite/io_flush/recursive/dependent/index_column/source_key.expected
@@ -2,7 +2,7 @@ table_create Memos TABLE_HASH_KEY ShortText
 [[0,0.0,0.0],true]
 column_create Memos timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --default_normalizer NormalizerNFKC100
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerNFKC100
 [[0,0.0,0.0],true]
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos _key
 [[0,0.0,0.0],true]

--- a/test/command/suite/io_flush/recursive/dependent/index_column/source_key.test
+++ b/test/command/suite/io_flush/recursive/dependent/index_column/source_key.test
@@ -3,7 +3,7 @@ column_create Memos timestamp COLUMN_SCALAR Time
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --default_normalizer NormalizerNFKC100
+  --normalizer NormalizerNFKC100
 column_create Terms memos_key_index COLUMN_INDEX|WITH_POSITION Memos _key
 column_create Terms is_stop_word COLUMN_SCALAR Bool
 

--- a/test/command/suite/io_flush/recursive/dependent/index_column/sources.expected
+++ b/test/command/suite/io_flush/recursive/dependent/index_column/sources.expected
@@ -6,7 +6,7 @@ column_create Memos content COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
 column_create Memos timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --default_normalizer NormalizerNFKC100
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerNFKC100
 [[0,0.0,0.0],true]
 column_create Terms memos_index   COLUMN_INDEX|WITH_POSITION|WITH_SECTION Memos _key,title,content
 [[0,0.0,0.0],true]

--- a/test/command/suite/io_flush/recursive/dependent/index_column/sources.test
+++ b/test/command/suite/io_flush/recursive/dependent/index_column/sources.test
@@ -5,7 +5,7 @@ column_create Memos timestamp COLUMN_SCALAR Time
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --default_normalizer NormalizerNFKC100
+  --normalizer NormalizerNFKC100
 column_create Terms memos_index \
   COLUMN_INDEX|WITH_POSITION|WITH_SECTION Memos _key,title,content
 column_create Terms is_stop_word COLUMN_SCALAR Bool

--- a/test/command/suite/select/filter/index/optimization/and_min_skip/equal_match_match.expected
+++ b/test/command/suite/select/filter/index/optimization/and_min_skip/equal_match_match.expected
@@ -8,7 +8,7 @@ column_create Memos tag COLUMN_SCALAR Tags
 [[0,0.0,0.0],true]
 column_create Memos content COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --normalize NormalizerNFKC100   --default_tokenizer TokenBigram
+table_create Terms TABLE_PAT_KEY ShortText   --normalizer NormalizerNFKC100   --default_tokenizer TokenBigram
 [[0,0.0,0.0],true]
 column_create Terms tags_label COLUMN_INDEX|WITH_POSITION Tags label
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/filter/index/optimization/and_min_skip/equal_match_match.test
+++ b/test/command/suite/select/filter/index/optimization/and_min_skip/equal_match_match.test
@@ -6,7 +6,7 @@ column_create Memos tag COLUMN_SCALAR Tags
 column_create Memos content COLUMN_SCALAR Text
 
 table_create Terms TABLE_PAT_KEY ShortText \
-  --normalize NormalizerNFKC100 \
+  --normalizer NormalizerNFKC100 \
   --default_tokenizer TokenBigram
 column_create Terms tags_label COLUMN_INDEX|WITH_POSITION Tags label
 column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content

--- a/test/command/suite/select/filter/index/optimization/and_min_skip/nested_index.expected
+++ b/test/command/suite/select/filter/index/optimization/and_min_skip/nested_index.expected
@@ -8,11 +8,11 @@ column_create Memos tag COLUMN_SCALAR Tags
 [[0,0.0,0.0],true]
 column_create Tags memos_tag COLUMN_INDEX Memos tag
 [[0,0.0,0.0],true]
-table_create UserTerms TABLE_PAT_KEY ShortText   --normalize NormalizerAuto   --default_tokenizer TokenBigram
+table_create UserTerms TABLE_PAT_KEY ShortText   --normalizer NormalizerAuto   --default_tokenizer TokenBigram
 [[0,0.0,0.0],true]
 column_create UserTerms memos_user COLUMN_INDEX|WITH_POSITION Memos user
 [[0,0.0,0.0],true]
-table_create TagTerms TABLE_PAT_KEY ShortText   --normalize NormalizerAuto   --default_tokenizer TokenBigram
+table_create TagTerms TABLE_PAT_KEY ShortText   --normalizer NormalizerAuto   --default_tokenizer TokenBigram
 [[0,0.0,0.0],true]
 column_create TagTerms tags_key COLUMN_INDEX|WITH_POSITION Tags _key
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/filter/index/optimization/and_min_skip/nested_index.test
+++ b/test/command/suite/select/filter/index/optimization/and_min_skip/nested_index.test
@@ -7,12 +7,12 @@ column_create Memos tag COLUMN_SCALAR Tags
 column_create Tags memos_tag COLUMN_INDEX Memos tag
 
 table_create UserTerms TABLE_PAT_KEY ShortText \
-  --normalize NormalizerAuto \
+  --normalizer NormalizerAuto \
   --default_tokenizer TokenBigram
 column_create UserTerms memos_user COLUMN_INDEX|WITH_POSITION Memos user
 
 table_create TagTerms TABLE_PAT_KEY ShortText \
-  --normalize NormalizerAuto \
+  --normalizer NormalizerAuto \
   --default_tokenizer TokenBigram
 column_create TagTerms tags_key COLUMN_INDEX|WITH_POSITION Tags _key
 

--- a/test/command/suite/select/query/match/with_index/token_mecab/use_reading.expected
+++ b/test/command/suite/select/query/match/with_index/token_mecab/use_reading.expected
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Menus name COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --normalize NormalizerNFKC100   --default_tokenizer 'TokenMecab("use_reading", true)'
+table_create Terms TABLE_PAT_KEY ShortText   --normalizer NormalizerNFKC100   --default_tokenizer 'TokenMecab("use_reading", true)'
 [[0,0.0,0.0],true]
 column_create Terms index COLUMN_INDEX|WITH_POSITION Menus name
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/query/match/with_index/token_mecab/use_reading.test
+++ b/test/command/suite/select/query/match/with_index/token_mecab/use_reading.test
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 column_create Menus name COLUMN_SCALAR Text
 
 table_create Terms TABLE_PAT_KEY ShortText \
-  --normalize NormalizerNFKC100 \
+  --normalizer NormalizerNFKC100 \
   --default_tokenizer 'TokenMecab("use_reading", true)'
 column_create Terms index COLUMN_INDEX|WITH_POSITION Menus name
 

--- a/test/command/suite/select/query/match/with_index/token_pattern/match.expected
+++ b/test/command/suite/select/query/match/with_index/token_pattern/match.expected
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Menus name COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
-table_create Keywords TABLE_PAT_KEY ShortText   --normalize NormalizerNFKC100   --default_tokenizer 'TokenPattern("pattern", "焼き?肉")'
+table_create Keywords TABLE_PAT_KEY ShortText   --normalizer NormalizerNFKC100   --default_tokenizer 'TokenPattern("pattern", "焼き?肉")'
 [[0,0.0,0.0],true]
 column_create Keywords index COLUMN_INDEX Menus name
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/query/match/with_index/token_pattern/match.test
+++ b/test/command/suite/select/query/match/with_index/token_pattern/match.test
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 column_create Menus name COLUMN_SCALAR Text
 
 table_create Keywords TABLE_PAT_KEY ShortText \
-  --normalize NormalizerNFKC100 \
+  --normalizer NormalizerNFKC100 \
   --default_tokenizer 'TokenPattern("pattern", "焼き?肉")'
 column_create Keywords index COLUMN_INDEX Menus name
 

--- a/test/command/suite/select/query/match/with_index/token_table/same.expected
+++ b/test/command/suite/select/query/match/with_index/token_table/same.expected
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Menus name COLUMN_SCALAR Text
 [[0,0.0,0.0],true]
-table_create Keywords TABLE_PAT_KEY ShortText   --normalize NormalizerNFKC100   --default_tokenizer 'TokenTable("table", "Keywords")'
+table_create Keywords TABLE_PAT_KEY ShortText   --normalizer NormalizerNFKC100   --default_tokenizer 'TokenTable("table", "Keywords")'
 [[0,0.0,0.0],true]
 column_create Keywords index COLUMN_INDEX Menus name
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/query/match/with_index/token_table/same.test
+++ b/test/command/suite/select/query/match/with_index/token_table/same.test
@@ -2,7 +2,7 @@ table_create Menus TABLE_NO_KEY
 column_create Menus name COLUMN_SCALAR Text
 
 table_create Keywords TABLE_PAT_KEY ShortText \
-  --normalize NormalizerNFKC100 \
+  --normalizer NormalizerNFKC100 \
   --default_tokenizer 'TokenTable("table", "Keywords")'
 column_create Keywords index COLUMN_INDEX Menus name
 


### PR DESCRIPTION
`table_create`の`normalizer`が間違えられがちなので、直しました。
テストの結果に影響はありませんでした。

default_normalizer -> normalizer
normalize -> normalizer