### PR TITLE
grn_output_range_normalize: fix wrong variable reference

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -44,7 +44,7 @@ grn_output_range_normalize(grn_ctx *ctx, int size, int *offset, int *limit)
 
   if (normalized_limit < 0) {
     normalized_limit += size + 1;
-    if (limit < 0) {
+    if (normalized_limit < 0) {
       *offset = 0;
       *limit = 0;
       return GRN_TOO_SMALL_LIMIT;


### PR DESCRIPTION
In the previous commit, it breaks range_filter/too_small_limit test case.

  range_filter Memos id --limit -2
  -[[[-22,0.0,0.0],"[range_filter] too small limit: <-2>"]]
  -#|e| [range_filter] too small limit: <-2>
  +[[0,0.0,0.0],[[["_id","UInt32"],["id","Int32"],["text","Text"]]]]