### PR TITLE
grndb recover: close used objects immediately

### DIFF
--- a/lib/mrb/mrb_ctx.c
+++ b/lib/mrb/mrb_ctx.c
@@ -832,6 +832,28 @@ grn_mrb_ctx_to_exception(mrb_state *mrb)
   return mrb_exc_new_str(mrb, error_class, mrb_str_new_cstr(mrb, message));
 }
 
+mrb_value
+ctx_push_temporary_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_ctx_push_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+mrb_value
+ctx_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_ctx_pop_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
 void
 grn_mrb_ctx_check(mrb_state *mrb)
 {
@@ -903,5 +925,11 @@ grn_mrb_ctx_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "opened?", ctx_is_opened,
                     MRB_ARGS_REQ(1));
+
+  mrb_define_method(mrb, klass, "push_temporary_open_space",
+                    ctx_push_temporary_open_space, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "pop_temporary_open_space",
+                    ctx_pop_temporary_open_space, MRB_ARGS_NONE());
+
 }
 #endif

--- a/lib/mrb/mrb_ctx.c
+++ b/lib/mrb/mrb_ctx.c
@@ -309,6 +309,28 @@ ctx_is_opened(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(grn_ctx_is_opened(ctx, mrb_id));
 }
 
+static mrb_value
+ctx_push_temporary_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_ctx_push_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
+ctx_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+
+  grn_ctx_pop_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
 mrb_value
 grn_mrb_ctx_to_exception(mrb_state *mrb)
 {
@@ -830,28 +852,6 @@ grn_mrb_ctx_to_exception(mrb_state *mrb)
 #undef MESSAGE_SIZE
 
   return mrb_exc_new_str(mrb, error_class, mrb_str_new_cstr(mrb, message));
-}
-
-static mrb_value
-ctx_push_temporary_open_space(mrb_state *mrb, mrb_value self)
-{
-  grn_ctx *ctx = (grn_ctx *)mrb->ud;
-
-  grn_ctx_push_temporary_open_space(ctx);
-  grn_mrb_ctx_check(mrb);
-
-  return mrb_nil_value();
-}
-
-static mrb_value
-ctx_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
-{
-  grn_ctx *ctx = (grn_ctx *)mrb->ud;
-
-  grn_ctx_pop_temporary_open_space(ctx);
-  grn_mrb_ctx_check(mrb);
-
-  return mrb_nil_value();
 }
 
 void

--- a/lib/mrb/mrb_ctx.c
+++ b/lib/mrb/mrb_ctx.c
@@ -832,7 +832,7 @@ grn_mrb_ctx_to_exception(mrb_state *mrb)
   return mrb_exc_new_str(mrb, error_class, mrb_str_new_cstr(mrb, message));
 }
 
-mrb_value
+static mrb_value
 ctx_push_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -843,7 +843,7 @@ ctx_push_temporary_open_space(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
-mrb_value
+static mrb_value
 ctx_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;

--- a/lib/mrb/mrb_object.c
+++ b/lib/mrb/mrb_object.c
@@ -255,6 +255,32 @@ grn_mrb_object_is_closed(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value
+grn_mrb_object_push_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
+
+  if (is_close_opened_object_mode) {
+    grn_ctx_push_temporary_open_space(ctx);
+  }
+
+  return mrb_nil_value();
+}
+
+mrb_value
+grn_mrb_object_pop_open_space(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
+
+  if (is_close_opened_object_mode) {
+    grn_ctx_pop_temporary_open_space(ctx);
+  }
+
+  return mrb_nil_value();
+}
+
+mrb_value
 grn_mrb_object_get_domain_id(mrb_state *mrb, mrb_value self)
 {
   grn_obj *object;
@@ -371,6 +397,11 @@ grn_mrb_object_init(grn_ctx *ctx)
   mrb_define_method(mrb, klass, "remove", object_remove, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, klass, "closed?",
                     grn_mrb_object_is_closed, MRB_ARGS_NONE());
+
+  mrb_define_method(mrb, klass, "push_open_space",
+                    grn_mrb_object_push_open_space, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "pop_open_space",
+                    grn_mrb_object_pop_open_space, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "domain_id", grn_mrb_object_get_domain_id,
                     MRB_ARGS_NONE());

--- a/lib/mrb/mrb_object.c
+++ b/lib/mrb/mrb_object.c
@@ -262,6 +262,7 @@ grn_mrb_object_push_temporary_open_space(mrb_state *mrb, mrb_value self)
 
   if (is_close_opened_object_mode) {
     grn_ctx_push_temporary_open_space(ctx);
+    grn_mrb_ctx_check(mrb);
   }
 
   return mrb_nil_value();
@@ -275,6 +276,7 @@ grn_mrb_object_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
 
   if (is_close_opened_object_mode) {
     grn_ctx_pop_temporary_open_space(ctx);
+    grn_mrb_ctx_check(mrb);
   }
 
   return mrb_nil_value();

--- a/lib/mrb/mrb_object.c
+++ b/lib/mrb/mrb_object.c
@@ -258,12 +258,9 @@ mrb_value
 grn_mrb_object_push_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
-  grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
 
-  if (is_close_opened_object_mode) {
-    grn_ctx_push_temporary_open_space(ctx);
-    grn_mrb_ctx_check(mrb);
-  }
+  grn_ctx_push_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
 
   return mrb_nil_value();
 }
@@ -272,12 +269,9 @@ mrb_value
 grn_mrb_object_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
-  grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
 
-  if (is_close_opened_object_mode) {
-    grn_ctx_pop_temporary_open_space(ctx);
-    grn_mrb_ctx_check(mrb);
-  }
+  grn_ctx_pop_temporary_open_space(ctx);
+  grn_mrb_ctx_check(mrb);
 
   return mrb_nil_value();
 }

--- a/lib/mrb/mrb_object.c
+++ b/lib/mrb/mrb_object.c
@@ -255,7 +255,7 @@ grn_mrb_object_is_closed(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value
-grn_mrb_object_push_open_space(mrb_state *mrb, mrb_value self)
+grn_mrb_object_push_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
   grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
@@ -268,7 +268,7 @@ grn_mrb_object_push_open_space(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value
-grn_mrb_object_pop_open_space(mrb_state *mrb, mrb_value self)
+grn_mrb_object_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
   grn_bool is_close_opened_object_mode = (grn_thread_get_limit() == 1);
@@ -398,10 +398,10 @@ grn_mrb_object_init(grn_ctx *ctx)
   mrb_define_method(mrb, klass, "closed?",
                     grn_mrb_object_is_closed, MRB_ARGS_NONE());
 
-  mrb_define_method(mrb, klass, "push_open_space",
-                    grn_mrb_object_push_open_space, MRB_ARGS_NONE());
-  mrb_define_method(mrb, klass, "pop_open_space",
-                    grn_mrb_object_pop_open_space, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "push_temporary_open_space",
+                    grn_mrb_object_push_temporary_open_space, MRB_ARGS_NONE());
+  mrb_define_method(mrb, klass, "pop_temporary_open_space",
+                    grn_mrb_object_pop_temporary_open_space, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "domain_id", grn_mrb_object_get_domain_id,
                     MRB_ARGS_NONE());

--- a/lib/mrb/mrb_object.c
+++ b/lib/mrb/mrb_object.c
@@ -255,28 +255,6 @@ grn_mrb_object_is_closed(mrb_state *mrb, mrb_value self)
 }
 
 mrb_value
-grn_mrb_object_push_temporary_open_space(mrb_state *mrb, mrb_value self)
-{
-  grn_ctx *ctx = (grn_ctx *)mrb->ud;
-
-  grn_ctx_push_temporary_open_space(ctx);
-  grn_mrb_ctx_check(mrb);
-
-  return mrb_nil_value();
-}
-
-mrb_value
-grn_mrb_object_pop_temporary_open_space(mrb_state *mrb, mrb_value self)
-{
-  grn_ctx *ctx = (grn_ctx *)mrb->ud;
-
-  grn_ctx_pop_temporary_open_space(ctx);
-  grn_mrb_ctx_check(mrb);
-
-  return mrb_nil_value();
-}
-
-mrb_value
 grn_mrb_object_get_domain_id(mrb_state *mrb, mrb_value self)
 {
   grn_obj *object;
@@ -393,11 +371,6 @@ grn_mrb_object_init(grn_ctx *ctx)
   mrb_define_method(mrb, klass, "remove", object_remove, MRB_ARGS_OPT(1));
   mrb_define_method(mrb, klass, "closed?",
                     grn_mrb_object_is_closed, MRB_ARGS_NONE());
-
-  mrb_define_method(mrb, klass, "push_temporary_open_space",
-                    grn_mrb_object_push_temporary_open_space, MRB_ARGS_NONE());
-  mrb_define_method(mrb, klass, "pop_temporary_open_space",
-                    grn_mrb_object_pop_temporary_open_space, MRB_ARGS_NONE());
 
   mrb_define_method(mrb, klass, "domain_id", grn_mrb_object_get_domain_id,
                     MRB_ARGS_NONE());

--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -602,7 +602,7 @@ module Groonga
         def recover
           logger.log(:info, "Recovering database: <#{@database.path}>")
           if @force_truncate
-            @database.each(use_temporary_open_space: true) do |object|
+            @database.each(use_temporary_open_space: close_opened_object_mode?) do |object|
               next unless truncate_target?(object)
               truncate_broken_object(object)
             end
@@ -616,6 +616,10 @@ module Groonga
         end
 
         private
+        def close_opened_object_mode?
+          Thread.limit == 1
+        end
+
         def truncate_target?(object)
           return true if object.corrupt?
 

--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -602,14 +602,9 @@ module Groonga
         def recover
           logger.log(:info, "Recovering database: <#{@database.path}>")
           if @force_truncate
-            @database.each do |object|
-              object.push_open_space
-              unless truncate_target?(object)
-                object.pop_open_space
-                next
-              end
+            @database.each(use_temporary_open_space: true) do |object|
+              next unless truncate_target?(object)
               truncate_broken_object(object)
-              object.pop_open_space
             end
           end
           if @force_lock_clear
@@ -680,8 +675,7 @@ module Groonga
             @database.clear_lock
             logger.log(:info, "Clear locked database: <#{@database.path}>")
           end
-          @database.each do |object|
-            object.push_open_space
+          @database.each(use_temporary_open_space: true) do |object|
             case object
             when IndexColumn
               # Ignore. It'll be recovered later.
@@ -692,7 +686,6 @@ module Groonga
                          "[#{object.name}] Clear locked object: " +
                          "<#{object.path}>")
             end
-            object.pop_open_space
           end
         end
 

--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -603,12 +603,13 @@ module Groonga
           logger.log(:info, "Recovering database: <#{@database.path}>")
           if @force_truncate
             @database.each do |object|
+              object.push_open_space
               unless truncate_target?(object)
-                object.close
+                object.pop_open_space
                 next
               end
               truncate_broken_object(object)
-              object.close
+              object.pop_open_space
             end
           end
           if @force_lock_clear
@@ -680,6 +681,7 @@ module Groonga
             logger.log(:info, "Clear locked database: <#{@database.path}>")
           end
           @database.each do |object|
+            object.push_open_space
             case object
             when IndexColumn
               # Ignore. It'll be recovered later.
@@ -690,7 +692,7 @@ module Groonga
                          "[#{object.name}] Clear locked object: " +
                          "<#{object.path}>")
             end
-            object.close
+            object.pop_open_space
           end
         end
 

--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -602,7 +602,7 @@ module Groonga
         def recover
           logger.log(:info, "Recovering database: <#{@database.path}>")
           if @force_truncate
-            @database.each(use_temporary_open_space: close_opened_object_mode?) do |object|
+            @database.each(use_temporary_open_space: true) do |object|
               next unless truncate_target?(object)
               truncate_broken_object(object)
             end
@@ -616,10 +616,6 @@ module Groonga
         end
 
         private
-        def close_opened_object_mode?
-          Thread.limit == 1
-        end
-
         def truncate_target?(object)
           return true if object.corrupt?
 

--- a/lib/mrb/scripts/command_line/grndb.rb
+++ b/lib/mrb/scripts/command_line/grndb.rb
@@ -603,8 +603,12 @@ module Groonga
           logger.log(:info, "Recovering database: <#{@database.path}>")
           if @force_truncate
             @database.each do |object|
-              next unless truncate_target?(object)
+              unless truncate_target?(object)
+                object.close
+                next
+              end
               truncate_broken_object(object)
+              object.close
             end
           end
           if @force_lock_clear
@@ -686,6 +690,7 @@ module Groonga
                          "[#{object.name}] Clear locked object: " +
                          "<#{object.path}>")
             end
+            object.close
           end
         end
 

--- a/lib/mrb/scripts/context.rb
+++ b/lib/mrb/scripts/context.rb
@@ -67,6 +67,19 @@ module Groonga
       end
     end
 
+    def with_temporary_open_space(push=true)
+      if push
+        push_temporary_open_space
+        begin
+          yield
+        ensure
+          pop_temporary_open_space
+        end
+      else
+        yield
+      end
+    end
+
     private
     def set_error_raw(rc, error_level, message, backtrace)
       self.rc = rc.to_i

--- a/lib/mrb/scripts/database.rb
+++ b/lib/mrb/scripts/database.rb
@@ -36,16 +36,9 @@ module Groonga
       return to_enum(__method__, options) unless block_given?
 
       context = Context.instance
+      use_temporary_open_space = options[:use_temporary_open_space]
       each_raw(options) do |id, cursor|
-        if options[:use_temporary_open_space]
-          context.push_temporary_open_space
-          begin
-            object = context[id]
-            yield(object) if object
-          ensure
-            context.pop_temporary_open_space
-          end
-        else
+        context.with_temporary_open_space(use_temporary_open_space) do
           object = context[id]
           yield(object) if object
         end

--- a/lib/mrb/scripts/database.rb
+++ b/lib/mrb/scripts/database.rb
@@ -38,7 +38,11 @@ module Groonga
       context = Context.instance
       each_raw(options) do |id, cursor|
         object = context[id]
-        yield(object) if object
+        if object
+          object.push_temporary_open_space if options[:use_temporary_open_space]
+          yield(object)
+          object.pop_temporary_open_space if options[:use_temporary_open_space]
+        end
       end
     end
 

--- a/lib/mrb/scripts/database.rb
+++ b/lib/mrb/scripts/database.rb
@@ -37,11 +37,17 @@ module Groonga
 
       context = Context.instance
       each_raw(options) do |id, cursor|
-        object = context[id]
-        if object
-          object.push_temporary_open_space if options[:use_temporary_open_space]
-          yield(object)
-          object.pop_temporary_open_space if options[:use_temporary_open_space]
+        if options[:use_temporary_open_space]
+          context.push_temporary_open_space
+          begin
+            object = context[id]
+            yield(object) if object
+          ensure
+            context.pop_temporary_open_space
+          end
+        else
+          object = context[id]
+          yield(object) if object
         end
       end
     end

--- a/src/grndb.c
+++ b/src/grndb.c
@@ -30,6 +30,12 @@
 #include <mruby/variable.h>
 #include <mruby/array.h>
 
+static uint32_t
+get_thread_limit(void *data)
+{
+  return 1;
+}
+
 static int
 run_command(grn_ctx *ctx, int argc, char **argv)
 {
@@ -133,6 +139,8 @@ main(int argc, char **argv)
   const char *log_path = GRN_LOG_PATH;
   const char *log_level_name = NULL;
   const char *log_flags_name = NULL;
+
+  grn_thread_set_get_limit_func(get_thread_limit, NULL);
 
   {
     int i;

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -51,7 +51,7 @@ module GroongaLog
     last_log_lines = []
     standard_log_lines.reverse_each do |line|
       case remove_timestamp(line)
-      when /\A\|[i-]\| \[io\]\[close\]/,
+      when /\A\|[d-]\| \[io\]\[close\]/,
            /\A\|n\| grn_fin/
         last_log_lines << line
       else
@@ -108,7 +108,7 @@ module GroongaLog
       when "info",
            "debug",
            "dump"
-        "|i| [io][close] <#{path}>"
+        "|d| [io][close] <#{path}>"
       else
         ""
       end

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -36,7 +36,7 @@ module GroongaLog
            /\A\|i\| To set/,
            /\A\|i\| add/,
            /\A\|i\| run/,
-           /\A\|-\| \[io\]\[open\]/
+           /\A\|[i-]\| \[io\]\[open\]/
         log << line
       else
         break
@@ -51,7 +51,7 @@ module GroongaLog
     last_log_lines = []
     standard_log_lines.reverse_each do |line|
       case remove_timestamp(line)
-      when /\A\|-\| \[io\]\[close\]/,
+      when /\A\|[i-]\| \[io\]\[close\]/,
            /\A\|n\| grn_fin/
         last_log_lines << line
       else

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -209,7 +209,7 @@ module GroongaLog
         end
         message = normalize_groonga_log_message(message)
         case message
-        when /\A\|e\| \[tokenizer\]\[mecab\]\[create\]\[wakati\]/
+        when /\A\[tokenizer\]\[mecab\]\[create\]\[wakati\]/
           # Ignore
           next
         end

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -62,6 +62,66 @@ module GroongaLog
     log
   end
 
+  def open_file_log_line(path, log_level)
+    if windows?
+      case log_level
+      when "info",
+           "debug",
+           "dump"
+        "|i| [io][open] open existing file: <#{path}>"
+      else
+        ""
+      end
+    else
+      case log_level
+      when "dump"
+        "|-| [io][open] <#{path}>"
+      else
+        ""
+      end
+    end
+  end
+
+  def create_file_log_line(path, log_level)
+    if windows?
+      case log_level
+      when "info",
+           "debug",
+           "dump"
+        "|i| [io][open] create new file: <#{path}>"
+      else
+        ""
+      end
+    else
+      case log_level
+      when "dump"
+        "|-| [io][open] <#{path}>"
+      else
+        ""
+      end
+    end
+  end
+
+  def close_file_log_line(path, log_level)
+    if windows?
+      case log_level
+      when "info",
+           "debug",
+           "dump"
+        "|i| [io][close] <#{path}>"
+      else
+        ""
+      end
+    else
+      case log_level
+      when "dump"
+        "|-| [io][close] <#{path}>"
+      else
+        ""
+      end
+    end
+  end
+
   def prepend_tag(tag, messages)
     messages.each_line.inject("") do |result, line|
       result + "#{tag}#{line}"

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -23,14 +23,22 @@ module GroongaLog
               "--log-level", level,
             ])
     standard_log_lines = normalize_groonga_log(File.read(log_file.path)).lines
-    log = standard_log_lines[0..-2].join("")
+    if level == "dump"
+      log = standard_log_lines[0..-6].join("") # [io][open]
+    else
+      log = standard_log_lines[0..-2].join("")
+    end
     unless messages.empty?
       messages.each_line do |message|
         next if message.chomp.empty?
         log << "1970-01-01 00:00:00.000000#{message}"
       end
     end
-    log << standard_log_lines[-1] # grn_fin
+    if level == "dump"
+      log << standard_log_lines[-5..-1].join("") # [io][close] and grn_fin
+    else
+      log << standard_log_lines[-1] # grn_fin
+    end
     log
   end
 
@@ -94,7 +102,7 @@ module GroongaLog
       when /\A
               (\d{4}-\d{2}-\d{2}\ \d{2}:\d{2}:\d{2}\.\d+)?
               \|\
-              ([a-zA-Z])
+              ([a-zA-Z-])
               \|\
               ([^: ]+)?
               ([|:]\ )?

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -209,7 +209,7 @@ module GroongaLog
         end
         message = normalize_groonga_log_message(message)
         case message
-        when /\A\[tokenizer\]\[mecab\]\[create\]\[wakati\]/
+        when /\A \[tokenizer\]\[mecab\]\[create\]\[wakati\]/
           # Ignore
           next
         end

--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -208,6 +208,11 @@ module GroongaLog
           id_section = "PROCESS_ID"
         end
         message = normalize_groonga_log_message(message)
+        case message
+        when /\A\|e\| \[tokenizer\]\[mecab\]\[create\]\[wakati\]/
+          # Ignore
+          next
+        end
         normalized <<
           "#{timestamp}|#{level}|#{id_section}#{separator}#{message}\n"
       else

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -374,11 +374,11 @@ object corrupt: <#{recover_error_message}>(-55)
                    "",
                    expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|d| [io][open] <#{path}>" : "|-| [io][open] <#{path}>"}
+#{windows? ? "" : "|-| [io][open] <#{path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
 #{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}
-#{windows? ? "|d| [io][open] <#{path}>" : "|-| [io][open] <#{path}>"}
+#{windows? ? "" : "|-| [io][open] <#{path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
 #{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -266,6 +266,7 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 |i| [io][remove] removed path: <#{@column_path}>
+#{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 #{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
@@ -442,6 +443,8 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -179,7 +179,7 @@ object corrupt: <#{recover_error_message}>(-55)
       FileUtils.touch(additional_path)
       result = grndb("recover",
                      "--force-truncate",
-                     "--log-level", "info")
+                     "--log-level", "dump")
       message = <<-MESSAGE
 [Users] Truncated broken object: <#{@table_path}>
 [Users] Removed broken object related file: <#{additional_path}>
@@ -187,14 +187,20 @@ object corrupt: <#{recover_error_message}>(-55)
       assert_equal([
                      "",
                      message,
-                     expected_groonga_log("info", <<-MESSAGES),
+                     expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
+|-| [io][open] <#{@table_path}>
+|-| [io][close] <#{@table_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| [io][remove] removed path: <#{@table_path}>
+|-| [io][open] <#{@table_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
+|-| [io][close] <#{@table_path}>
+|-| [io][open] <#{@table_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
+|-| [io][close] <#{@table_path}>
                      MESSAGES
                    ],
                    [
@@ -365,16 +371,20 @@ object corrupt: <#{recover_error_message}>(-55)
     _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][1]
 
     remove_groonga_log
-    result = grndb("recover", "--force-lock-clear", "--log-level", "info")
+    result = grndb("recover", "--force-lock-clear", "--log-level", "dump")
     assert_equal([
                    "",
                    "",
-                   expected_groonga_log("info", <<-MESSAGES),
+                   expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
+|-| [io][open] <#{path}>
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
+|-| [io][close] <#{path}>
+|-| [io][open] <#{path}>
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
+|-| [io][close] <#{path}>
                    MESSAGES
                  ],
                  [

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -193,6 +193,7 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| [io][remove] removed path: <#{@table_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -263,9 +264,11 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| Recovering database: <#{@database_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 |i| [io][remove] removed path: <#{@column_path}>
-#{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
+#{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -369,6 +372,7 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| Recovering database: <#{@database_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -396,6 +400,8 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users.age] Clear locked object: <#{path}>
+#{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -431,6 +437,11 @@ object corrupt: <#{recover_error_message}>(-55)
                    "",
                    expected_groonga_log("info", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -189,18 +189,15 @@ object corrupt: <#{recover_error_message}>(-55)
                      message,
                      expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
 #{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| [io][remove] removed path: <#{@table_path}>
-#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
-#{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
+#{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
 #{prepend_tag("|i| ", message).chomp}
 #{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
-#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
 |i| Recovered database: <#{@database_path}>
-#{windows? ? "|-| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
+#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
                      MESSAGES
                    ],
                    [
@@ -275,7 +272,7 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
-#{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -448,8 +445,7 @@ object corrupt: <#{recover_error_message}>(-55)
                    "",
                    expected_groonga_log("info", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -177,9 +177,10 @@ object corrupt: <#{recover_error_message}>(-55)
     def test_force_truncate
       additional_path = "#{@table_path}.002"
       FileUtils.touch(additional_path)
+      log_level = "dump"
       result = grndb("recover",
                      "--force-truncate",
-                     "--log-level", "dump")
+                     "--log-level", log_level)
       message = <<-MESSAGE
 [Users] Truncated broken object: <#{@table_path}>
 [Users] Removed broken object related file: <#{additional_path}>
@@ -187,17 +188,17 @@ object corrupt: <#{recover_error_message}>(-55)
       assert_equal([
                      "",
                      message,
-                     expected_groonga_log("dump", <<-MESSAGES),
+                     expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
-#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
+#{open_file_log_line(@table_path, log_level)}
+#{close_file_log_line(@table_path, log_level)}
 |i| [io][remove] removed path: <#{@table_path}>
-#{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
+#{create_file_log_line(@table_path, log_level)}
 #{prepend_tag("|i| ", message).chomp}
-#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
+#{close_file_log_line(@table_path, log_level)}
+#{open_file_log_line(@table_path, log_level)}
+#{close_file_log_line(@table_path, log_level)}
 |i| Recovered database: <#{@database_path}>
-#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
                      MESSAGES
                    ],
                    [
@@ -253,9 +254,10 @@ object corrupt: <#{recover_error_message}>(-55)
     def test_force_truncate
       additional_path = "#{@column_path}.002"
       FileUtils.touch(additional_path)
+      log_level = "dump"
       result = grndb("recover",
                      "--force-truncate",
-                     "--log-level", "info")
+                     "--log-level", log_level)
       message = <<-MESSAGE
 [Users.age] Truncated broken object: <#{@column_path}>
 [Users.age] Removed broken object related file: <#{additional_path}>
@@ -263,16 +265,22 @@ object corrupt: <#{recover_error_message}>(-55)
       assert_equal([
                      "",
                      message,
-                     expected_groonga_log("info", <<-MESSAGES),
+                     expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
+#{open_file_log_line(@table_path, log_level)}
+#{open_file_log_line(@column_path, log_level)}
+#{close_file_log_line(@column_path, log_level)}
+#{close_file_log_line(@table_path, log_level)}
+#{open_file_log_line(@column_path, log_level)}
+#{close_file_log_line(@column_path, log_level)}
 |i| [io][remove] removed path: <#{@column_path}>
-#{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
+#{create_file_log_line(@column_path, log_level)}
 #{prepend_tag("|i| ", message).chomp}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
+#{close_file_log_line(@column_path, log_level)}
+#{open_file_log_line(@table_path, log_level)}
+#{close_file_log_line(@table_path, log_level)}
+#{open_file_log_line(@column_path, log_level)}
+#{close_file_log_line(@column_path, log_level)}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -301,6 +309,17 @@ object corrupt: <#{recover_error_message}>(-55)
       groonga("truncate", "Ages")
       groonga("lock_acquire", "Ages.users_age")
 
+      _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][1]
+      @ages_path = path
+      _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][2]
+      @users_path = path
+      ages_column_list = JSON.parse(groonga("column_list", "Ages").output)
+      _id, _name, path, *_ = ages_column_list[1][2]
+      @ages_users_age_path = path
+      users_column_list = JSON.parse(groonga("column_list", "Users").output)
+      _id, _name, path, *_ = users_column_list[1][2]
+      @users_age_path = path
+
       remove_groonga_log
     end
 
@@ -309,7 +328,7 @@ object corrupt: <#{recover_error_message}>(-55)
       assert_equal([
                      "",
                      "",
-                     expected_groonga_log("notice", ""),
+                     expected_groonga_log("notice", "")
                    ],
                    [
                      result.output,
@@ -323,11 +342,58 @@ object corrupt: <#{recover_error_message}>(-55)
     end
 
     def test_force_truncate
-      result = grndb("recover", "--force-truncate")
+      log_level = "dump"
+      result = grndb("recover",
+                     "--force-truncate",
+                     "--log-level", log_level)
       assert_equal([
                      "",
                      "",
-                     expected_groonga_log("notice", ""),
+                     expected_groonga_log(log_level, <<-MESSAGES),
+|i| Recovering database: <#{@database_path}>
+#{open_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@ages_users_age_path, log_level)}
+#{open_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_users_age_path, log_level)}
+#{close_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@ages_users_age_path, log_level)}
+#{open_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_users_age_path, log_level)}
+#{close_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@users_path, log_level)}
+#{open_file_log_line(@users_age_path, log_level)}
+#{close_file_log_line(@users_age_path, log_level)}
+#{close_file_log_line(@users_path, log_level)}
+#{open_file_log_line(@users_age_path, log_level)}
+#{close_file_log_line(@users_age_path, log_level)}
+#{open_file_log_line(@users_path, log_level)}
+#{close_file_log_line(@users_path, log_level)}
+#{open_file_log_line(@users_age_path, log_level)}
+#{close_file_log_line(@users_age_path, log_level)}
+#{open_file_log_line(@ages_path, log_level)}
+#{close_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@ages_path, log_level)}
+#{open_file_log_line(@ages_users_age_path, log_level)}
+#{open_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_users_age_path, log_level)}
+#{close_file_log_line("#{@ages_users_age_path}.c", log_level)}
+|i| [io][remove] removed path: <#{@ages_users_age_path}>
+|i| [io][remove] removed path: <#{@ages_users_age_path}.c>
+#{create_file_log_line(@ages_users_age_path, log_level)}
+#{create_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{open_file_log_line(@users_age_path, log_level)}
+#{open_file_log_line(@users_path, log_level)}
+|i| [ii][builder][fin] removed path: <#{@ages_users_age_path}XXXXXX>
+#{close_file_log_line(@users_path, log_level)}
+#{close_file_log_line(@users_age_path, log_level)}
+#{close_file_log_line(@ages_users_age_path, log_level)}
+#{close_file_log_line("#{@ages_users_age_path}.c", log_level)}
+#{close_file_log_line(@ages_path, log_level)}
+|i| Recovered database: <#{@database_path}>
+                     MESSAGES
                    ],
                    [
                      result.output,
@@ -345,11 +411,14 @@ object corrupt: <#{recover_error_message}>(-55)
     groonga("lock_acquire")
 
     remove_groonga_log
-    result = grndb("recover", "--force-lock-clear", "--log-level", "info")
+    log_level = "info"
+    result = grndb("recover",
+                   "--force-lock-clear",
+                   "--log-level", log_level)
     assert_equal([
                    "",
                    "",
-                   expected_groonga_log("info", <<-MESSAGES),
+                   expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
 |i| Clear locked database: <#{@database_path}>
 |i| Recovered database: <#{@database_path}>
@@ -368,20 +437,21 @@ object corrupt: <#{recover_error_message}>(-55)
     _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][1]
 
     remove_groonga_log
-    result = grndb("recover", "--force-lock-clear", "--log-level", "dump")
+    log_level = "dump"
+    result = grndb("recover",
+                   "--force-lock-clear",
+                   "--log-level", log_level)
     assert_equal([
                    "",
                    "",
-                   expected_groonga_log("dump", <<-MESSAGES),
+                   expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "" : "|-| [io][open] <#{path}>"}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{open_file_log_line(path, log_level)}
 |i| [Users] Clear locked object: <#{path}>
-#{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}
-#{windows? ? "" : "|-| [io][open] <#{path}>"}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{close_file_log_line(path, log_level)}
+#{open_file_log_line(path, log_level)}
+#{close_file_log_line(path, log_level)}
 |i| Recovered database: <#{@database_path}>
-#{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}
                    MESSAGES
                  ],
                  [
@@ -399,17 +469,24 @@ object corrupt: <#{recover_error_message}>(-55)
     _id, _name, path, *_ = JSON.parse(groonga("column_list Users").output)[1][2]
 
     remove_groonga_log
-    result = grndb("recover", "--force-lock-clear", "--log-level", "info")
+    log_level = "dump"
+    result = grndb("recover",
+                   "--force-lock-clear",
+                   "--log-level", log_level)
     assert_equal([
                    "",
                    "",
-                   expected_groonga_log("info", <<-MESSAGES),
+                   expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{open_file_log_line(table_path, log_level)}
+#{close_file_log_line(table_path, log_level)}
+#{open_file_log_line(path, log_level)}
 |i| [Users.age] Clear locked object: <#{path}>
-#{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{close_file_log_line(path, log_level)}
+#{open_file_log_line(table_path, log_level)}
+#{close_file_log_line(table_path, log_level)}
+#{open_file_log_line(path, log_level)}
+#{close_file_log_line(path, log_level)}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -426,7 +503,16 @@ object corrupt: <#{recover_error_message}>(-55)
 
     groonga("table_create", "Ages", "TABLE_PAT_KEY", "UInt8")
     groonga("column_create", "Ages", "users_age", "COLUMN_INDEX", "Users", "age")
+
+    _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][1]
+    ages_path = path
+    _id, _name, path, *_ = JSON.parse(groonga("table_list").output)[1][2]
+    users_path = path
+
     _id, _name, path, *_ = JSON.parse(groonga("column_list Ages").output)[1][2]
+    ages_users_age_path = path
+    _id, _name, path, *_ = JSON.parse(groonga("column_list Users").output)[1][2]
+    users_age_path = path
 
     groonga("load",
             "--table", "Users",
@@ -439,28 +525,50 @@ object corrupt: <#{recover_error_message}>(-55)
     assert_equal([0], n_hits)
 
     remove_groonga_log
-    result = grndb("recover", "--force-lock-clear", "--log-level", "info")
+    log_level = "dump"
+    result = grndb("recover",
+                   "--force-lock-clear",
+                   "--log-level", log_level)
     assert_equal([
                    "",
                    "",
-                   expected_groonga_log("info", <<-MESSAGES),
+                   expected_groonga_log(log_level, <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
-|i| [io][remove] removed path: <#{path}>
-|i| [io][remove] removed path: <#{path}.c>
-#{windows? ? "|i| [io][open] create new file: <#{path}>" : ""}
-#{windows? ? "|i| [io][open] create new file: <#{path}.c>" : ""}
-|i| [ii][builder][fin] removed path: <#{path}XXXXXX>
+#{open_file_log_line(ages_path, log_level)}
+#{close_file_log_line(ages_path, log_level)}
+#{open_file_log_line(ages_path, log_level)}
+#{open_file_log_line(ages_users_age_path, log_level)}
+#{open_file_log_line("#{ages_users_age_path}.c", log_level)}
+#{close_file_log_line(ages_users_age_path, log_level)}
+#{close_file_log_line("#{ages_users_age_path}.c", log_level)}
+#{close_file_log_line(ages_path, log_level)}
+#{open_file_log_line(users_path, log_level)}
+#{close_file_log_line(users_path, log_level)}
+#{open_file_log_line(users_age_path, log_level)}
+#{close_file_log_line(users_age_path, log_level)}
+#{open_file_log_line(users_path, log_level)}
+#{close_file_log_line(users_path, log_level)}
+#{open_file_log_line(users_age_path, log_level)}
+#{close_file_log_line(users_age_path, log_level)}
+#{open_file_log_line(ages_path, log_level)}
+#{close_file_log_line(ages_path, log_level)}
+#{open_file_log_line(ages_path, log_level)}
+#{open_file_log_line(ages_users_age_path, log_level)}
+#{open_file_log_line("#{ages_users_age_path}.c", log_level)}
+#{close_file_log_line(ages_users_age_path, log_level)}
+#{close_file_log_line("#{ages_users_age_path}.c", log_level)}
+|i| [io][remove] removed path: <#{ages_users_age_path}>
+|i| [io][remove] removed path: <#{ages_users_age_path}.c>
+#{create_file_log_line(ages_users_age_path, log_level)}
+#{create_file_log_line("#{ages_users_age_path}.c", log_level)}
+#{open_file_log_line(users_age_path, log_level)}
+#{open_file_log_line(users_path, log_level)}
+|i| [ii][builder][fin] removed path: <#{ages_users_age_path}XXXXXX>
+#{close_file_log_line(users_path, log_level)}
+#{close_file_log_line(users_age_path, log_level)}
+#{close_file_log_line(ages_users_age_path, log_level)}
+#{close_file_log_line("#{ages_users_age_path}.c", log_level)}
+#{close_file_log_line(ages_path, log_level)}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -193,7 +193,6 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| [io][remove] removed path: <#{@table_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -267,8 +266,6 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| [io][remove] removed path: <#{@column_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
-#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -372,7 +369,6 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| Recovering database: <#{@database_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -400,7 +396,6 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users.age] Clear locked object: <#{path}>
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -439,8 +434,6 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
-#{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
 |i| [io][remove] removed path: <#{path}>

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -193,6 +193,7 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| [io][remove] removed path: <#{@table_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -266,6 +267,8 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| [io][remove] removed path: <#{@column_path}>
 #{windows? ? "|i| [io][open] create new file: <#{@column_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
+#{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{@column_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                      MESSAGES
                    ],
@@ -369,6 +372,7 @@ object corrupt: <#{recover_error_message}>(-55)
 |i| Recovering database: <#{@database_path}>
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -396,6 +400,7 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{table_path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users.age] Clear locked object: <#{path}>
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
                    MESSAGES
                  ],
@@ -434,6 +439,8 @@ object corrupt: <#{recover_error_message}>(-55)
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000100>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000101>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{@database_path}.0000102>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
+#{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 #{windows? ? "|i| [io][open] open existing file: <#{path}.c>" : ""}
 |i| [io][remove] removed path: <#{path}>

--- a/test/command_line/suite/grndb/test_recover.rb
+++ b/test/command_line/suite/grndb/test_recover.rb
@@ -189,18 +189,18 @@ object corrupt: <#{recover_error_message}>(-55)
                      message,
                      expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-|-| [io][open] <#{@table_path}>
-|-| [io][close] <#{@table_path}>
+#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
+#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| [io][remove] removed path: <#{@table_path}>
-|-| [io][open] <#{@table_path}>
+#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
 #{windows? ? "|i| [io][open] create new file: <#{@table_path}>" : ""}
 #{prepend_tag("|i| ", message).chomp}
-|-| [io][close] <#{@table_path}>
-|-| [io][open] <#{@table_path}>
+#{windows? ? "|d| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
+#{windows? ? "|d| [io][open] <#{@table_path}>" : "|-| [io][open] <#{@table_path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{@table_path}>" : ""}
 |i| Recovered database: <#{@database_path}>
-|-| [io][close] <#{@table_path}>
+#{windows? ? "|-| [io][close] <#{@table_path}>" : "|-| [io][close] <#{@table_path}>"}
                      MESSAGES
                    ],
                    [
@@ -377,14 +377,14 @@ object corrupt: <#{recover_error_message}>(-55)
                    "",
                    expected_groonga_log("dump", <<-MESSAGES),
 |i| Recovering database: <#{@database_path}>
-|-| [io][open] <#{path}>
+#{windows? ? "|d| [io][open] <#{path}>" : "|-| [io][open] <#{path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| [Users] Clear locked object: <#{path}>
-|-| [io][close] <#{path}>
-|-| [io][open] <#{path}>
+#{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}
+#{windows? ? "|d| [io][open] <#{path}>" : "|-| [io][open] <#{path}>"}
 #{windows? ? "|i| [io][open] open existing file: <#{path}>" : ""}
 |i| Recovered database: <#{@database_path}>
-|-| [io][close] <#{path}>
+#{windows? ? "|d| [io][close] <#{path}>" : "|-| [io][close] <#{path}>"}
                    MESSAGES
                  ],
                  [


### PR DESCRIPTION
We can reduce memory usage by this.
This may decrease performance but it will be acceptable.

Note that "grndb check" doesn't close used objects immediately yet.