### PR TITLE
Support calculate max/min/sum for float value

### DIFF
--- a/lib/grn_rset.h
+++ b/lib/grn_rset.h
@@ -39,9 +39,9 @@ typedef struct {
 #define GRN_RSET_UTIL_BIT (0x80000000)
 
 #define GRN_RSET_N_SUBRECS_SIZE (sizeof(int))
-#define GRN_RSET_MAX_SIZE       (sizeof(int64_t))
-#define GRN_RSET_MIN_SIZE       (sizeof(int64_t))
-#define GRN_RSET_SUM_SIZE       (sizeof(int64_t))
+#define GRN_RSET_MAX_SIZE       (sizeof(int64_t) + sizeof(bool))
+#define GRN_RSET_MIN_SIZE       (sizeof(int64_t) + sizeof(bool))
+#define GRN_RSET_SUM_SIZE       (sizeof(int64_t) + sizeof(bool))
 #define GRN_RSET_AVG_SIZE       (sizeof(double) + sizeof(uint64_t))
 
 #define GRN_RSET_SCORE_SIZE (sizeof(double))
@@ -65,38 +65,69 @@ void grn_rset_recinfo_update_calc_values(grn_ctx *ctx,
                                          grn_obj *table,
                                          grn_obj *value);
 
-int64_t *grn_rset_recinfo_get_max_(grn_ctx *ctx,
-                                   grn_rset_recinfo *ri,
-                                   grn_obj *table);
+byte *grn_rset_recinfo_get_max_(grn_ctx *ctx,
+                                grn_rset_recinfo *ri,
+                                grn_obj *table);
 int64_t grn_rset_recinfo_get_max(grn_ctx *ctx,
                                  grn_rset_recinfo *ri,
                                  grn_obj *table);
+double grn_rset_recinfo_get_max_float(grn_ctx *ctx,
+                                      grn_rset_recinfo *ri,
+                                      grn_obj *table);
 void grn_rset_recinfo_set_max(grn_ctx *ctx,
                               grn_rset_recinfo *ri,
                               grn_obj *table,
                               int64_t max);
-
-int64_t *grn_rset_recinfo_get_min_(grn_ctx *ctx,
+void grn_rset_recinfo_set_max_float(grn_ctx *ctx,
+                                    grn_rset_recinfo *ri,
+                                    grn_obj *table,
+                                    double max);
+bool grn_rset_recinfo_is_max_float(grn_ctx *ctx,
                                    grn_rset_recinfo *ri,
                                    grn_obj *table);
+
+
+byte *grn_rset_recinfo_get_min_(grn_ctx *ctx,
+                                grn_rset_recinfo *ri,
+                                grn_obj *table);
 int64_t grn_rset_recinfo_get_min(grn_ctx *ctx,
                                  grn_rset_recinfo *ri,
                                  grn_obj *table);
+double grn_rset_recinfo_get_min_float(grn_ctx *ctx,
+                                      grn_rset_recinfo *ri,
+                                      grn_obj *table);
 void grn_rset_recinfo_set_min(grn_ctx *ctx,
                               grn_rset_recinfo *ri,
                               grn_obj *table,
                               int64_t min);
-
-int64_t *grn_rset_recinfo_get_sum_(grn_ctx *ctx,
+void grn_rset_recinfo_set_min_float(grn_ctx *ctx,
+                                    grn_rset_recinfo *ri,
+                                    grn_obj *table,
+                                    double min);
+bool grn_rset_recinfo_is_min_float(grn_ctx *ctx,
                                    grn_rset_recinfo *ri,
                                    grn_obj *table);
+
+byte *grn_rset_recinfo_get_sum_(grn_ctx *ctx,
+                                grn_rset_recinfo *ri,
+                                grn_obj *table);
 int64_t grn_rset_recinfo_get_sum(grn_ctx *ctx,
                                  grn_rset_recinfo *ri,
                                  grn_obj *table);
+double grn_rset_recinfo_get_sum_float(grn_ctx *ctx,
+                                      grn_rset_recinfo *ri,
+                                      grn_obj *table);
 void grn_rset_recinfo_set_sum(grn_ctx *ctx,
                               grn_rset_recinfo *ri,
                               grn_obj *table,
                               int64_t sum);
+void grn_rset_recinfo_set_sum_float(grn_ctx *ctx,
+                                    grn_rset_recinfo *ri,
+                                    grn_obj *table,
+                                    double sum);
+bool grn_rset_recinfo_is_sum_float(grn_ctx *ctx,
+                                   grn_rset_recinfo *ri,
+                                   grn_obj *table);
 
 double *grn_rset_recinfo_get_avg_(grn_ctx *ctx,
                                   grn_rset_recinfo *ri,

--- a/lib/output.c
+++ b/lib/output.c
@@ -1035,29 +1035,50 @@ grn_output_table_column_value(grn_ctx *ctx,
       case GRN_ACCESSOR_GET_MAX :
         {
           grn_rset_recinfo *ri = (grn_rset_recinfo *)grn_obj_get_value_(ctx, a->obj, id, &vs);
-          int64_t max;
-          max = grn_rset_recinfo_get_max(ctx, ri, a->obj);
-          GRN_INT64_PUT(ctx, bulk, max);
+          if (grn_rset_recinfo_is_max_float(ctx, ri, a->obj)) {
+            double max;
+            max = grn_rset_recinfo_get_max_float(ctx, ri, a->obj);
+            GRN_FLOAT_PUT(ctx, bulk, max);
+            bulk->header.domain = GRN_DB_FLOAT;
+          } else {
+            int64_t max;
+            max = grn_rset_recinfo_get_max(ctx, ri, a->obj);
+            GRN_INT64_PUT(ctx, bulk, max);
+            bulk->header.domain = GRN_DB_INT64;
+          }
         }
-        bulk->header.domain = GRN_DB_INT64;
         break;
       case GRN_ACCESSOR_GET_MIN :
         {
           grn_rset_recinfo *ri = (grn_rset_recinfo *)grn_obj_get_value_(ctx, a->obj, id, &vs);
-          int64_t min;
-          min = grn_rset_recinfo_get_min(ctx, ri, a->obj);
-          GRN_INT64_PUT(ctx, bulk, min);
+          if (grn_rset_recinfo_is_min_float(ctx, ri, a->obj)) {
+            double min;
+            min = grn_rset_recinfo_get_min_float(ctx, ri, a->obj);
+            GRN_FLOAT_PUT(ctx, bulk, min);
+            bulk->header.domain = GRN_DB_FLOAT;
+          } else {
+            int64_t min;
+            min = grn_rset_recinfo_get_min(ctx, ri, a->obj);
+            GRN_INT64_PUT(ctx, bulk, min);
+            bulk->header.domain = GRN_DB_INT64;
+          }
         }
-        bulk->header.domain = GRN_DB_INT64;
         break;
       case GRN_ACCESSOR_GET_SUM :
         {
           grn_rset_recinfo *ri = (grn_rset_recinfo *)grn_obj_get_value_(ctx, a->obj, id, &vs);
-          int64_t sum;
-          sum = grn_rset_recinfo_get_sum(ctx, ri, a->obj);
-          GRN_INT64_PUT(ctx, bulk, sum);
+          if (grn_rset_recinfo_is_sum_float(ctx, ri, a->obj)) {
+            double sum;
+            sum = grn_rset_recinfo_get_sum_float(ctx, ri, a->obj);
+            GRN_FLOAT_PUT(ctx, bulk, sum);
+            bulk->header.domain = GRN_DB_FLOAT;
+          } else {
+            int64_t sum;
+            sum = grn_rset_recinfo_get_sum(ctx, ri, a->obj);
+            GRN_INT64_PUT(ctx, bulk, sum);
+            bulk->header.domain = GRN_DB_INT64;
+          }
         }
-        bulk->header.domain = GRN_DB_INT64;
         break;
       case GRN_ACCESSOR_GET_AVG :
         {

--- a/test/command/suite/select/drilldowns/calc_types/single/max_float.expected
+++ b/test/command/suite/select/drilldowns/calc_types/single/max_float.expected
@@ -1,0 +1,83 @@
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+column_create Memos priority COLUMN_SCALAR Float
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga1", "tag": "Groonga", "priority": 10},
+{"_key": "Groonga2", "tag": "Groonga", "priority": 20},
+{"_key": "Groonga3", "tag": "Groonga", "priority": 40.1},
+{"_key": "Mroonga1", "tag": "Mroonga", "priority": 50.01},
+{"_key": "Mroonga2", "tag": "Mroonga", "priority": 25},
+{"_key": "Mroonga3", "tag": "Mroonga", "priority": 10},
+{"_key": "Rroonga1", "tag": "Rroonga", "priority": 25.001},
+{"_key": "Rroonga2", "tag": "Rroonga", "priority": -25},
+{"_key": "Rroonga3", "tag": "Rroonga", "priority": 0}
+]
+[[0,0.0,0.0],9]
+select Memos   --limit 0   --drilldowns[tag].keys tag   --drilldowns[tag].calc_types MAX   --drilldowns[tag].calc_target priority   --drilldowns[tag].output_columns _key,_max
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "priority",
+          "Float"
+        ],
+        [
+          "tag",
+          "Tags"
+        ]
+      ]
+    ],
+    {
+      "tag": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_max",
+            "Int64"
+          ]
+        ],
+        [
+          "Groonga",
+          40.1
+        ],
+        [
+          "Mroonga",
+          50.01
+        ],
+        [
+          "Rroonga",
+          25.001
+        ]
+      ]
+    }
+  ]
+]

--- a/test/command/suite/select/drilldowns/calc_types/single/max_float.test
+++ b/test/command/suite/select/drilldowns/calc_types/single/max_float.test
@@ -1,0 +1,25 @@
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos tag COLUMN_SCALAR Tags
+column_create Memos priority COLUMN_SCALAR Float
+
+load --table Memos
+[
+{"_key": "Groonga1", "tag": "Groonga", "priority": 10},
+{"_key": "Groonga2", "tag": "Groonga", "priority": 20},
+{"_key": "Groonga3", "tag": "Groonga", "priority": 40.1},
+{"_key": "Mroonga1", "tag": "Mroonga", "priority": 50.01},
+{"_key": "Mroonga2", "tag": "Mroonga", "priority": 25},
+{"_key": "Mroonga3", "tag": "Mroonga", "priority": 10},
+{"_key": "Rroonga1", "tag": "Rroonga", "priority": 25.001},
+{"_key": "Rroonga2", "tag": "Rroonga", "priority": -25},
+{"_key": "Rroonga3", "tag": "Rroonga", "priority": 0}
+]
+
+select Memos \
+  --limit 0 \
+  --drilldowns[tag].keys tag \
+  --drilldowns[tag].calc_types MAX \
+  --drilldowns[tag].calc_target priority \
+  --drilldowns[tag].output_columns _key,_max


### PR DESCRIPTION
計算対象の値がfloat系の場合、``calc_type``が``MAX``, ``MIN``, ``SUM``を``GRN_DB_FLOAT``で計算するようにしました。

ただ、``grn_obj_get_range_info``では、FLOATかINT64かを判別することができず、``Int64``のままになってしまっています。

その他の良い実装方法があれば、クローズして別途対応をお願いします。

参考までにこちらでの実装をPRしておきます。