### PR TITLE
configure: fix test(1) portability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -967,7 +967,7 @@ AC_ARG_WITH(rapidjson,
   [with_rapidjson="$withval"],
   [with_rapidjson="auto"])
 if test "x$with_rapidjson" != "xno"; then
-  if test "x$with_rapidjson" == "xbundled"; then
+  if test "x$with_rapidjson" = "xbundled"; then
     RAPIDJSON_CFLAGS="-I\$(top_srcdir)/vendor/rapidjson-${BUNDLED_RAPIDJSON_VERSION}/include"
     GRN_WITH_RAPIDJSON=yes
   else


### PR DESCRIPTION
`==` operator for test(1) is not in the standard, then not portable.