### PR TITLE
Add new option for tokenmecab

### DIFF
--- a/plugins/tokenizers/mecab.c
+++ b/plugins/tokenizers/mecab.c
@@ -50,7 +50,7 @@ static const size_t GRN_MECAB_FEATURE_LOCATION_CLASS = 0;
 static const size_t GRN_MECAB_FEATURE_LOCATION_SUBCLASS0 = 1;
 static const size_t GRN_MECAB_FEATURE_LOCATION_SUBCLASS1 = 2;
 static const size_t GRN_MECAB_FEATURE_LOCATION_SUBCLASS2 = 3;
-static const size_t GRN_MECAB_FEATURE_LOCATION_BASE = 6;
+static const size_t GRN_MECAB_FEATURE_LOCATION_BASE_FORM = 6;
 static const size_t GRN_MECAB_FEATURE_LOCATION_READING = 7;
 
 typedef struct {
@@ -938,7 +938,7 @@ mecab_next_default_format(grn_ctx *ctx,
     size_t base_form_length;
     base_form_length = mecab_get_feature(ctx,
                                          feature_locations,
-                                         GRN_MECAB_FEATURE_LOCATION_BASE,
+                                         GRN_MECAB_FEATURE_LOCATION_BASE_FORM,
                                          &base_form);
     if (base_form_length > 0) {
       grn_token_set_data(ctx, token, base_form, base_form_length);
@@ -981,7 +981,7 @@ mecab_next_default_format(grn_ctx *ctx,
     mecab_next_default_format_add_feature(ctx,
                                           &data,
                                           "base_form",
-                                          GRN_MECAB_FEATURE_LOCATION_BASE);
+                                          GRN_MECAB_FEATURE_LOCATION_BASE_FORM);
   }
   {
     grn_tokenizer_status status;

--- a/plugins/tokenizers/mecab.c
+++ b/plugins/tokenizers/mecab.c
@@ -978,7 +978,10 @@ mecab_next_default_format(grn_ctx *ctx,
     data.ignore_asterisk_value = GRN_TRUE;
     mecab_next_default_format_add_feature(ctx, &data, "inflected_type", 4);
     mecab_next_default_format_add_feature(ctx, &data, "inflected_form", 5);
-    mecab_next_default_format_add_feature(ctx, &data, "base_form", 6);
+    mecab_next_default_format_add_feature(ctx,
+                                          &data,
+                                          "base_form",
+                                          GRN_MECAB_FEATURE_LOCATION_BASE);
   }
   {
     grn_tokenizer_status status;

--- a/plugins/tokenizers/mecab.c
+++ b/plugins/tokenizers/mecab.c
@@ -929,10 +929,7 @@ mecab_next_default_format(grn_ctx *ctx,
     } else {
       grn_token_set_data(ctx, token, surface, surface_length);
     }
-  } else {
-    grn_token_set_data(ctx, token, surface, surface_length);
-  }
-  if (tokenizer->options->use_base_form) {
+  } else if (tokenizer->options->use_base_form) {
     grn_obj *feature_locations = &(tokenizer->feature_locations);
     const char *base_form = NULL;
     size_t base_form_length;
@@ -942,7 +939,11 @@ mecab_next_default_format(grn_ctx *ctx,
                                          &base_form);
     if (base_form_length > 0) {
       grn_token_set_data(ctx, token, base_form, base_form_length);
+    } else {
+      grn_token_set_data(ctx, token, surface, surface_length);
     }
+  } else {
+    grn_token_set_data(ctx, token, surface, surface_length);
   }
   if (tokenizer->options->include_class) {
     add_feature_data data;

--- a/test/command/suite/tokenizers/mecab/options/use_base_form.expected
+++ b/test/command/suite/tokenizers/mecab/options/use_base_form.expected
@@ -1,0 +1,46 @@
+tokenize   'TokenMecab("use_base_form", true)'    '支える 支えられた 支えた'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "支える",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "支える",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "られる",
+      "position": 2,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "た",
+      "position": 3,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "支える",
+      "position": 4,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "た",
+      "position": 5,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/tokenizers/mecab/options/use_base_form.test
+++ b/test/command/suite/tokenizers/mecab/options/use_base_form.test
@@ -1,0 +1,1 @@
+tokenize   'TokenMecab("use_base_form", true)'    '支える 支えられた 支えた'


### PR DESCRIPTION
We can search using the base form of a token by this option.
For example, if we search "支えた" using this option, "支える" is hit also.