### PR TITLE
grn_expr_slice: adjust nargs for GRN_OP_CALL

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6927,10 +6927,14 @@ grn_expr_slice(grn_ctx *ctx,
                             code->nargs);
       }
     } else {
+      int nargs = code->nargs;
+      if (code->op == GRN_OP_CALL) {
+        nargs--;
+      }
       grn_expr_append_op(ctx,
                          sliced_expr,
                          code->op,
-                         code->nargs);
+                         nargs);
     }
   }
   GRN_API_RETURN(sliced_expr);

--- a/test/command/suite/select/function/query_paralell_or/match_columns/scorer.expected
+++ b/test/command/suite/select/function/query_paralell_or/match_columns/scorer.expected
@@ -1,0 +1,45 @@
+table_create Tags TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Users TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Users tags COLUMN_VECTOR Tags
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Alice",
+ "tags": ["beginner", "active"]},
+{"_key": "Bob",
+ "tags": ["expert", "passive"]},
+{"_key": "Chris",
+ "tags": ["beginner", "passive"]}
+]
+[[0,0.0,0.0],3]
+column_create Tags users COLUMN_INDEX Users tags
+[[0,0.0,0.0],true]
+select Users   --output_columns _key,_score   --sort_keys _id   --command_version 3   --filter 'query_parallel_or("scorer_tf_idf(tags)",                               "beginner active")'
+{
+  "header": {
+    "return_code": 0,
+    "start_time": 0.0,
+    "elapsed_time": 0.0
+  },
+  "body": {
+    "n_hits": 1,
+    "columns": [
+      {
+        "name": "_key",
+        "type": "ShortText"
+      },
+      {
+        "name": "_score",
+        "type": "Float"
+      }
+    ],
+    "records": [
+      [
+        "Alice",
+        2.098612308502197
+      ]
+    ]
+  }
+}

--- a/test/command/suite/select/function/query_paralell_or/match_columns/scorer.test
+++ b/test/command/suite/select/function/query_paralell_or/match_columns/scorer.test
@@ -1,0 +1,23 @@
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create Users TABLE_HASH_KEY ShortText
+column_create Users tags COLUMN_VECTOR Tags
+
+load --table Users
+[
+{"_key": "Alice",
+ "tags": ["beginner", "active"]},
+{"_key": "Bob",
+ "tags": ["expert", "passive"]},
+{"_key": "Chris",
+ "tags": ["beginner", "passive"]}
+]
+
+column_create Tags users COLUMN_INDEX Users tags
+
+select Users \
+  --output_columns _key,_score \
+  --sort_keys _id \
+  --command_version 3 \
+  --filter 'query_parallel_or("scorer_tf_idf(tags)", \
+                              "beginner active")'


### PR DESCRIPTION
In order to slice the expr of match_columns including ``scorer_tf_idf``, it is necessary to adjust the nargs of ``GRN_OP_CALL``. 

Example case:

```
#$GRN_QUERY_PARALLEL_OR_N_CONDITIONS_THRESHOLD=1
#$GRN_QUERY_PARALLEL_OR_N_THREADS_LIMIT=2

table_create Tags TABLE_HASH_KEY ShortText

table_create Users TABLE_HASH_KEY ShortText
column_create Users comment COLUMN_SCALAR ShortText
column_create Users tags_by_me COLUMN_VECTOR Tags
column_create Users tags_by_others COLUMN_VECTOR Tags

load --table Users
[
{"_key": "Alice",
 "tags_by_me": ["beginner", "active"],
 "tags_by_others": ["expert", "active"]},
{"_key": "Bob",
 "tags_by_me": ["expert", "passive"],
 "tags_by_others": ["beginner", "passive"]},
{"_key": "Chris",
 "tags_by_me": ["beginner", "passive"],
 "tags_by_others": ["beginner", "active"]}
]

column_create Tags users COLUMN_INDEX|WITH_SECTION \
  Users tags_by_me,tags_by_others

select Users \
  --output_columns _id,_key,tags_by_me,tags_by_others,,_score \
  --sort_keys _id \
  --filter 'query_parallel_or("scorer_tf_idf(tags_by_me) || scorer_tf_idf(tags_by_me,1) * 1", \
                              "beginner active")'
```