### PR TITLE
ci macos: unlink symlink for python 3.8

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
       - name: Install packages
         run: |
-	  brew unlink python@3.8
+          brew unlink python@3.8
           brew update || :
           brew bundle
       - name: Generate configure

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,7 @@ jobs:
           submodules: recursive
       - name: Install packages
         run: |
+	  brew unlink python@3.8
           brew update || :
           brew bundle
       - name: Generate configure


### PR DESCRIPTION
Because we fail to install python 3.9 if symlink for python 3.8 exists.