### PR TITLE
ci macos: remove a needless unlink

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           brew unlink python@3.8
           rm -f /usr/local/bin/2to3
-          brew unlink gcc@8
           brew unlink gcc@9
           brew update || :
           brew bundle


### PR DESCRIPTION
Because GCC version 8 has been removed from images on May, 31.

See:
https://github.com/actions/virtual-environments/blob/macOS-10.15/20210531.1/images/macos/macos-10.15-Readme.md
https://github.com/actions/virtual-environments/issues/3378