### PR TITLE
grn_expr_match_columns_split: Don't split by GRN_OP_STAR

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6724,16 +6724,6 @@ grn_expr_match_columns_split(grn_ctx *ctx,
   uint32_t i;
   for (i = 0; i < e->codes_curr; i++) {
     switch (e->codes[i].op) {
-    case GRN_OP_STAR :
-      {
-        grn_obj *match_column = grn_expr_slice(ctx,
-                                               expr,
-                                               match_columns_start,
-                                               i + 1);
-        GRN_PTR_PUT(ctx, splitted_match_columns, match_column);
-        match_columns_start = i + 1;
-      }
-      break;
     case GRN_OP_OR :
       if (match_columns_start == i) {
         match_columns_start++;

--- a/test/command/suite/select/function/query_paralell_or/match_columns/or_with_another_op.expected
+++ b/test/command/suite/select/function/query_paralell_or/match_columns/or_with_another_op.expected
@@ -1,0 +1,24 @@
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Users memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Users tag COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenNgram
+[[0,0.0,0.0],true]
+column_create Terms name COLUMN_INDEX|WITH_POSITION Users name
+[[0,0.0,0.0],true]
+column_create Terms memo COLUMN_INDEX|WITH_POSITION Users memo
+[[0,0.0,0.0],true]
+column_create Terms tag COLUMN_INDEX|WITH_POSITION Users tag
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"name": "Alice", "memo": "Groonga user", "tag": "Groonga"},
+{"name": "Bob",   "memo": "Rroonga user", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],2]
+select Users   --output_columns _score,name   --filter 'query_parallel_or("name * 100 + memo * 10 || tag * 1", "Alice OR Groonga")'
+[[0,0.0,0.0],[[[1],[["_score","Int32"],["name","ShortText"]],[111,"Alice"]]]]

--- a/test/command/suite/select/function/query_paralell_or/match_columns/or_with_another_op.test
+++ b/test/command/suite/select/function/query_paralell_or/match_columns/or_with_another_op.test
@@ -1,0 +1,19 @@
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
+column_create Users memo COLUMN_SCALAR ShortText
+column_create Users tag COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenNgram
+column_create Terms name COLUMN_INDEX|WITH_POSITION Users name
+column_create Terms memo COLUMN_INDEX|WITH_POSITION Users memo
+column_create Terms tag COLUMN_INDEX|WITH_POSITION Users tag
+
+load --table Users
+[
+{"name": "Alice", "memo": "Groonga user", "tag": "Groonga"},
+{"name": "Bob",   "memo": "Rroonga user", "tag": "Rroonga"}
+]
+
+select Users \
+  --output_columns _score,name \
+  --filter 'query_parallel_or("name * 100 + memo * 10 || tag * 1", "Alice OR Groonga")'


### PR DESCRIPTION
We don't want to split only by ``GRN_OP_STAR`` in ``grn_expr_match_columns_split``.
We would like to represent a group of parallel match_columns, for example by using a combination of OR and other OPs.

This makes it possible to realize a query that has the same number of hits as a normal ``query()`` function in some cases even if it includes an ``and`` logical operator in query string.

For example in our query, it looks like this:

```
query_parallel_or ( \
"vgram_terms.app_claims1 * 1 + vgram_terms.description1 * 1 || 
 vgram_terms.app_claims2 * 1 + vgram_terms.description2 * 1", \
"search query + keywords") 
```

```
table_create Users TABLE_NO_KEY
[[0,0.0,0.0],true]
column_create Users name COLUMN_SCALAR ShortText
[[0,0.0,0.0],true]
column_create Users memo COLUMN_SCALAR ShortText
[[0,0.0,0.0],true]
column_create Users tag COLUMN_SCALAR ShortText
[[0,0.0,0.0],true]
table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenNgram
[[0,0.0,0.0],true]
column_create Terms name COLUMN_INDEX|WITH_POSITION Users name
[[0,0.0,0.0],true]
column_create Terms memo COLUMN_INDEX|WITH_POSITION Users memo
[[0,0.0,0.0],true]
column_create Terms tag COLUMN_INDEX|WITH_POSITION Users tag
[[0,0.0,0.0],true]
load --table Users
[
{"name": "Alice", "memo": "Groonga user", "tag": "Groonga"},
{"name": "Bob",   "memo": "Rroonga user", "tag": "Rroonga"}
]
[[0,0.0,0.0],2]
select Users   --output_columns _score,name   --filter 'query_parallel_or("name * 100 + memo * 10 || tag * 1", "Alice OR Groonga")'
[[0,0.0,0.0],[[[1],[["_score","Int32"],["name","ShortText"]],[111,"Alice"]]]]
```

```
orginal expr:
#<expr
  vars:{
    $1:#<record:no_key:Users id:(no value)>
  },
  codes:{
    0:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.name range:ShortText type:scalar compress:none>>,
    1:<push n_args:1, flags:0, modify:0, value:100>,
    2:<star n_args:2, flags:0, modify:4, value:(NULL)>,
    3:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.memo range:ShortText type:scalar compress:none>>,
    4:<push n_args:1, flags:0, modify:0, value:10>,
    5:<star n_args:2, flags:0, modify:0, value:(NULL)>,
    6:<plus n_args:2, flags:1, modify:4, value:(NULL)>,
    7:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.tag range:ShortText type:scalar compress:none>>,
    8:<push n_args:1, flags:0, modify:0, value:1>,
    9:<star n_args:2, flags:1, modify:0, value:(NULL)>,
    10:<or n_args:2, flags:0, modify:0, value:(NULL)>
  }
>
splitted expr:
[#<expr
  vars:{
    $1:#<record:no_key:Users id:0(nonexistent)>
  },
  codes:{
    0:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.name range:ShortText type:scalar compress:none>>,
    1:<push n_args:1, flags:0, modify:0, value:100>,
    2:<star n_args:2, flags:0, modify:4, value:(NULL)>,
    3:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.memo range:ShortText type:scalar compress:none>>,
    4:<push n_args:1, flags:0, modify:0, value:10>,
    5:<star n_args:2, flags:0, modify:0, value:(NULL)>,
    6:<plus n_args:2, flags:0, modify:0, value:(NULL)>
  }
>, #<expr
  vars:{
    $1:#<record:no_key:Users id:0(nonexistent)>
  },
  codes:{
    0:<get_value n_args:1, flags:0, modify:2, value:#<column:var_size Users.tag range:ShortText type:scalar compress:none>>,
    1:<push n_args:1, flags:0, modify:0, value:1>,
    2:<star n_args:2, flags:0, modify:0, value:(NULL)>
  }
>]
```