### PR TITLE
ci: use old red-arrow until the packages of Apache Arrow 4.0.1 are provided

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -108,8 +108,8 @@ jobs:
           sudo gem install \
             groonga-client \
             json \
-            pkg-config \
-            red-arrow
+            pkg-config
+          sudo gem install red-arrow -v 4.0.0
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -69,8 +69,8 @@ jobs:
           gem install \
             groonga-client \
             json \
-            pkg-config \
-            red-arrow
+            pkg-config
+          gem install red-arrow -v 4.0.0
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install red-arrow
         shell: msys2 {0}
         run: |
-          gem install red-arrow
+          gem install red-arrow -v 4.0.0
       - name: "Test: command line"
         shell: msys2 {0}
         run: |

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -312,7 +312,7 @@ jobs:
           matrix.architecture == 'x64'
         run: |
           ridk exec pacman --sync --noconfirm mingw-w64-x86_64-arrow
-          gem install red-arrow
+          gem install red-arrow -v 4.0.0
       - name: "Test: command line"
         run: |
           ruby test\command_line\run-test.rb `

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -54,7 +54,7 @@ gem install grntest
 if groonga --version | grep -q apache-arrow; then
   apt install -V -y \
     g++
-  gem install red-arrow
+  gem install red-arrow -v 4.0.0
 fi
 
 export TZ=Asia/Tokyo


### PR DESCRIPTION
This is testing now.