### PR TITLE
com: fix a bug that conditional expression always false

### DIFF
--- a/lib/com.c
+++ b/lib/com.c
@@ -105,7 +105,7 @@ grn_com_queue_deque(grn_ctx *ctx, grn_com_queue *q)
   CRITICAL_SECTION_ENTER(q->cs);
   if (q->next) {
     e = q->next;
-    if (!(q->next = e->next)) { q->tail = &q->next; }
+    if (q->next != e->next) { q->tail = &q->next; }
   }
   CRITICAL_SECTION_LEAVE(q->cs);
 


### PR DESCRIPTION
I think `if (!(q->next = e->next))` is always false.
So, `q->tail = &q->next;` doesn't execute.

Does this code on purpose, or a bug?