### PR TITLE
ci: use the latest red-arrow for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -34,8 +34,8 @@ jobs:
           gem install \
             groonga-client \
             json \
-            pkg-config
-          gem install red-arrow -v 0.17.1
+            pkg-config \
+            red-arrow
       - name: Set environment variables
         run: |
           echo "::set-env name=COLUMNS::79"


### PR DESCRIPTION
Because Homebrew provide Apache Arrow 1.0.0.
https://github.com/Homebrew/homebrew-core/commit/057bf8766203e92e49bd86a46cbfffde1a8d25ee