### PR TITLE
logical_range_filter: fix exception about closing same object twice

### DIFF
--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -919,7 +919,7 @@ module Groonga
               return
             end
             if @range_index
-              filter_by_range(range_index,
+              filter_by_range(range_index ? range_index : @range_index,
                               nil, nil,
                               nil, nil)
             else
@@ -927,7 +927,7 @@ module Groonga
             end
           else
             if @range_index
-              filter_by_range(range_index,
+              filter_by_range(range_index ? range_index : @range_index,
                               nil, nil,
                               nil, nil)
             else
@@ -1002,7 +1002,9 @@ module Groonga
                 decide_use_range_index(false,
                                        fallback_message,
                                        __LINE__, __method__)
+                @disable_estimate_unmatched_records = true
                 execute_filter(nil)
+                @disable_estimate_unmatched_records = false
                 return
               end
             end
@@ -1051,6 +1053,9 @@ module Groonga
         end
 
         def compute_max_n_unmatched_records(data_table_size, limit)
+          if @disable_estimate_unmatched_records
+            return data_table_size
+          end
           max_n_unmatched_records = limit * 100
           max_n_sample_records = data_table_size
           if max_n_sample_records > 10000

--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -954,66 +954,60 @@ module Groonga
 
           result_set = HashTable.create(:flags => ObjectFlags::WITH_SUBREC,
                                         :key_type => data_table)
+          @temporary_tables << result_set
           n_matched_records = 0
-          begin
-            TableCursor.open(lexicon,
-                             :min => min,
-                             :max => max,
-                             :flags => flags) do |table_cursor|
-              options = {
-                :offset => @context.current_offset,
-              }
-              current_limit = @context.current_limit
-              if current_limit < 0
-                options[:limit] = data_table.size
-              else
-                options[:limit] = current_limit
-              end
-              max_n_unmatched_records =
-                compute_max_n_unmatched_records(data_table.size,
-                                                options[:limit])
-              options[:max_n_unmatched_records] = max_n_unmatched_records
-              if @filter
-                create_expression(data_table) do |expression|
-                  expression.parse(@filter)
-                  options[:expression] = expression
-                  IndexCursor.open(table_cursor, range_index) do |index_cursor|
-                    n_matched_records = index_cursor.select(result_set, options)
-                  end
-                end
-                # TODO: Add range information
-                query_logger.log(:size, ":",
-                                 "filter(#{n_matched_records})" +
-                                 "[#{@shard.table_name}]: #{@filter}")
-              else
+          TableCursor.open(lexicon,
+                           :min => min,
+                           :max => max,
+                           :flags => flags) do |table_cursor|
+            options = {
+              :offset => @context.current_offset,
+            }
+            current_limit = @context.current_limit
+            if current_limit < 0
+              options[:limit] = data_table.size
+            else
+              options[:limit] = current_limit
+            end
+            max_n_unmatched_records =
+              compute_max_n_unmatched_records(data_table.size,
+                                              options[:limit])
+            options[:max_n_unmatched_records] = max_n_unmatched_records
+            if @filter
+              create_expression(data_table) do |expression|
+                expression.parse(@filter)
+                options[:expression] = expression
                 IndexCursor.open(table_cursor, range_index) do |index_cursor|
                   n_matched_records = index_cursor.select(result_set, options)
                 end
-                # TODO: Add range information
-                query_logger.log(:size, ":",
-                                 "filter(#{n_matched_records})" +
-                                 "[#{@shard.table_name}]")
               end
-              if n_matched_records == -1
-                result_set.close
-                fallback_message =
-                  "fallback because there are too much unmatched records: "
-                fallback_message << "<#{max_n_unmatched_records}>"
-                decide_use_range_index(false,
-                                       fallback_message,
-                                       __LINE__, __method__)
-                execute_filter(nil)
-                return
+              # TODO: Add range information
+              query_logger.log(:size, ":",
+                               "filter(#{n_matched_records})" +
+                               "[#{@shard.table_name}]: #{@filter}")
+            else
+              IndexCursor.open(table_cursor, range_index) do |index_cursor|
+                n_matched_records = index_cursor.select(result_set, options)
               end
+              # TODO: Add range information
+              query_logger.log(:size, ":",
+                               "filter(#{n_matched_records})" +
+                               "[#{@shard.table_name}]")
             end
-          rescue => error
-            result_set.close
-            raise error
+            if n_matched_records == -1
+              fallback_message =
+                "fallback because there are too much unmatched records: "
+              fallback_message << "<#{max_n_unmatched_records}>"
+              decide_use_range_index(false,
+                                     fallback_message,
+                                     __LINE__, __method__)
+              execute_filter(nil)
+              return
+            end
           end
 
           if n_matched_records <= @context.current_offset
             @context.current_offset -= n_matched_records
-            @temporary_tables << result_set
             return
           end
 
@@ -1023,7 +1017,6 @@ module Groonga
           if @context.current_limit > 0
             @context.current_limit -= result_set.size
           end
-          @temporary_tables << result_set
           @result_sets << result_set
         end
 

--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -918,16 +918,16 @@ module Groonga
               @context.current_offset -= table.size
               return
             end
-            if @range_index
-              filter_by_range(range_index ? range_index : @range_index,
+            if range_index
+              filter_by_range(range_index,
                               nil, nil,
                               nil, nil)
             else
               add_filtered_result_set(table)
             end
           else
-            if @range_index
-              filter_by_range(range_index ? range_index : @range_index,
+            if range_index
+              filter_by_range(range_index,
                               nil, nil,
                               nil, nil)
             else
@@ -1002,9 +1002,7 @@ module Groonga
                 decide_use_range_index(false,
                                        fallback_message,
                                        __LINE__, __method__)
-                @disable_estimate_unmatched_records = true
                 execute_filter(nil)
-                @disable_estimate_unmatched_records = false
                 return
               end
             end
@@ -1053,9 +1051,6 @@ module Groonga
         end
 
         def compute_max_n_unmatched_records(data_table_size, limit)
-          if @disable_estimate_unmatched_records
-            return data_table_size
-          end
           max_n_unmatched_records = limit * 100
           max_n_sample_records = data_table_size
           if max_n_sample_records > 10000

--- a/test/command/suite/sharding/logical_range_filter/limit/positive/many_unmatched_records.expected
+++ b/test/command/suite/sharding/logical_range_filter/limit/positive/many_unmatched_records.expected
@@ -1,0 +1,7 @@
+load --table Logs_20150204
+[
+{"timestamp": "2015-02-04 00:00:00", "memo": "2015-02-04 00:00:00", "message": "Shutdown"}
+]
+[[0,0.0,0.0],1]
+logical_range_filter Logs timestamp   --filter 'message == "Shutdown"'   --min "2015-02-03 00:00:00"   --min_border "include"   --max "2015-02-04 00:00:00"   --max_border "exclude"   --limit 10000
+[[0,0.0,0.0],[[["memo","ShortText"],["message","Text"],["timestamp","Time"]]]]

--- a/test/command/suite/sharding/logical_range_filter/limit/positive/many_unmatched_records.test
+++ b/test/command/suite/sharding/logical_range_filter/limit/positive/many_unmatched_records.test
@@ -1,0 +1,18 @@
+#@include fixture/sharding/logical_range_filter/index/schema.grn
+
+#@disable-logging
+#@generate-series 0 10000 Logs_20150203 '{"timestamp": "2015-02-03 23:59:59", "memo": "2015-02-03 23:59:59", "message": "Start"}'
+#@enable-logging
+
+load --table Logs_20150204
+[
+{"timestamp": "2015-02-04 00:00:00", "memo": "2015-02-04 00:00:00", "message": "Shutdown"}
+]
+
+logical_range_filter Logs timestamp \
+  --filter 'message == "Shutdown"' \
+  --min "2015-02-03 00:00:00" \
+  --min_border "include" \
+  --max "2015-02-04 00:00:00" \
+  --max_border "exclude" \
+  --limit 10000


### PR DESCRIPTION
This commit fixes the following error:

  #|e| ArgumentError: already closed object

This exception occurs when max_n_unmatched_records estimation
is not accurate. In such a case, execute_filter(nil) is executed
as a fallback without specifying range index, as a result, no
method exception is raised and closes same object twice in
ensure block.