### PR TITLE
ci: add missing trigger patterns

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+      - 'maintenance/**'
+    tags:
+      - '*'
   pull_request:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+      - 'maintenance/**'
+    tags:
+      - '*'
   pull_request:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+      - 'maintenance/**'
+    tags:
+      - '*'
   pull_request:
   schedule:
     - cron: |

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+      - 'maintenance/**'
+    tags:
+      - '*'
   pull_request:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+      - 'maintenance/**'
+    tags:
+      - '*'
   pull_request:
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
Because CI doesn't execute even if we push tags or maintenance branch currently.