### PR TITLE
admin: fix wrong paths to images

### DIFF
--- a/data/html/admin/assets/groonga-admin.css
+++ b/data/html/admin/assets/groonga-admin.css
@@ -34,7 +34,7 @@ input[type="text"] {
 
 #header {
   height: 80px;
-  background: url(../images/groonga.png) no-repeat left center;
+  background: url(groonga.png) no-repeat left center;
 }
 
 #locale-list {

--- a/data/html/admin/assets/groonga-admin.ja.js
+++ b/data/html/admin/assets/groonga-admin.ja.js
@@ -1292,7 +1292,7 @@ jQuery.extend(GroongaAdmin.prototype, {
     $("<div />")
       .attr("id", "loadingdialog")
       .attr("style", "text-align: center;")
-      .append($("<img />").attr("src", "images/loading.gif"))
+      .append($("<img />").attr("src", "assets/loading.gif"))
       .append(" Loading...")
       .dialog({
         title: "",

--- a/data/html/admin/assets/groonga-admin.js
+++ b/data/html/admin/assets/groonga-admin.js
@@ -1292,7 +1292,7 @@ jQuery.extend(GroongaAdmin.prototype, {
     $("<div />")
       .attr("id", "loadingdialog")
       .attr("style", "text-align: center;")
-      .append($("<img />").attr("src", "images/loading.gif"))
+      .append($("<img />").attr("src", "assets/loading.gif"))
       .append(" Loading...")
       .dialog({
         title: "",


### PR DESCRIPTION
This commit fixes a part of #1139.
The logo of Groonga is displayed by this commit.