### PR TITLE
package groonga-tokenizer-mecab: add support for CentOS8

### DIFF
--- a/packages/yum/centos-8/Dockerfile
+++ b/packages/yum/centos-8/Dockerfile
@@ -27,6 +27,5 @@ RUN \
     tar \
     zlib-devel && \
   dnf install -y ${quiet} https://packages.groonga.org/centos/8/groonga-release-latest.noarch.rpm && \
-  dnf install -y --enablerepo=epel groonga && \
   dnf install -y ${quiet} mecab-devel && \
   dnf clean ${quiet} all

--- a/packages/yum/centos-8/Dockerfile
+++ b/packages/yum/centos-8/Dockerfile
@@ -6,7 +6,10 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
   dnf update -y ${quiet} && \
-  dnf install -y ${quiet} epel-release 'dnf-command(config-manager)' && \
+  dnf install -y ${quiet} \
+    epel-release \
+    'dnf-command(config-manager)' \
+    https://packages.groonga.org/centos/8/groonga-release-latest.noarch.rpm && \
   dnf config-manager --set-enabled PowerTools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \
@@ -17,6 +20,7 @@ RUN \
     libstemmer-devel \
     libzstd-devel \
     lz4-devel \
+    mecab-devel \
     msgpack-devel \
     openssl-devel \
     pcre-devel \
@@ -26,6 +30,4 @@ RUN \
     ruby \
     tar \
     zlib-devel && \
-  dnf install -y ${quiet} https://packages.groonga.org/centos/8/groonga-release-latest.noarch.rpm && \
-  dnf install -y ${quiet} mecab-devel && \
   dnf clean ${quiet} all

--- a/packages/yum/centos-8/Dockerfile
+++ b/packages/yum/centos-8/Dockerfile
@@ -26,4 +26,7 @@ RUN \
     ruby \
     tar \
     zlib-devel && \
+  dnf install -y ${quiet} https://packages.groonga.org/centos/8/groonga-release-latest.noarch.rpm && \
+  dnf install -y --enablerepo=epel groonga && \
+  dnf install -y ${quiet} mecab-devel && \
   dnf clean ${quiet} all

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -1,6 +1,5 @@
 %define _centos_ver   %{?centos_ver:%{centos_ver}}%{!?centos_ver:6}
 
-%define _use_mecab    %{?use_mecab:%{use_mecab}}%{!?use_mecab:%{_centos_ver} <= 7}
 %define _use_jemalloc %{?use_jemalloc:%{use_jemalloc}}%{!?use_jemalloc:0}
 %define _use_msgpack  %{?use_msgpack:%{use_msgpack}}%{!?use_msgpack:%{_centos_ver} >= 7}
 %define _use_libstemmer %{?use_libstemmer:%{use_libstemmer}}%{!?use_libstemmer:%{_centos_ver} >= 7}
@@ -23,9 +22,7 @@ URL:		http://groonga.org/
 Source0:	http://packages.groonga.org/source/groonga/groonga-%{version}.tar.gz
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
-%if %{_use_mecab}
 BuildRequires:	mecab-devel
-%endif
 BuildRequires:	zlib-devel
 BuildRequires:	lz4-devel
 BuildRequires:	libzstd-devel
@@ -166,16 +163,14 @@ Requires:	%{name}-libs = %{version}-%{release}
 %description devel
 Libraries and header files for Groonga
 
-%if %{_use_mecab}
 %package tokenizer-mecab
 Summary:	MeCab tokenizer for Groonga
 Group:		Applications/Text
 Requires:	%{name}-libs = %{version}-%{release}
-Requires:	mecab-dic
+Requires:	mecab-ipadic
 
 %description tokenizer-mecab
 MeCab tokenizer for Groonga
-%endif
 
 %if %{_use_libstemmer}
 %package token-filter-stem
@@ -217,11 +212,7 @@ Munin plugins for Groonga
 %configure \
   --disable-static \
   --with-package-platform=centos%{?centos_ver} \
-%if %{_use_mecab}
   --with-mecab \
-%else
-  --without-mecab \
-%endif
 %if ! %{_use_msgpack}
   --without-message-pack \
 %endif
@@ -417,9 +408,7 @@ fi
 %dir %{_libdir}/groonga
 %dir %{_libdir}/groonga/plugins
 %dir %{_libdir}/groonga/plugins/functions
-%if %{_use_mecab}
 %dir %{_libdir}/groonga/plugins/tokenizers
-%endif
 %dir %{_libdir}/groonga/plugins/token_filters
 %dir %{_libdir}/groonga/plugins/ruby
 %dir %{_libdir}/groonga/plugins/sharding
@@ -521,11 +510,9 @@ fi
 %dir %{_libdir}/groonga/plugins
 %{_libdir}/groonga/plugins/suggest/suggest.so
 
-%if %{_use_mecab}
 %files tokenizer-mecab
 %defattr(-,root,root,-)
 %{_libdir}/groonga/plugins/tokenizers/mecab.so
-%endif
 
 %if %{_use_libstemmer}
 %files token-filter-stem


### PR DESCRIPTION
groonga-tokenizer-mecab requires mecab-devel package.
However, currently, mecab-devel package doesn't provide in the repository of CentOS8.

Therefore, we provide mecab-devel package in the repository of Groonga(packages.groonga.org) for a while.
Thereby we can provide groonga-tonkenizer-mecab on CentOS8.
We can build groonga-tokenizer-mecab package by this PR.