### PR TITLE
NormalizerTable: add

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1236,6 +1236,7 @@ GRN_API grn_rc grn_bulk_write_from(grn_ctx *ctx, grn_obj *bulk,
 GRN_API grn_rc grn_bulk_reserve(grn_ctx *ctx, grn_obj *bulk, size_t len);
 GRN_API grn_rc grn_bulk_space(grn_ctx *ctx, grn_obj *bulk, size_t len);
 GRN_API grn_rc grn_bulk_truncate(grn_ctx *ctx, grn_obj *bulk, size_t len);
+GRN_API char *grn_bulk_detach(grn_ctx *ctx, grn_obj *bulk);
 GRN_API grn_rc grn_bulk_fin(grn_ctx *ctx, grn_obj *bulk);
 
 /* grn_text */

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -2478,12 +2478,18 @@ table_options_init(grn_ctx *ctx, table_options *options)
 static void
 table_options_fin(grn_ctx *ctx, table_options *options)
 {
+  /* We can't call grn_obj_unlink() safety here. Options are cached
+   * and closed when the table that have this option is closed. It may
+   * be occurred when DB is closed. In the case, options->column or
+   * options->table are already closed. If we call grn_obj_unlink()
+   * with closed column/table, Groonga may be crashed. */
+
   if (options->column) {
-    grn_obj_unlink(ctx, options->column);
+    /* grn_obj_unlink(ctx, options->column); */
     options->column = NULL;
   }
   if (options->table) {
-    grn_obj_unlink(ctx, options->table);
+    /* grn_obj_unlink(ctx, options->table); */
     options->table = NULL;
   }
 }

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -2985,10 +2985,12 @@ table_normalize(grn_ctx *ctx, grn_string *string, table_options *options)
   }
 
   if (data.need_types) {
+    GRN_UINT64_PUT(ctx, &(data.types), GRN_CHAR_NULL);
     string->ctypes = (uint_least8_t *)grn_bulk_detach(ctx, &(data.types));
   }
 
   if (data.need_offsets) {
+    GRN_UINT64_PUT(ctx, &(data.offsets), string->original_length_in_bytes);
     string->offsets = (uint64_t *)grn_bulk_detach(ctx, &(data.offsets));
   }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -2766,7 +2766,7 @@ table_normalize_add_checks_and_offsets(grn_ctx *ctx,
             (int)(source_end - source_current),
             source_current);
         return;
-        }
+      }
       GRN_INT16_VALUE_AT(checks, last_check_index) += source_char_length;
       source_current += source_char_length;
     }

--- a/lib/str.c
+++ b/lib/str.c
@@ -1,6 +1,6 @@
 /*
   Copyright(C) 2009-2017  Brazil
-  Copyright(C) 2018-2020  Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2018-2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -3366,3 +3366,24 @@ grn_bulk_is_zero(grn_ctx *ctx, grn_obj *obj)
   return GRN_TRUE;
 }
 
+char *
+grn_bulk_detach(grn_ctx *ctx, grn_obj *bulk)
+{
+  if (GRN_BULK_VSIZE(bulk) == 0) {
+    return NULL;
+  }
+
+  char *data;
+  if (GRN_BULK_OUTP(bulk)) {
+    data = GRN_BULK_HEAD(bulk);
+    bulk->header.impl_flags &= ~GRN_OBJ_OUTPLACE;
+  } else {
+    data = GRN_MALLOC(GRN_BULK_VSIZE(bulk));
+    if (!data) {
+      return NULL;
+    }
+    memcpy(data, GRN_BULK_HEAD(bulk), GRN_BULK_VSIZE(bulk));
+  }
+  GRN_BULK_REWIND(bulk);
+  return data;
+}

--- a/test/command/suite/normalizer_list/default.expected
+++ b/test/command/suite/normalizer_list/default.expected
@@ -20,6 +20,9 @@ normalizer_list
     },
     {
       "name": "NormalizerNFKC130"
+    },
+    {
+      "name": "NormalizerTable"
     }
   ]
 ]

--- a/test/command/suite/normalizers/table/checks.expected
+++ b/test/command/suite/normalizers/table/checks.expected
@@ -1,0 +1,37 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+[[0,0.0,0.0],2]
+normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".あ。いち."   WITH_CHECKS
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": ".<あ>。1.",
+    "types": [
+
+    ],
+    "checks": [
+      1,
+      3,
+      -1,
+      0,
+      0,
+      -1,
+      3,
+      0,
+      0,
+      6,
+      1
+    ]
+  }
+]

--- a/test/command/suite/normalizers/table/checks.test
+++ b/test/command/suite/normalizers/table/checks.test
@@ -1,0 +1,13 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+
+normalize \
+  'NormalizerTable("column", "Substitutions.substituted")' \
+  ".あ。いち." \
+  WITH_CHECKS

--- a/test/command/suite/normalizers/table/highlight_html.expected
+++ b/test/command/suite/normalizers/table/highlight_html.expected
@@ -1,0 +1,50 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Substitutions
+[
+{"_key": "a", "substituted": "AAA"},
+{"_key": "b", "substituted": "BBB"},
+{"_key": "c", "substituted": "CCC"},
+{"_key": "d", "substituted": "DDD"},
+{"_key": "e", "substituted": "EEE"}
+]
+[[0,0.0,0.0],5]
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries body COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("report_source_location", true)'   --normalizer 'NormalizerTable("column", "Substitutions.substituted",                                 "report_source_offset", true)'
+[[0,0.0,0.0],true]
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"body": ".a.b.c.d.e."}
+]
+[[0,0.0,0.0],1]
+select Entries   --match_columns body   --query 'CCC'   --output_columns 'highlight_html(body, Terms)'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "highlight_html",
+          null
+        ]
+      ],
+      [
+        ".a.b.<span class=\"keyword\">c</span>.d.e."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/normalizers/table/highlight_html.test
+++ b/test/command/suite/normalizers/table/highlight_html.test
@@ -1,0 +1,30 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+load --table Substitutions
+[
+{"_key": "a", "substituted": "AAA"},
+{"_key": "b", "substituted": "BBB"},
+{"_key": "c", "substituted": "CCC"},
+{"_key": "d", "substituted": "DDD"},
+{"_key": "e", "substituted": "EEE"}
+]
+
+table_create Entries TABLE_NO_KEY
+column_create Entries body COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("report_source_location", true)' \
+  --normalizer 'NormalizerTable("column", "Substitutions.substituted", \
+                                "report_source_offset", true)'
+column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
+
+load --table Entries
+[
+{"body": ".a.b.c.d.e."}
+]
+
+select Entries \
+  --match_columns body \
+  --query 'CCC' \
+  --output_columns 'highlight_html(body, Terms)'

--- a/test/command/suite/normalizers/table/many.expected
+++ b/test/command/suite/normalizers/table/many.expected
@@ -1,0 +1,51 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Substitutions
+[
+{"_key": "a", "substituted": "<A>"},
+{"_key": "b", "substituted": "<B>"},
+{"_key": "c", "substituted": "<C>"},
+{"_key": "d", "substituted": "<D>"},
+{"_key": "e", "substituted": "<E>"},
+{"_key": "f", "substituted": "<F>"},
+{"_key": "g", "substituted": "<G>"},
+{"_key": "h", "substituted": "<H>"},
+{"_key": "i", "substituted": "<I>"},
+{"_key": "j", "substituted": "<J>"},
+{"_key": "k", "substituted": "<K>"},
+{"_key": "l", "substituted": "<L>"},
+{"_key": "m", "substituted": "<M>"},
+{"_key": "n", "substituted": "<N>"},
+{"_key": "o", "substituted": "<O>"},
+{"_key": "p", "substituted": "<P>"},
+{"_key": "q", "substituted": "<Q>"},
+{"_key": "r", "substituted": "<R>"},
+{"_key": "s", "substituted": "<S>"},
+{"_key": "t", "substituted": "<T>"},
+{"_key": "u", "substituted": "<U>"},
+{"_key": "v", "substituted": "<V>"},
+{"_key": "w", "substituted": "<W>"},
+{"_key": "x", "substituted": "<X>"},
+{"_key": "y", "substituted": "<Y>"},
+{"_key": "z", "substituted": "<Z>"}
+]
+[[0,0.0,0.0],26]
+normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": ".<A>.<B>.<C>.<D>.<E>.<F>.<G>.<H>.<I>.<J>.<K>.<L>.<M>.<N>.<O>.<P>.<Q>.<R>.<S>.<T>.<U>.<V>.<W>.<X>.<Y>.<Z>.",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/table/many.test
+++ b/test/command/suite/normalizers/table/many.test
@@ -1,0 +1,36 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+load --table Substitutions
+[
+{"_key": "a", "substituted": "<A>"},
+{"_key": "b", "substituted": "<B>"},
+{"_key": "c", "substituted": "<C>"},
+{"_key": "d", "substituted": "<D>"},
+{"_key": "e", "substituted": "<E>"},
+{"_key": "f", "substituted": "<F>"},
+{"_key": "g", "substituted": "<G>"},
+{"_key": "h", "substituted": "<H>"},
+{"_key": "i", "substituted": "<I>"},
+{"_key": "j", "substituted": "<J>"},
+{"_key": "k", "substituted": "<K>"},
+{"_key": "l", "substituted": "<L>"},
+{"_key": "m", "substituted": "<M>"},
+{"_key": "n", "substituted": "<N>"},
+{"_key": "o", "substituted": "<O>"},
+{"_key": "p", "substituted": "<P>"},
+{"_key": "q", "substituted": "<Q>"},
+{"_key": "r", "substituted": "<R>"},
+{"_key": "s", "substituted": "<S>"},
+{"_key": "t", "substituted": "<T>"},
+{"_key": "u", "substituted": "<U>"},
+{"_key": "v", "substituted": "<V>"},
+{"_key": "w", "substituted": "<W>"},
+{"_key": "x", "substituted": "<X>"},
+{"_key": "y", "substituted": "<Y>"},
+{"_key": "z", "substituted": "<Z>"}
+]
+
+normalize \
+  'NormalizerTable("column", "Substitutions.substituted")' \
+  ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."

--- a/test/command/suite/normalizers/table/report_source_offset.expected
+++ b/test/command/suite/normalizers/table/report_source_offset.expected
@@ -1,0 +1,36 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+[[0,0.0,0.0],2]
+normalize   'NormalizerTable("column", "Substitutions.substituted",                    "report_source_offset", true)'   ".あ。いち."
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": ".<あ>。1.",
+    "types": [
+
+    ],
+    "checks": [
+
+    ],
+    "offsets": [
+      0,
+      1,
+      1,
+      1,
+      4,
+      7,
+      13
+    ]
+  }
+]

--- a/test/command/suite/normalizers/table/report_source_offset.test
+++ b/test/command/suite/normalizers/table/report_source_offset.test
@@ -1,0 +1,13 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+
+normalize \
+  'NormalizerTable("column", "Substitutions.substituted", \
+                   "report_source_offset", true)' \
+  ".あ。いち."

--- a/test/command/suite/normalizers/table/types.expected
+++ b/test/command/suite/normalizers/table/types.expected
@@ -1,0 +1,33 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+[[0,0.0,0.0],2]
+normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".あ。いち."   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": ".<あ>。1.",
+    "types": [
+      "symbol",
+      "symbol",
+      "hiragana",
+      "symbol",
+      "symbol",
+      "digit",
+      "symbol"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/table/types.test
+++ b/test/command/suite/normalizers/table/types.test
@@ -1,0 +1,13 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+load --table Substitutions
+[
+{"_key": "あ", "substituted": "<あ>"},
+{"_key": "いち", "substituted": "1"}
+]
+
+normalize \
+  'NormalizerTable("column", "Substitutions.substituted")' \
+  ".あ。いち." \
+  WITH_TYPES

--- a/test/command/suite/normalizers/table/unicode_version.expected
+++ b/test/command/suite/normalizers/table/unicode_version.expected
@@ -1,0 +1,6 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+normalize   'NormalizerTable("column", "Substitutions.substituted",                    "unicode_version", "13.0.0")'   "©"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"©","types":["emoji"],"checks":[]}]

--- a/test/command/suite/normalizers/table/unicode_version.test
+++ b/test/command/suite/normalizers/table/unicode_version.test
@@ -1,0 +1,8 @@
+table_create Substitutions TABLE_PAT_KEY ShortText
+column_create Substitutions substituted COLUMN_SCALAR ShortText
+
+normalize \
+  'NormalizerTable("column", "Substitutions.substituted", \
+                   "unicode_version", "13.0.0")' \
+  "©" \
+  WITH_TYPES

--- a/test/command/suite/schema/plugins.expected
+++ b/test/command/suite/schema/plugins.expected
@@ -239,6 +239,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/compress/lz4.expected
+++ b/test/command/suite/schema/tables/columns/compress/lz4.expected
@@ -238,6 +238,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/compress/zlib.expected
+++ b/test/command/suite/schema/tables/columns/compress/zlib.expected
@@ -238,6 +238,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/compress/zstd.expected
+++ b/test/command/suite/schema/tables/columns/compress/zstd.expected
@@ -238,6 +238,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/index_large.expected
+++ b/test/command/suite/schema/tables/columns/type/index_large.expected
@@ -244,6 +244,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/index_medium.expected
+++ b/test/command/suite/schema/tables/columns/type/index_medium.expected
@@ -244,6 +244,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/index_small.expected
+++ b/test/command/suite/schema/tables/columns/type/index_small.expected
@@ -244,6 +244,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/scalar.expected
+++ b/test/command/suite/schema/tables/columns/type/scalar.expected
@@ -238,6 +238,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/vector.expected
+++ b/test/command/suite/schema/tables/columns/type/vector.expected
@@ -240,6 +240,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/vector_token.expected
+++ b/test/command/suite/schema/tables/columns/type/vector_token.expected
@@ -242,6 +242,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/columns/type/vector_weight32.expected
+++ b/test/command/suite/schema/tables/columns/type/vector_weight32.expected
@@ -240,6 +240,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/normalizer.expected
+++ b/test/command/suite/schema/tables/normalizer.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/normalizer_with_options.expected
+++ b/test/command/suite/schema/tables/normalizer_with_options.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/token_filters.expected
+++ b/test/command/suite/schema/tables/token_filters.expected
@@ -241,6 +241,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/token_filters_with_options.expected
+++ b/test/command/suite/schema/tables/token_filters_with_options.expected
@@ -241,6 +241,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/tokenizer.expected
+++ b/test/command/suite/schema/tables/tokenizer.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/tokenizer_with_options.expected
+++ b/test/command/suite/schema/tables/tokenizer_with_options.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/type/array.expected
+++ b/test/command/suite/schema/tables/type/array.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/type/hash_table.expected
+++ b/test/command/suite/schema/tables/type/hash_table.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/value_type/reference.expected
+++ b/test/command/suite/schema/tables/value_type/reference.expected
@@ -238,6 +238,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {

--- a/test/command/suite/schema/tables/value_type/type.expected
+++ b/test/command/suite/schema/tables/value_type/type.expected
@@ -236,6 +236,10 @@ schema
       "NormalizerNFKC51": {
         "id": 84,
         "name": "NormalizerNFKC51"
+      },
+      "NormalizerTable": {
+        "id": 88,
+        "name": "NormalizerTable"
       }
     },
     "token_filters": {


### PR DESCRIPTION
See the added tests for how to use.

It uses Groonga table to normalize text. Users can implement custom
normalization by managing a Groonga table.

Note that users need to rebuild the index that uses NormalizerTable
when they change substitution table for the NormalizerTable. Because
normalization rules are changed by change of the substitution table.