### PR TITLE
docs: fix simple typo, repoted -> reported

### DIFF
--- a/doc/source/troubleshooting/how_to_analyze_error_message.rst
+++ b/doc/source/troubleshooting/how_to_analyze_error_message.rst
@@ -17,7 +17,7 @@ This subsection describes how to analyze socket errors with an example.
 Example
 ^^^^^^^
 
-The following is an example of an error message repoted by Groonga, where xxxxx is an arbitrary number::
+The following is an example of an error message reported by Groonga, where xxxxx is an arbitrary number::
 
   socket error[xxxxx]: no buffer: accept
 


### PR DESCRIPTION
There is a small typo in doc/source/troubleshooting/how_to_analyze_error_message.rst.

Should read `reported` rather than `repoted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md