### PR TITLE
packages debian: use the qemu-user-static >= 5.0

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,7 +43,7 @@ jobs:
             task-namespace: yum
             target: centos-8
             test-docker-image: centos:8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.10
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Because qemu-user-static has crash bug in version before 5.0.
(See: https://bugs.launchpad.net/qemu/+bug/1749393)
By this bug, host OS may crashes.

TODO: Test