### PR TITLE
increment/decrement: add support for nested

### DIFF
--- a/test/command/suite/select/query/adjust/decrease/nested.expected
+++ b/test/command/suite/select/query/adjust/decrease/nested.expected
@@ -1,0 +1,48 @@
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos content
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"content": "Groonga is a full text search engine."},
+{"content": "Rroonga is the Ruby bindings of Groonga."},
+{"content": "Mroonga is a MySQL storage engine based of Groonga."}
+]
+[[0,0.0,0.0],3]
+select Memos   --match_columns content   --query 'Groonga <2(<3Ruby OR <4MySQL)'   --output_columns 'content, _score'   --sort_keys -_score,_id
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "content",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Rroonga is the Ruby bindings of Groonga.",
+        -3
+      ],
+      [
+        "Mroonga is a MySQL storage engine based of Groonga.",
+        -4
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/query/adjust/decrease/nested.test
+++ b/test/command/suite/select/query/adjust/decrease/nested.test
@@ -1,0 +1,21 @@
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos content
+
+load --table Memos
+[
+{"content": "Groonga is a full text search engine."},
+{"content": "Rroonga is the Ruby bindings of Groonga."},
+{"content": "Mroonga is a MySQL storage engine based of Groonga."}
+]
+
+select Memos \
+  --match_columns content \
+  --query 'Groonga <2(<3Ruby OR <4MySQL)' \
+  --output_columns 'content, _score' \
+  --sort_keys -_score,_id
+

--- a/test/command/suite/select/query/adjust/increase/nested.expected
+++ b/test/command/suite/select/query/adjust/increase/nested.expected
@@ -1,0 +1,48 @@
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos content
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"content": "Groonga is a full text search engine."},
+{"content": "Rroonga is the Ruby bindings of Groonga."},
+{"content": "Mroonga is a MySQL storage engine based of Groonga."}
+]
+[[0,0.0,0.0],3]
+select Memos   --match_columns content   --query 'Groonga >2(>3Ruby OR >4MySQL)'   --output_columns 'content, _score'   --sort_keys -_score,_id
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "content",
+          "ShortText"
+        ],
+        [
+          "_score",
+          "Int32"
+        ]
+      ],
+      [
+        "Mroonga is a MySQL storage engine based of Groonga.",
+        8
+      ],
+      [
+        "Rroonga is the Ruby bindings of Groonga.",
+        7
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/query/adjust/increase/nested.test
+++ b/test/command/suite/select/query/adjust/increase/nested.test
@@ -1,0 +1,21 @@
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer NormalizerAuto
+column_create Terms index COLUMN_INDEX|WITH_POSITION Memos content
+
+load --table Memos
+[
+{"content": "Groonga is a full text search engine."},
+{"content": "Rroonga is the Ruby bindings of Groonga."},
+{"content": "Mroonga is a MySQL storage engine based of Groonga."}
+]
+
+select Memos \
+  --match_columns content \
+  --query 'Groonga >2(>3Ruby OR >4MySQL)' \
+  --output_columns 'content, _score' \
+  --sort_keys -_score,_id
+


### PR DESCRIPTION
Parent weights are added to the specified weight.

Negative is also supported but there is no meaningful syntax for
it. For example "~2(~3XXX)" is invalid. "~" requires one or more
preceding words. So nested negative is meaningless.