### PR TITLE
windows: fix build error on MinGW

### DIFF
--- a/vendor/mruby/Makefile.am
+++ b/vendor/mruby/Makefile.am
@@ -8,6 +8,7 @@ EXTRA_DIST =					\
 	mruby-dir/src/Win/dirent.c
 
 DEFAULT_INCLUDES =						\
+	-I$(builddir)/mruby-file-stat/src			\
 	-I$(srcdir)/../mruby-source/include			\
 	-I$(srcdir)/../mruby-source/src				\
 	-I$(srcdir)/../mruby-source/mrbgems/mruby-compiler/core	\


### PR DESCRIPTION
Patch via
https://github.com/msys2/MINGW-packages/commit/9c76ae395dd490b259d270608b47d130c6245490#diff-b266d04f16a509dc5bd3a3d12ca9df53