### PR TITLE
query_parallel_or: fix a wrong result bug

### DIFF
--- a/lib/cpp_sources.am
+++ b/lib/cpp_sources.am
@@ -7,6 +7,7 @@ libgroonga_cpp_source =				\
 	grn_arrow.hpp				\
 	grn_bulk.h				\
 	grn_cast.h				\
+	grn_ctx.hpp				\
 	grn_token_column.h			\
 	token_column.cpp			\
 	vector.cpp				\

--- a/lib/grn_ctx.hpp
+++ b/lib/grn_ctx.hpp
@@ -1,0 +1,38 @@
+/*
+  Copyright(C) 2021  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License version 2.1 as published by the Free Software Foundation.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "grn_ctx.h"
+
+namespace grn {
+  class ChildCtxReleaser {
+  public:
+    ChildCtxReleaser(grn_ctx *ctx, grn_ctx *child_ctx) :
+      ctx_(ctx),
+      child_ctx_(child_ctx) {
+    };
+
+    ~ChildCtxReleaser() {
+      grn_ctx_release_child(ctx_, child_ctx_);
+    }
+
+  private:
+    grn_ctx *ctx_;
+    grn_ctx *child_ctx_;
+  };
+}

--- a/test/command/suite/select/function/query_paralell_or/query/and.expected
+++ b/test/command/suite/select/function/query_paralell_or/query/and.expected
@@ -1,0 +1,88 @@
+table_create Tags TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users comment COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Users tags_by_me COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+column_create Users tags_by_others COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Alice",
+ "tags_by_me": ["beginner", "active"],
+ "tags_by_others": ["expert", "active"]},
+{"_key": "Bob",
+ "tags_by_me": ["expert", "passive"],
+ "tags_by_others": ["beginner", "passive"]},
+{"_key": "Chris",
+ "tags_by_me": ["beginner", "passive"],
+ "tags_by_others": ["beginner", "active"]}
+]
+[[0,0.0,0.0],3]
+column_create Tags users COLUMN_INDEX|WITH_SECTION   Users tags_by_me,tags_by_others
+[[0,0.0,0.0],true]
+select Users   --output_columns _id,_key,tags_by_me,tags_by_others,,_score   --sort_keys _id   --filter 'query_parallel_or("tags_by_me * 1 ||                                tags_by_me * 10 ||                                tags_by_me * 100 ||                                tags_by_others * 1000",                               "beginner active")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "tags_by_me",
+          "Tags"
+        ],
+        [
+          "tags_by_others",
+          "Tags"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        1,
+        "Alice",
+        [
+          "beginner",
+          "active"
+        ],
+        [
+          "expert",
+          "active"
+        ],
+        222
+      ],
+      [
+        3,
+        "Chris",
+        [
+          "beginner",
+          "passive"
+        ],
+        [
+          "beginner",
+          "active"
+        ],
+        2000
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/query_paralell_or/query/and.test
+++ b/test/command/suite/select/function/query_paralell_or/query/and.test
@@ -1,0 +1,34 @@
+#$GRN_QUERY_PARALLEL_OR_N_CONDITIONS_THRESHOLD=1
+#$GRN_QUERY_PARALLEL_OR_N_THREADS_LIMIT=2
+
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users comment COLUMN_SCALAR ShortText
+column_create Users tags_by_me COLUMN_VECTOR Tags
+column_create Users tags_by_others COLUMN_VECTOR Tags
+
+load --table Users
+[
+{"_key": "Alice",
+ "tags_by_me": ["beginner", "active"],
+ "tags_by_others": ["expert", "active"]},
+{"_key": "Bob",
+ "tags_by_me": ["expert", "passive"],
+ "tags_by_others": ["beginner", "passive"]},
+{"_key": "Chris",
+ "tags_by_me": ["beginner", "passive"],
+ "tags_by_others": ["beginner", "active"]}
+]
+
+column_create Tags users COLUMN_INDEX|WITH_SECTION \
+  Users tags_by_me,tags_by_others
+
+select Users \
+  --output_columns _id,_key,tags_by_me,tags_by_others,,_score \
+  --sort_keys _id \
+  --filter 'query_parallel_or("tags_by_me * 1 || \
+                               tags_by_me * 10 || \
+                               tags_by_me * 100 || \
+                               tags_by_others * 1000", \
+                              "beginner active")'


### PR DESCRIPTION
We can't reuse a result set for grn_table_selector_select(). It
doesn't work when a query has multiple conditions.

If we reuse a result set, we need to truncate the result set. But
"truncate" is slower than "delete all". ("Truncate" may be faster with
a large result set.)