### PR TITLE
grn_token_status: use uint32_t instead of unsigned int

### DIFF
--- a/include/groonga/token.h
+++ b/include/groonga/token.h
@@ -65,7 +65,7 @@ typedef grn_tokenize_mode grn_token_mode;
  *
  * @since 4.0.8
  */
-typedef unsigned int grn_token_status;
+typedef uint32_t grn_token_status;
 
 /*
  * GRN_TOKEN_CONTINUE means that the next token is not the last one.


### PR DESCRIPTION
{,u}int{8,16,32,64}_t are suitable raw integer types such as int and
unsigned int. Because they aren't depend on build environment. long
may be 32-bit integer or 64-bit integer.