### PR TITLE
Initialize grn_search_optarg::query_options

### DIFF
--- a/lib/proc.c
+++ b/lib/proc.c
@@ -3891,6 +3891,7 @@ selector_in_values(grn_ctx *ctx, grn_obj *table, grn_obj *index,
     search_options.proc = NULL;
     search_options.max_size = 0;
     search_options.scorer = NULL;
+    search_options.query_options = NULL;
     if (i == n_values - 1) {
       ctx->flags = original_flags;
     }

--- a/lib/proc/proc_select.c
+++ b/lib/proc/proc_select.c
@@ -2265,6 +2265,7 @@ grn_select_apply_adjuster_execute_adjust(grn_ctx *ctx,
     options.proc = NULL;
     options.max_size = 0;
     options.scorer = NULL;
+    options.query_options = NULL;
 
     grn_obj_search(ctx, index, value, table, GRN_OP_ADJUST, &options);
   }


### PR DESCRIPTION
The newly added ``grn_search_optarg :: query_options`` pointer may not be initialized with ``NULL`` and may try to parse to invalid addresses. 

https://github.com/groonga/groonga/blob/d883cd887b35947e16a7073b1fd59e685b45c862/plugins/token_filters/stop_word.c#L160-L162