### PR TITLE
NormalizerTable: add support for indexed target

### DIFF
--- a/include/groonga/raw_string.h
+++ b/include/groonga/raw_string.h
@@ -74,6 +74,10 @@ GRN_API bool
 grn_raw_string_have_sub_string(grn_ctx *ctx,
                                grn_raw_string *string,
                                grn_raw_string *sub_string);
+GRN_API bool
+grn_raw_string_have_sub_string_cstring(grn_ctx *ctx,
+                                       grn_raw_string *string,
+                                       const char *sub_cstring);
 
 #ifdef __cplusplus
 }

--- a/lib/raw_string.c
+++ b/lib/raw_string.c
@@ -1,6 +1,6 @@
 /*
-  Copyright(C) 2016-2017 Brazil
-  Copyright(C) 2019 Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2016-2017  Brazil
+  Copyright(C) 2019-2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -94,4 +94,21 @@ grn_raw_string_have_sub_string(grn_ctx *ctx,
   }
 
   return false;
+}
+
+bool
+grn_raw_string_have_sub_string_cstring(grn_ctx *ctx,
+                                       grn_raw_string *string,
+                                       const char *sub_cstring)
+{
+  grn_raw_string sub_string;
+  if (sub_cstring) {
+    sub_string.value = sub_cstring;
+    sub_string.length = strlen(sub_cstring);
+  } else {
+    sub_string.value = NULL;
+    sub_string.length = 0;
+  }
+
+  return grn_raw_string_have_sub_string(ctx, string, &sub_string);
 }

--- a/lib/string.c
+++ b/lib/string.c
@@ -294,6 +294,9 @@ grn_string_open_(grn_ctx *ctx,
       }
       grn_normalizer_normalize(ctx, normalizer, string);
       if (i > 0) {
+        if (ctx->rc != GRN_SUCCESS) {
+          break;
+        }
         if (previous_checks) {
           if (string_->checks) {
             unsigned int previous_i = 0;

--- a/test/command/suite/normalizers/multiple/options/all.expected
+++ b/test/command/suite/normalizers/multiple/options/all.expected
@@ -1,13 +1,13 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"}
+{"_key": "あ", "normalized": "<あ>"}
 ]
 [[0,0.0,0.0],1]
-normalize   'NormalizerNFKC130("unify_kana", true, "report_source_offset", true),    NormalizerTable("column", "Substitutions.substituted",                    "report_source_offset", true)'   "お あ ａ ア ｉ ｱ オ"   REMOVE_BLANK|WITH_TYPES|WITH_CHECKS
+normalize   'NormalizerNFKC130("unify_kana", true, "report_source_offset", true),    NormalizerTable("normalized", "Normalizations.normalized",                    "report_source_offset", true)'   "お あ ａ ア ｉ ｱ オ"   REMOVE_BLANK|WITH_TYPES|WITH_CHECKS
 [
   [
     0,

--- a/test/command/suite/normalizers/multiple/options/all.test
+++ b/test/command/suite/normalizers/multiple/options/all.test
@@ -1,14 +1,14 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"}
+{"_key": "あ", "normalized": "<あ>"}
 ]
 
 normalize \
   'NormalizerNFKC130("unify_kana", true, "report_source_offset", true), \
-   NormalizerTable("column", "Substitutions.substituted", \
+   NormalizerTable("normalized", "Normalizations.normalized", \
                    "report_source_offset", true)' \
   "お あ ａ ア ｉ ｱ オ" \
   REMOVE_BLANK|WITH_TYPES|WITH_CHECKS

--- a/test/command/suite/normalizers/multiple/options/error.expected
+++ b/test/command/suite/normalizers/multiple/options/error.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC130("unify_kana", true),    NormalizerTable("normalized", "Nonexistent.nonexistent")'   "abcde"
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[normalizer][table][normalized] nonexistent column: <Nonexistent.nonexistent>"
+  ],
+  {
+    "normalized": "",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]
+#|e| [normalizer][table][normalized] nonexistent column: <Nonexistent.nonexistent>

--- a/test/command/suite/normalizers/multiple/options/error.test
+++ b/test/command/suite/normalizers/multiple/options/error.test
@@ -1,0 +1,4 @@
+normalize \
+  'NormalizerNFKC130("unify_kana", true), \
+   NormalizerTable("normalized", "Nonexistent.nonexistent")' \
+  "abcde"

--- a/test/command/suite/normalizers/table/checks.expected
+++ b/test/command/suite/normalizers/table/checks.expected
@@ -1,14 +1,14 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 [[0,0.0,0.0],2]
-normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".あ。いち."   WITH_CHECKS
+normalize   'NormalizerTable("normalized", "Normalizations.normalized")'   ".あ。いち."   WITH_CHECKS
 [
   [
     0,

--- a/test/command/suite/normalizers/table/checks.test
+++ b/test/command/suite/normalizers/table/checks.test
@@ -1,13 +1,13 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 
 normalize \
-  'NormalizerTable("column", "Substitutions.substituted")' \
+  'NormalizerTable("normalized", "Normalizations.normalized")' \
   ".あ。いち." \
   WITH_CHECKS

--- a/test/command/suite/normalizers/table/highlight_html.expected
+++ b/test/command/suite/normalizers/table/highlight_html.expected
@@ -1,21 +1,21 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "a", "substituted": "AAA"},
-{"_key": "b", "substituted": "BBB"},
-{"_key": "c", "substituted": "CCC"},
-{"_key": "d", "substituted": "DDD"},
-{"_key": "e", "substituted": "EEE"}
+{"_key": "a", "normalized": "AAA"},
+{"_key": "b", "normalized": "BBB"},
+{"_key": "c", "normalized": "CCC"},
+{"_key": "d", "normalized": "DDD"},
+{"_key": "e", "normalized": "EEE"}
 ]
 [[0,0.0,0.0],5]
 table_create Entries TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Entries body COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("report_source_location", true)'   --normalizer 'NormalizerTable("column", "Substitutions.substituted",                                 "report_source_offset", true)'
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("report_source_location", true)'   --normalizer 'NormalizerTable("normalized", "Normalizations.normalized",                                 "report_source_offset", true)'
 [[0,0.0,0.0],true]
 column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
 [[0,0.0,0.0],true]

--- a/test/command/suite/normalizers/table/highlight_html.test
+++ b/test/command/suite/normalizers/table/highlight_html.test
@@ -1,13 +1,13 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "a", "substituted": "AAA"},
-{"_key": "b", "substituted": "BBB"},
-{"_key": "c", "substituted": "CCC"},
-{"_key": "d", "substituted": "DDD"},
-{"_key": "e", "substituted": "EEE"}
+{"_key": "a", "normalized": "AAA"},
+{"_key": "b", "normalized": "BBB"},
+{"_key": "c", "normalized": "CCC"},
+{"_key": "d", "normalized": "DDD"},
+{"_key": "e", "normalized": "EEE"}
 ]
 
 table_create Entries TABLE_NO_KEY
@@ -15,7 +15,7 @@ column_create Entries body COLUMN_SCALAR ShortText
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer 'TokenNgram("report_source_location", true)' \
-  --normalizer 'NormalizerTable("column", "Substitutions.substituted", \
+  --normalizer 'NormalizerTable("normalized", "Normalizations.normalized", \
                                 "report_source_offset", true)'
 column_create Terms document_index COLUMN_INDEX|WITH_POSITION Entries body
 

--- a/test/command/suite/normalizers/table/many.expected
+++ b/test/command/suite/normalizers/table/many.expected
@@ -1,38 +1,38 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "a", "substituted": "<A>"},
-{"_key": "b", "substituted": "<B>"},
-{"_key": "c", "substituted": "<C>"},
-{"_key": "d", "substituted": "<D>"},
-{"_key": "e", "substituted": "<E>"},
-{"_key": "f", "substituted": "<F>"},
-{"_key": "g", "substituted": "<G>"},
-{"_key": "h", "substituted": "<H>"},
-{"_key": "i", "substituted": "<I>"},
-{"_key": "j", "substituted": "<J>"},
-{"_key": "k", "substituted": "<K>"},
-{"_key": "l", "substituted": "<L>"},
-{"_key": "m", "substituted": "<M>"},
-{"_key": "n", "substituted": "<N>"},
-{"_key": "o", "substituted": "<O>"},
-{"_key": "p", "substituted": "<P>"},
-{"_key": "q", "substituted": "<Q>"},
-{"_key": "r", "substituted": "<R>"},
-{"_key": "s", "substituted": "<S>"},
-{"_key": "t", "substituted": "<T>"},
-{"_key": "u", "substituted": "<U>"},
-{"_key": "v", "substituted": "<V>"},
-{"_key": "w", "substituted": "<W>"},
-{"_key": "x", "substituted": "<X>"},
-{"_key": "y", "substituted": "<Y>"},
-{"_key": "z", "substituted": "<Z>"}
+{"_key": "a", "normalized": "<A>"},
+{"_key": "b", "normalized": "<B>"},
+{"_key": "c", "normalized": "<C>"},
+{"_key": "d", "normalized": "<D>"},
+{"_key": "e", "normalized": "<E>"},
+{"_key": "f", "normalized": "<F>"},
+{"_key": "g", "normalized": "<G>"},
+{"_key": "h", "normalized": "<H>"},
+{"_key": "i", "normalized": "<I>"},
+{"_key": "j", "normalized": "<J>"},
+{"_key": "k", "normalized": "<K>"},
+{"_key": "l", "normalized": "<L>"},
+{"_key": "m", "normalized": "<M>"},
+{"_key": "n", "normalized": "<N>"},
+{"_key": "o", "normalized": "<O>"},
+{"_key": "p", "normalized": "<P>"},
+{"_key": "q", "normalized": "<Q>"},
+{"_key": "r", "normalized": "<R>"},
+{"_key": "s", "normalized": "<S>"},
+{"_key": "t", "normalized": "<T>"},
+{"_key": "u", "normalized": "<U>"},
+{"_key": "v", "normalized": "<V>"},
+{"_key": "w", "normalized": "<W>"},
+{"_key": "x", "normalized": "<X>"},
+{"_key": "y", "normalized": "<Y>"},
+{"_key": "z", "normalized": "<Z>"}
 ]
 [[0,0.0,0.0],26]
-normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."
+normalize   'NormalizerTable("normalized", "Normalizations.normalized")'   ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."
 [
   [
     0,

--- a/test/command/suite/normalizers/table/many.test
+++ b/test/command/suite/normalizers/table/many.test
@@ -1,36 +1,36 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "a", "substituted": "<A>"},
-{"_key": "b", "substituted": "<B>"},
-{"_key": "c", "substituted": "<C>"},
-{"_key": "d", "substituted": "<D>"},
-{"_key": "e", "substituted": "<E>"},
-{"_key": "f", "substituted": "<F>"},
-{"_key": "g", "substituted": "<G>"},
-{"_key": "h", "substituted": "<H>"},
-{"_key": "i", "substituted": "<I>"},
-{"_key": "j", "substituted": "<J>"},
-{"_key": "k", "substituted": "<K>"},
-{"_key": "l", "substituted": "<L>"},
-{"_key": "m", "substituted": "<M>"},
-{"_key": "n", "substituted": "<N>"},
-{"_key": "o", "substituted": "<O>"},
-{"_key": "p", "substituted": "<P>"},
-{"_key": "q", "substituted": "<Q>"},
-{"_key": "r", "substituted": "<R>"},
-{"_key": "s", "substituted": "<S>"},
-{"_key": "t", "substituted": "<T>"},
-{"_key": "u", "substituted": "<U>"},
-{"_key": "v", "substituted": "<V>"},
-{"_key": "w", "substituted": "<W>"},
-{"_key": "x", "substituted": "<X>"},
-{"_key": "y", "substituted": "<Y>"},
-{"_key": "z", "substituted": "<Z>"}
+{"_key": "a", "normalized": "<A>"},
+{"_key": "b", "normalized": "<B>"},
+{"_key": "c", "normalized": "<C>"},
+{"_key": "d", "normalized": "<D>"},
+{"_key": "e", "normalized": "<E>"},
+{"_key": "f", "normalized": "<F>"},
+{"_key": "g", "normalized": "<G>"},
+{"_key": "h", "normalized": "<H>"},
+{"_key": "i", "normalized": "<I>"},
+{"_key": "j", "normalized": "<J>"},
+{"_key": "k", "normalized": "<K>"},
+{"_key": "l", "normalized": "<L>"},
+{"_key": "m", "normalized": "<M>"},
+{"_key": "n", "normalized": "<N>"},
+{"_key": "o", "normalized": "<O>"},
+{"_key": "p", "normalized": "<P>"},
+{"_key": "q", "normalized": "<Q>"},
+{"_key": "r", "normalized": "<R>"},
+{"_key": "s", "normalized": "<S>"},
+{"_key": "t", "normalized": "<T>"},
+{"_key": "u", "normalized": "<U>"},
+{"_key": "v", "normalized": "<V>"},
+{"_key": "w", "normalized": "<W>"},
+{"_key": "x", "normalized": "<X>"},
+{"_key": "y", "normalized": "<Y>"},
+{"_key": "z", "normalized": "<Z>"}
 ]
 
 normalize \
-  'NormalizerTable("column", "Substitutions.substituted")' \
+  'NormalizerTable("normalized", "Normalizations.normalized")' \
   ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."

--- a/test/command/suite/normalizers/table/report_source_offset.expected
+++ b/test/command/suite/normalizers/table/report_source_offset.expected
@@ -1,14 +1,14 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 [[0,0.0,0.0],2]
-normalize   'NormalizerTable("column", "Substitutions.substituted",                    "report_source_offset", true)'   ".あ。いち."
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "report_source_offset", true)'   ".あ。いち."
 [
   [
     0,

--- a/test/command/suite/normalizers/table/report_source_offset.test
+++ b/test/command/suite/normalizers/table/report_source_offset.test
@@ -1,13 +1,13 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 
 normalize \
-  'NormalizerTable("column", "Substitutions.substituted", \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
                    "report_source_offset", true)' \
   ".あ。いち."

--- a/test/command/suite/normalizers/table/target/data_column/invalid/no_equal_index.expected
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/no_equal_index.expected
@@ -1,0 +1,36 @@
+table_create Normalizations TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Normalizations target COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenNgram
+[[0,0.0,0.0],true]
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+[[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+[[0,0.0,0.0],1]
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "target", "target")'   ".a."
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[normalizer][table][target] no equal index: <target>"
+  ],
+  {
+    "normalized": "",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]
+#|e| [normalizer][table][target] no equal index: <target>

--- a/test/command/suite/normalizers/table/target/data_column/invalid/no_equal_index.test
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/no_equal_index.test
@@ -1,0 +1,17 @@
+table_create Normalizations TABLE_NO_KEY
+column_create Normalizations target COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenNgram
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+
+normalize \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
+                   "target", "target")' \
+  ".a."

--- a/test/command/suite/normalizers/table/target/data_column/invalid/nonexistent.expected
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/nonexistent.expected
@@ -1,0 +1,32 @@
+table_create Normalizations TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Normalizations target COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+[[0,0.0,0.0],1]
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "target", "nonexistent")'   ".a."
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[normalizer][table][target] nonexistent column: <nonexistent>"
+  ],
+  {
+    "normalized": "",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]
+#|e| [normalizer][table][target] nonexistent column: <nonexistent>

--- a/test/command/suite/normalizers/table/target/data_column/invalid/nonexistent.test
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/nonexistent.test
@@ -1,0 +1,13 @@
+table_create Normalizations TABLE_NO_KEY
+column_create Normalizations target COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+
+normalize \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
+                   "target", "nonexistent")' \
+  ".a."

--- a/test/command/suite/normalizers/table/target/data_column/invalid/not_patricia_trie.expected
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/not_patricia_trie.expected
@@ -1,0 +1,36 @@
+table_create Normalizations TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Normalizations target COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+[[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+[[0,0.0,0.0],1]
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "target", "target")'   ".a."
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[normalizer][table][target] table must be a TABLE_PAT_KEY: <#<table:hash Terms key:ShortText value:(nil) size:1 columns:[nor..."
+  ],
+  {
+    "normalized": "",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]
+#|e| [normalizer][table][target] table must be a TABLE_PAT_KEY: <#<table:hash Terms key:ShortText value:(nil) size:1 columns:[nor...(149)>

--- a/test/command/suite/normalizers/table/target/data_column/invalid/not_patricia_trie.test
+++ b/test/command/suite/normalizers/table/target/data_column/invalid/not_patricia_trie.test
@@ -1,0 +1,16 @@
+table_create Normalizations TABLE_NO_KEY
+column_create Normalizations target COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_HASH_KEY ShortText
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"}
+]
+
+normalize \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
+                   "target", "target")' \
+  ".a."

--- a/test/command/suite/normalizers/table/target/data_column/many.expected
+++ b/test/command/suite/normalizers/table/target/data_column/many.expected
@@ -1,0 +1,57 @@
+table_create Normalizations TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Normalizations target COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+[[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"},
+{"target": "b", "normalized": "<B>"},
+{"target": "c", "normalized": "<C>"},
+{"target": "d", "normalized": "<D>"},
+{"target": "e", "normalized": "<E>"},
+{"target": "f", "normalized": "<F>"},
+{"target": "g", "normalized": "<G>"},
+{"target": "h", "normalized": "<H>"},
+{"target": "i", "normalized": "<I>"},
+{"target": "j", "normalized": "<J>"},
+{"target": "k", "normalized": "<K>"},
+{"target": "l", "normalized": "<L>"},
+{"target": "m", "normalized": "<M>"},
+{"target": "n", "normalized": "<N>"},
+{"target": "o", "normalized": "<O>"},
+{"target": "p", "normalized": "<P>"},
+{"target": "q", "normalized": "<Q>"},
+{"target": "r", "normalized": "<R>"},
+{"target": "s", "normalized": "<S>"},
+{"target": "t", "normalized": "<T>"},
+{"target": "u", "normalized": "<U>"},
+{"target": "v", "normalized": "<V>"},
+{"target": "w", "normalized": "<W>"},
+{"target": "x", "normalized": "<X>"},
+{"target": "y", "normalized": "<Y>"},
+{"target": "z", "normalized": "<Z>"}
+]
+[[0,0.0,0.0],26]
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "target", "target")'   ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": ".<A>.<B>.<C>.<D>.<E>.<F>.<G>.<H>.<I>.<J>.<K>.<L>.<M>.<N>.<O>.<P>.<Q>.<R>.<S>.<T>.<U>.<V>.<W>.<X>.<Y>.<Z>.",
+    "types": [
+
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/table/target/data_column/many.test
+++ b/test/command/suite/normalizers/table/target/data_column/many.test
@@ -1,0 +1,41 @@
+table_create Normalizations TABLE_NO_KEY
+column_create Normalizations target COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText
+column_create Terms normalizations_target COLUMN_INDEX Normalizations target
+
+load --table Normalizations
+[
+{"target": "a", "normalized": "<A>"},
+{"target": "b", "normalized": "<B>"},
+{"target": "c", "normalized": "<C>"},
+{"target": "d", "normalized": "<D>"},
+{"target": "e", "normalized": "<E>"},
+{"target": "f", "normalized": "<F>"},
+{"target": "g", "normalized": "<G>"},
+{"target": "h", "normalized": "<H>"},
+{"target": "i", "normalized": "<I>"},
+{"target": "j", "normalized": "<J>"},
+{"target": "k", "normalized": "<K>"},
+{"target": "l", "normalized": "<L>"},
+{"target": "m", "normalized": "<M>"},
+{"target": "n", "normalized": "<N>"},
+{"target": "o", "normalized": "<O>"},
+{"target": "p", "normalized": "<P>"},
+{"target": "q", "normalized": "<Q>"},
+{"target": "r", "normalized": "<R>"},
+{"target": "s", "normalized": "<S>"},
+{"target": "t", "normalized": "<T>"},
+{"target": "u", "normalized": "<U>"},
+{"target": "v", "normalized": "<V>"},
+{"target": "w", "normalized": "<W>"},
+{"target": "x", "normalized": "<X>"},
+{"target": "y", "normalized": "<Y>"},
+{"target": "z", "normalized": "<Z>"}
+]
+
+normalize \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
+                   "target", "target")' \
+  ".a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z."

--- a/test/command/suite/normalizers/table/types.expected
+++ b/test/command/suite/normalizers/table/types.expected
@@ -1,14 +1,14 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 [[0,0.0,0.0],2]
-normalize   'NormalizerTable("column", "Substitutions.substituted")'   ".あ。いち."   WITH_TYPES
+normalize   'NormalizerTable("normalized", "Normalizations.normalized")'   ".あ。いち."   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/table/types.test
+++ b/test/command/suite/normalizers/table/types.test
@@ -1,13 +1,13 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
-load --table Substitutions
+load --table Normalizations
 [
-{"_key": "あ", "substituted": "<あ>"},
-{"_key": "いち", "substituted": "1"}
+{"_key": "あ", "normalized": "<あ>"},
+{"_key": "いち", "normalized": "1"}
 ]
 
 normalize \
-  'NormalizerTable("column", "Substitutions.substituted")' \
+  'NormalizerTable("normalized", "Normalizations.normalized")' \
   ".あ。いち." \
   WITH_TYPES

--- a/test/command/suite/normalizers/table/unicode_version.expected
+++ b/test/command/suite/normalizers/table/unicode_version.expected
@@ -1,6 +1,6 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
-normalize   'NormalizerTable("column", "Substitutions.substituted",                    "unicode_version", "13.0.0")'   "©"   WITH_TYPES
+normalize   'NormalizerTable("normalized", "Normalizations.normalized",                    "unicode_version", "13.0.0")'   "©"   WITH_TYPES
 [[0,0.0,0.0],{"normalized":"©","types":["emoji"],"checks":[]}]

--- a/test/command/suite/normalizers/table/unicode_version.test
+++ b/test/command/suite/normalizers/table/unicode_version.test
@@ -1,8 +1,8 @@
-table_create Substitutions TABLE_PAT_KEY ShortText
-column_create Substitutions substituted COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 
 normalize \
-  'NormalizerTable("column", "Substitutions.substituted", \
+  'NormalizerTable("normalized", "Normalizations.normalized", \
                    "unicode_version", "13.0.0")' \
   "©" \
   WITH_TYPES


### PR DESCRIPTION
Without this change, the following table is only supported:

    table_create Normalizations TABLE_PAT_KEY ShortText
    column_create Normalizations normalized COLUMN_SCALAR ShortText

With this change, the following table with an index is also supported:

    table_create Normalizations TABLE_NO_KEY
    column_create Normalizations target COLUMN_SCALAR ShortText
    column_create Normalizations normalized COLUMN_SCALAR ShortText

    table_create Terms TABLE_PAT_KEY ShortText
    column_create Terms normalizations_target COLUMN_INDEX \
      Normalizations target

The former can be used with:

    NormalizerTable("normalized", Normalizations.normalized")

The latter can be used with:

    NormalizerTable("normalized", "Normalizations.normalized",
                    "target", "Normalizations.target")

Note that "column" option is deprecated. Use "normalized" option
instead.
