### PR TITLE
doc: use highlight directive instead of highlightlang directive

### DIFF
--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-.. highlightlang:: c
+.. highlight:: c
 
 ``grn_cache``
 =============

--- a/doc/source/reference/api/grn_column.rst
+++ b/doc/source/reference/api/grn_column.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-.. highlightlang:: c
+.. highlight:: c
 
 ``grn_column``
 ==============


### PR DESCRIPTION
Because highlightlang directive is removed since Sphinx 4.0.0.