### PR TITLE
Add missing check about m4 macro availability

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,4 +30,21 @@ git submodule update --init
 
 mkdir -p m4
 
+# ax_cxx_compile_stdcxx macro is required to check compiler option correctly
+if [ -x /usr/bin/dpkg -o -x /bin/dpkg ]; then
+  if ! dpkg -s autoconf-archive > /dev/null; then
+    echo "ERROR: autoconf-archive package is not installed yet."
+    exit 1
+  fi
+elif [ -x /usr/bin/rpm -o -x /bin/rpm ]; then
+  if ! rpm -q autoconf-archive > /dev/null; then
+    echo "ERROR: autoconf-archive package is not installed yet."
+    exit 1
+  fi
+elif [ ! -f /usr/share/aclocal/ax_cxx_compile_stdcxx_11.m4 -a \
+       ! -f /usr/local/share/aclocal/ax_cxx_compile_stdcxx_11.m4 ]; then
+  echo "ERROR: autoconf-archive is not installed yet."
+  exit 1
+fi
+
 ${AUTORECONF:-autoreconf} --force --install "$@"


### PR DESCRIPTION
When RapidJSON support is enabled, proper compiler option must be
set by AX_CXX_COMPILE_STDCXX_11 macro. This m4 macro
is distributed in autoconf-archive package. We need to
enable it before regenerating configure script correctly.