### PR TITLE
Fix typos in string_slice.rst

### DIFF
--- a/doc/source/reference/functions/string_slice.rst
+++ b/doc/source/reference/functions/string_slice.rst
@@ -32,8 +32,8 @@ Extraction by position
 
 ::
 
-  string_slice(target, nth[, options])``
-  string_slice(target, nth, length[, options])``
+  string_slice(target, nth[, options])
+  string_slice(target, nth, length[, options])
 
 ``options`` uses the following format. All of key-value pairs are optional::
 


### PR DESCRIPTION
Fix typos in ``string_slice.rst``