### PR TITLE
TokenFilterStem: add support for searching by the original token conditionally

### DIFF
--- a/include/groonga/raw_string.h
+++ b/include/groonga/raw_string.h
@@ -42,6 +42,10 @@ extern "C" {
     string.length = GRN_TEXT_LEN(bulk);          \
   }
 
+#define GRN_RAW_STRING_EQUAL(string, other_string)                      \
+  (string.length == other_string.length &&                              \
+   memcmp(string.value, other_string.value, string.length) == 0)
+
 #define GRN_RAW_STRING_EQUAL_CSTRING(string, cstring)           \
   (cstring ?                                                    \
    (string.length == strlen(cstring) &&                         \

--- a/include/groonga/token.h
+++ b/include/groonga/token.h
@@ -132,6 +132,12 @@ GRN_API grn_token_status grn_token_get_status(grn_ctx *ctx,
 GRN_API grn_rc grn_token_set_status(grn_ctx *ctx,
                                     grn_token *token,
                                     grn_token_status status);
+GRN_API grn_rc grn_token_add_status(grn_ctx *ctx,
+                                    grn_token *token,
+                                    grn_token_status status);
+GRN_API grn_rc grn_token_remove_status(grn_ctx *ctx,
+                                       grn_token *token,
+                                       grn_token_status status);
 GRN_API uint64_t
 grn_token_get_source_offset(grn_ctx *ctx,
                             grn_token *token);

--- a/include/groonga/token.h
+++ b/include/groonga/token.h
@@ -115,6 +115,13 @@ typedef unsigned int grn_token_status;
  * @since 4.0.8
  */
 #define GRN_TOKEN_FORCE_PREFIX       (0x01L<<6)
+/*
+ * GRN_TOKEN_KEEP_ORIGINAL means that the original token of the token is
+ * also used. This is for token filter.
+ *
+ * @since 11.0.3
+ */
+#define GRN_TOKEN_KEEP_ORIGINAL      (0x01L<<7)
 
 typedef struct _grn_token grn_token;
 

--- a/lib/grn_token_cursor.h
+++ b/lib/grn_token_cursor.h
@@ -1,6 +1,6 @@
 /*
   Copyright(C) 2009-2016  Brazil
-  Copyright(C) 2018-2020  Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2018-2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -48,12 +48,16 @@ struct _grn_token_cursor {
     void *user_data;
     grn_token current_token;
     grn_token next_token;
+    grn_token original_token;
   } tokenizer;
   struct {
     grn_obj *objects;
     void **data;
   } token_filter;
-  uint32_t variant;
+  struct {
+    grn_token_cursor_status status;
+    grn_token *token;
+  } pending;
 };
 
 #ifdef __cplusplus

--- a/lib/token.c
+++ b/lib/token.c
@@ -1,6 +1,6 @@
 /*
   Copyright(C) 2012-2018  Brazil
-  Copyright(C) 2018-2020  Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2018-2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -119,6 +119,38 @@ grn_token_set_status(grn_ctx *ctx,
     goto exit;
   }
   token->status = status;
+exit:
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_rc
+grn_token_add_status(grn_ctx *ctx,
+                     grn_token *token,
+                     grn_token_status status)
+{
+  GRN_API_ENTER;
+  if (!token) {
+    ERR(GRN_INVALID_ARGUMENT,
+        "[token][status][add] token must not be NULL");
+    goto exit;
+  }
+  token->status |= status;
+exit:
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_rc
+grn_token_remove_status(grn_ctx *ctx,
+                        grn_token *token,
+                        grn_token_status status)
+{
+  GRN_API_ENTER;
+  if (!token) {
+    ERR(GRN_INVALID_ARGUMENT,
+        "[token][status][remove] token must not be NULL");
+    goto exit;
+  }
+  token->status &= ~status;
 exit:
   GRN_API_RETURN(ctx->rc);
 }

--- a/test/command/suite/token_filters/stem/keep_original/add.expected
+++ b/test/command/suite/token_filters/stem/keep_original/add.expected
@@ -1,0 +1,44 @@
+plugin_register token_filters/stem
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters 'TokenFilterStem("keep_original", true)'
+[[0,0.0,0.0],true]
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+[[0,0.0,0.0],true]
+table_tokenize Terms "I developed Groonga" --mode ADD
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "i",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "develop",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "developed",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "groonga",
+      "position": 2,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/token_filters/stem/keep_original/add.test
+++ b/test/command/suite/token_filters/stem/keep_original/add.test
@@ -1,0 +1,14 @@
+#@on-error omit
+plugin_register token_filters/stem
+#@on-error default
+
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto \
+  --token_filters 'TokenFilterStem("keep_original", true)'
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+
+table_tokenize Terms "I developed Groonga" --mode ADD

--- a/test/command/suite/token_filters/stem/keep_original/search_by_original.expected
+++ b/test/command/suite/token_filters/stem/keep_original/search_by_original.expected
@@ -1,0 +1,46 @@
+plugin_register token_filters/stem
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto   --token_filters 'TokenFilterStem("keep_original", true)'
+[[0,0.0,0.0],true]
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"content": "I develop Groonga"},
+{"content": "I'm developing Groonga"},
+{"content": "I developed Groonga"}
+]
+[[0,0.0,0.0],3]
+select Memos   --match_columns content   --query '"developed groonga"'   --query_options '{"TokenFilterStem.enable": false}'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "content",
+          "ShortText"
+        ]
+      ],
+      [
+        3,
+        "I developed Groonga"
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/token_filters/stem/keep_original/search_by_original.test
+++ b/test/command/suite/token_filters/stem/keep_original/search_by_original.test
@@ -1,0 +1,24 @@
+#@on-error omit
+plugin_register token_filters/stem
+#@on-error default
+
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto \
+  --token_filters 'TokenFilterStem("keep_original", true)'
+column_create Terms memos_content COLUMN_INDEX|WITH_POSITION Memos content
+
+load --table Memos
+[
+{"content": "I develop Groonga"},
+{"content": "I'm developing Groonga"},
+{"content": "I developed Groonga"}
+]
+
+select Memos \
+  --match_columns content \
+  --query '"developed groonga"' \
+  --query_options '{"TokenFilterStem.enable": false}'


### PR DESCRIPTION
Users can search by the original token (not stemmed token) conditionally with this.

It's useful when users want to search by a stemmed word generally but users sometimes want to search by a exact (not stemmed) word. For example:

* Searching by a stemmed word returns many results.
* Stemming returns wrong result.
* Users want to find only records that have a exact (not stemmed) word.