### PR TITLE
packages launchpad: fix a wrong argument

### DIFF
--- a/packages/launchpad-helper.rb
+++ b/packages/launchpad-helper.rb
@@ -92,14 +92,14 @@ allow_unsigned_uploads = 0
     tmp_dir = "#{ubuntu_dir}/tmp"
     rm_rf(tmp_dir)
     mkdir_p(tmp_dir)
-    apt_prepare_debian_dir(tmp_dir, "#{code_name}-#{version}")
+    apt_prepare_debian_dir(tmp_dir, "ubuntu-#{code_name}")
     cd(tmp_dir) do
       deb_archive_base_name = File.basename(absoulte_deb_archive_name, ".tar.gz")
       sh("tar", "xf", absoulte_deb_archive_name)
       cp(absoulte_deb_archive_name,
          "#{@package}_#{@deb_upstream_version}.orig.tar.gz")
       cd(deb_archive_base_name) do
-        cp_r("../debian.#{code_name}-#{version}", "debian")
+        cp_r("../debian.ubuntu-#{code_name}", "debian")
         minor_version = ENV["UBUNTU_MINOR_VERSION"] || "1"
         version_suffix = "ubuntu#{version}.#{minor_version}"
         deb_version = "#{detect_current_deb_version}.#{version_suffix}"


### PR DESCRIPTION
"apt_prepare_debian_dir()" is expecting that gives
the distribution name, the code name and, the architecture
into the second argument.

(See: https://github.com/apache/arrow/blob/master/dev/tasks/linux-packages/package-task.rb#L262)

However, in "launchpad-helper.rb", we are setting
the code name and version into the second argument of
"apt_prepare_debian_dir()".

Then, in Mroonga, "detect_mysql_version_ubuntu()" can't call in
https://github.com/mroonga/mroonga/blob/9d79ad72c71f8a7929ef92616f6ddb196f2dce66/packages/mroonga-package-task.rb#L50.

Because #{destribution} of
https://github.com/mroonga/mroonga/blob/master/packages/mroonga-package-task.rb#L50
is the code name of Ubuntu.