### PR TITLE
package ubuntu: add support for Ubuntu 20.04 (Focal Fossa)

### DIFF
--- a/packages/launchpad-helper.rb
+++ b/packages/launchpad-helper.rb
@@ -37,6 +37,7 @@ module LaunchpadHelper
       ["bionic", "18.04"],
       ["disco", "19.04"],
       ["eoan", "19.10"],
+      ["focal", "20.04"],
     ]
   end
 


### PR DESCRIPTION
We success build a package for Ubuntu 20.04 by using current master's source.

https://launchpad.net/~groonga/+archive/ubuntu/nightly/+build/18891539