### PR TITLE
packages rpm: require versioned arrow-libs explicitly

### DIFF
--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -45,6 +45,7 @@ on relational data model.
 Summary:	Runtime libraries for Groonga
 Group:		System Environment/Libraries
 License:	LGPLv2 and (MIT or GPLv2)
+Requires:	arrow-libs = @APACHE_ARROW_VERSION@
 Requires:	zlib
 Requires:	lz4
 Requires:	libzstd


### PR DESCRIPTION
This avoids the following error:

https://github.com/groonga/groonga/runs/2691119502?check_suite_focus=true

    Error: Package: arrow-devel-4.0.0-1.el7.x86_64 (groonga-centos)
     You could try using --skip-broken to work around the problem
               Requires: arrow-libs = 4.0.0-1.el7
               Available: arrow-libs-0.3.1.20170506-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.3.1.20170506-1.el7.centos
               Available: arrow-libs-0.3.1.20170508-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.3.1.20170508-1.el7.centos
               Available: arrow-libs-0.3.1.20170510-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.3.1.20170510-1.el7.centos
               Available: arrow-libs-0.3.1.20170512-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.3.1.20170512-1.el7.centos
               Available: arrow-libs-0.3.1.20170517-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.3.1.20170517-1.el7.centos
               Available: arrow-libs-0.4.1.20170524-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.4.1.20170524-1.el7.centos
               Available: arrow-libs-0.5.0.20170612-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.5.0.20170612-1.el7.centos
               Available: arrow-libs-0.6.0.20170726-1.el7.centos.x86_64 (groonga-centos)
                   arrow-libs = 0.6.0.20170726-1.el7.centos
               Available: arrow-libs-2.0.0-1.el7.x86_64 (groonga-centos)
                   arrow-libs = 2.0.0-1.el7
               Available: arrow-libs-3.0.0-1.el7.x86_64 (groonga-centos)
                   arrow-libs = 3.0.0-1.el7
               Available: arrow-libs-4.0.0-1.el7.x86_64 (groonga-centos)
                   arrow-libs = 4.0.0-1.el7
               Installing: arrow-libs-4.0.1-1.el7.x86_64 (groonga-centos)
                   arrow-libs = 4.0.1-1.el7