### PR TITLE
package: add a new task for installing qemu-user-static from Groovy

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,7 +68,7 @@ jobs:
             devscripts \
             python3-pip \
             ruby
-      - name: Install Qemu from Groovy
+      - name: Install QEMU from Groovy
         run: |
           sudo tee /etc/apt/preferences.d/qemu <<EOF
           Package: *

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,8 +67,26 @@ jobs:
             autoconf-archive \
             devscripts \
             python3-pip \
-            qemu-user-static \
             ruby
+      - name: Install Qemu from Groovy
+        run: |
+          sudo tee /etc/apt/preferences.d/qemu <<EOF
+          Package: *
+          Pin: release n=focal
+          Pin-Priority: 900
+          Package: *
+          Pin: release n=groovy
+          Pin-Priority: 400
+          EOF
+          cat /etc/apt/preferences.d/qemu
+          sudo tee /etc/apt/sources.list.d/groovy.list <<EOF
+          deb http://jp.archive.ubuntu.com/ubuntu groovy universe
+          deb http://jp.archive.ubuntu.com/ubuntu groovy-updates universe
+          deb http://security.ubuntu.com/ubuntu groovy-security universe
+          EOF
+          cat /etc/apt/sources.list.d/groovy.list
+          sudo apt update
+          sudo apt install -t groovy qemu-user-static
       - name: Install Sphinx
         run: |
           sudo pip3 install -v sphinx

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,6 +68,12 @@ jobs:
             devscripts \
             python3-pip \
             ruby
+      # qemu-user-static in Ubuntu 20.04 has the following bug.
+      # https://bugs.launchpad.net/qemu/+bug/1749393
+      # This bug has already fixed in Ubuntu 20.10.
+      # However, this fix is not included in Ubuntu 20.04.
+      # Therefore, we temporaly use qemu-user-static in Ubuntu 20.10.
+      # We remove this step when qemu-user-static in Ubuntu 20.04 will include above remediation.
       - name: Install QEMU from Groovy
         run: |
           sudo tee /etc/apt/preferences.d/qemu <<EOF

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -78,13 +78,11 @@ jobs:
           Pin: release n=groovy
           Pin-Priority: 400
           EOF
-          cat /etc/apt/preferences.d/qemu
           sudo tee /etc/apt/sources.list.d/groovy.list <<EOF
           deb http://jp.archive.ubuntu.com/ubuntu groovy universe
           deb http://jp.archive.ubuntu.com/ubuntu groovy-updates universe
           deb http://security.ubuntu.com/ubuntu groovy-security universe
           EOF
-          cat /etc/apt/sources.list.d/groovy.list
           sudo apt update
           sudo apt install -t groovy qemu-user-static
       - name: Install Sphinx


### PR DESCRIPTION
Because qemu-user-static in Ubuntu 20.04 has a crash bug as below.

  * https://bugs.launchpad.net/qemu/+bug/1749393
  * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=971537

This bug has already fixed in Ubuntu 20.10.
However, this bug isn't fixed in Ubuntu 20.04.