### PR TITLE
Detect libedit at configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -823,8 +823,8 @@ AM_CONDITIONAL([WITH_LEMON], [test "$lemon_available" = "yes"])
 # libedit
 libedit_available="no"
 AC_ARG_WITH([libedit],
-            AS_HELP_STRING([--with-libedit=PATH],
-                           [libedit path (default: auto)]),
+            AS_HELP_STRING([--with-libedit],
+                           [Support line editing (default: auto)]),
             [LIBEDIT="$withval"],
             [: ${LIBEDIT:=auto}])
 

--- a/configure.ac
+++ b/configure.ac
@@ -821,33 +821,41 @@ AC_SUBST(LEMON)
 AM_CONDITIONAL([WITH_LEMON], [test "$lemon_available" = "yes"])
 
 # libedit
-AC_ARG_ENABLE(libedit,
-  [AS_HELP_STRING([--disable-libedit],
-    [use libedit for console. [default=auto-detect]])],
-  [enable_libedit="$enableval"],
-  [enable_libedit="auto"])
-if test "x$enable_libedit" != "xno"; then
-  m4_ifdef([PKG_CHECK_MODULES], [
-    PKG_CHECK_MODULES([LIBEDIT], [libedit >= 3.0],
-      [LIBS_SAVE="$LIBS"
-       LDFLAGS_SAVE="$LDFLAGS"
-       LDFLAGS="$LIBEDIT_LIBS $LDFLAGS"
-       AC_SEARCH_LIBS(el_wline, edit,
-                      [libedit_available=yes],
-                      [libedit_available=no])
-       LIBS="$LIBS_SAVE"
-       LDFLAGS="$LDFLAGS_SAVE"],
-      [libedit_available=no])
-    ],
-    [libedit_available=no])
-  if test "x$libedit_available" = "xyes"; then
-    AC_DEFINE(GRN_WITH_LIBEDIT, [1], [Use libedit with multibyte support.])
+libedit_available="no"
+AC_ARG_WITH([libedit],
+            AS_HELP_STRING([--with-libedit=PATH],
+                           [libedit path (default: auto)]),
+            [LIBEDIT="$withval"],
+            [: ${LIBEDIT:=auto}])
+
+if test "$LIBEDIT" = "no"; then
+  LIBEDIT=
+  AC_MSG_WARN([libedit is disabled. CLI does not support line editing.])
+else
+  if test "$LIBEDIT" = "auto"; then
+    AC_CHECK_LIB(edit, el_init,
+                 [LIBEDIT="yes"],
+                 [LIBEDIT="none"])
+    if test "$LIBEDIT" != "none"; then
+      libedit_available="yes"
+      LIBEDIT_LIBS="-ledit"
+    fi
   else
-    if test "x$enable_editline" = "xyes"; then
+    AC_CHECK_LIB(edit, el_init,
+                 [LIBEDIT="yes"],
+                 [LIBEDIT="none"])
+    if test "$LIBEDIT" = "none"; then
       AC_MSG_ERROR("No libedit found")
+    else
+      libedit_available="yes"
+      LIBEDIT_LIBS="-ledit"
     fi
   fi
 fi
+if test "$libedit_available" = "yes"; then
+  AC_DEFINE(GRN_WITH_LIBEDIT, 1, [Define to 1 if libedit works])
+fi
+AC_SUBST(LIBEDIT_LIBS)
 
 # zlib
 AC_ARG_WITH(zlib,
@@ -1842,6 +1850,11 @@ echo "  MessagePack:           $message_pack_available"
 if test "x$message_pack_available" = "xyes"; then
   echo "    CFLAGS:              ${MESSAGE_PACK_CFLAGS}"
   echo "    LIBS:                ${MESSAGE_PACK_LIBS}"
+fi
+echo "  libedit:               $libedit_available"
+if test "x$libedit_available" = "xyes"; then
+  echo "    CFLAGS:              ${LIBEDIT_CFLAGS}"
+  echo "    LIBS:                ${LIBEDIT_LIBS}"
 fi
 echo "  LZ4:                   $GRN_WITH_LZ4"
 if test "x$GRN_WITH_LZ4" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -825,44 +825,53 @@ libedit_available="no"
 AC_ARG_WITH([libedit],
             AS_HELP_STRING([--with-libedit],
                            [Support line editing (default: auto)]),
-            [LIBEDIT="$withval"],
-            [: ${LIBEDIT:=auto}])
+            [with_libedit="$withval"],
+            [: ${with_libedit:=auto}])
 
-if test "$LIBEDIT" = "no"; then
-  LIBEDIT=
+if test "${with_libedit}" = "no"; then
+  LIBEDIT_CFLAGS=
+  LIBEDIT_LIBS=
 else
-  m4_ifdef([PKG_CHECK_MODULES], [
-    PKG_CHECK_MODULES([LIBEDIT],
-                      [libedit],
-                      [libedit_available=yes],
-                      [])
-  ],
-  [])
-  if test "$libedit_available" != "yes"; then
-    LIBEDIT_CFLAGS=""
-    LIBEDIT_LDFLAGS=""
-    if test "$LIBEDIT" != "auto" -a "$LIBEDIT" != "yes"; then
-      LIBEDIT_CFLAGS="-I${LIBEDIT}/include"
-      LIBEDIT_LDFLAGS="-L${LIBEDIT}/lib"
-      CFLAGS="${CFLAGS} ${LIBEDIT_CFLAGS}"
-      LDFLAGS="${LDFLAGS} ${LIBEDIT_LDFLAGS}"
-    fi
-    AC_CHECK_LIB(edit, el_init,[
-      AC_CHECK_HEADER("histedit.h",
-        [libedit_available="yes"; LIBEDIT_LIBS="-ledit ${LIBEDIT_LDFLAGS}"],
-        [])
-    ],[])
-    if test "$libedit_available" != "yes" -a "$LIBEDIT" != "auto"; then
+  if test "${with_libedit}" = "yes" -o "${with_libedit}" = "auto"; then
+    LIBEDIT_CFLAGS=
+    LIBEDIT_LIBS=
+    m4_ifdef([PKG_CHECK_MODULES], [
+      PKG_CHECK_MODULES([LIBEDIT],
+			[libedit >= 3.0],
+			[],
+			[LIBEDIT_LIBS="-ledit"])
+    ])
+  else
+    LIBEDIT_CFLAGS="-I${with_libedit}/include"
+    LIBEDIT_LIBS="-L${with_libedit}/lib -ledit"
+  fi
+  CFLAGS_SAVE="${CFLAGS}"
+  LDFLAGS_SAVE="${LDFLAGS}"
+  CFLAGS="${LIBEDIT_CFLAGS} ${CFLAGS}"
+  LDFLAGS="${LIBEDIT_LIBS} ${LDFLAGS}"
+  AC_SEARCH_LIBS(el_wline,
+                 ,
+                 [libedit_available="yes"],
+                 [libedit_available="no"])
+  if test "${libedit_available}" = "yes"; then
+    AC_CHECK_HEADERS(histedit.h,
+                     [],
+                     [libedit_available="no"])
+  fi
+  CFLAGS="${CFLAGS_SAVE}"
+  LDFLAGS="${LDFLAGS_SAVE}"
+  if test "${libedit_available}" = "yes"; then
+    AC_DEFINE(GRN_WITH_LIBEDIT, 1, [Define to 1 if libedit works])
+  else
+    LIBEDIT_CFLAGS=
+    LIBEDIT_LIBS=
+    if test "${with_libedit}" != "auto"; then
       AC_MSG_ERROR("No libedit found")
     fi
   fi
-  if test "$libedit_available" = "yes"; then
-    AC_DEFINE(GRN_WITH_LIBEDIT, 1, [Define to 1 if libedit works])
-    AC_SUBST(LIBEDIT_CFLAGS)
-    AC_SUBST(LIBEDIT_LIBS)
-  fi
 fi
-
+AC_SUBST(LIBEDIT_CFLAGS)
+AC_SUBST(LIBEDIT_LIBS)
 
 # zlib
 AC_ARG_WITH(zlib,

--- a/configure.ac
+++ b/configure.ac
@@ -830,32 +830,39 @@ AC_ARG_WITH([libedit],
 
 if test "$LIBEDIT" = "no"; then
   LIBEDIT=
-  AC_MSG_WARN([libedit is disabled. CLI does not support line editing.])
 else
-  if test "$LIBEDIT" = "auto"; then
-    AC_CHECK_LIB(edit, el_init,
-                 [LIBEDIT="yes"],
-                 [LIBEDIT="none"])
-    if test "$LIBEDIT" != "none"; then
-      libedit_available="yes"
-      LIBEDIT_LIBS="-ledit"
+  m4_ifdef([PKG_CHECK_MODULES], [
+    PKG_CHECK_MODULES([LIBEDIT],
+                      [libedit],
+                      [libedit_available=yes],
+                      [])
+  ],
+  [])
+  if test "$libedit_available" != "yes"; then
+    LIBEDIT_CFLAGS=""
+    LIBEDIT_LDFLAGS=""
+    if test "$LIBEDIT" != "auto" -a "$LIBEDIT" != "yes"; then
+      LIBEDIT_CFLAGS="-I${LIBEDIT}/include"
+      LIBEDIT_LDFLAGS="-L${LIBEDIT}/lib"
+      CFLAGS="${CFLAGS} ${LIBEDIT_CFLAGS}"
+      LDFLAGS="${LDFLAGS} ${LIBEDIT_LDFLAGS}"
     fi
-  else
-    AC_CHECK_LIB(edit, el_init,
-                 [LIBEDIT="yes"],
-                 [LIBEDIT="none"])
-    if test "$LIBEDIT" = "none"; then
+    AC_CHECK_LIB(edit, el_init,[
+      AC_CHECK_HEADER("histedit.h",
+        [libedit_available="yes"; LIBEDIT_LIBS="-ledit ${LIBEDIT_LDFLAGS}"],
+        [])
+    ],[])
+    if test "$libedit_available" != "yes" -a "$LIBEDIT" != "auto"; then
       AC_MSG_ERROR("No libedit found")
-    else
-      libedit_available="yes"
-      LIBEDIT_LIBS="-ledit"
     fi
   fi
+  if test "$libedit_available" = "yes"; then
+    AC_DEFINE(GRN_WITH_LIBEDIT, 1, [Define to 1 if libedit works])
+    AC_SUBST(LIBEDIT_CFLAGS)
+    AC_SUBST(LIBEDIT_LIBS)
+  fi
 fi
-if test "$libedit_available" = "yes"; then
-  AC_DEFINE(GRN_WITH_LIBEDIT, 1, [Define to 1 if libedit works])
-fi
-AC_SUBST(LIBEDIT_LIBS)
+
 
 # zlib
 AC_ARG_WITH(zlib,


### PR DESCRIPTION
The configure phase did not detect libedit despite installing dev files and this fix makes it work properly.
Verified on FreeBSD 11 and Debian 9.