### PR TITLE
grn_ctx_at: don't unlock when reference count mode and succeeded case

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -11152,8 +11152,7 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
           vp->done = 1;
           GRN_FUTEX_WAKE(&vp->ptr);
         } else {
-          bool success = grn_db_value_wait(ctx, id, vp);
-          if (!success) {
+          if (!grn_db_value_wait(ctx, id, vp)) {
             const char *name;
             uint32_t name_size = 0;
             name = _grn_table_key(ctx, (grn_obj *)s, id, &name_size);
@@ -11164,17 +11163,11 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
                 "<%u>(<%.*s>)",
                 id,
                 name_size, name);
-          }
-          if (grn_enable_reference_count) {
-            if (!success) {
-              grn_db_value_unlock(ctx, id, vp);
-              goto exit;
-            }
-          } else {
             grn_db_value_unlock(ctx, id, vp);
-            if (!success) {
-              goto exit;
-            }
+            goto exit;
+          }
+          if (!grn_enable_reference_count) {
+            grn_db_value_unlock(ctx, id, vp);
           }
         }
         if (vp->ptr) {

--- a/lib/db.c
+++ b/lib/db.c
@@ -1,6 +1,7 @@
 /*
   Copyright(C) 2009-2018  Brazil
   Copyright(C) 2018-2021  Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2021       Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -11164,9 +11165,16 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
                 id,
                 name_size, name);
           }
-          grn_db_value_unlock(ctx, id, vp);
-          if (!success) {
-            goto exit;
+          if (grn_enable_reference_count) {
+            if (!success) {
+              grn_db_value_unlock(ctx, id, vp);
+              goto exit;
+            }
+          } else {
+            grn_db_value_unlock(ctx, id, vp);
+            if (!success) {
+              goto exit;
+            }
           }
         }
         if (vp->ptr) {


### PR DESCRIPTION
Because if reference count mode and succeeded case, vp->lock unlock
when grn_obj_unlink().