### PR TITLE
arrow: use dictionary array for reference text column

### DIFF
--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -240,7 +240,7 @@ namespace grnarrow {
     // - Dictionary data in DictionaryBuilder are held in memory until
     //   ResetFull() is executed.
     // - Some Apache Arrow implementations (clients) have a 2GB limitation on
-    //   the value size of array.
+    //   the value size of array: C#.
   public:
     ArrayBuilderResetFullVisitor(grn_ctx *ctx,
                                  arrow::ArrayBuilder *builder)

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -234,12 +234,12 @@ namespace grnarrow {
   }
 
   class ArrayBuilderResetFullVisitor : public arrow::TypeVisitor {
-    // We need execute ResetFull() with an appropriate dictionary length
+    // We need to execute ResetFull() with an appropriate dictionary length
     // in order to avoid memory exhaustion and so on.
     // - Dictionary data in DictionaryBuilder are held in memory until
     //   ResetFull() is executed.
-    // - Some arrow implementations (clients) have a 2GB limitation on
-    //   the value size of ArrowArray. 
+    // - Some Apache Arrow implementations (clients) have a 2GB limitation on
+    //   the value size of array.
   public:
     ArrayBuilderResetFullVisitor(grn_ctx *ctx,
                                  arrow::ArrayBuilder *builder)
@@ -249,7 +249,7 @@ namespace grnarrow {
 
     arrow::Status Visit(const arrow::DictionaryType &type) override
     {
-      const int dictionary_length_threshold = 10000;
+      const int64_t dictionary_length_threshold = 10000;
 
       // The value type of Dictionary is always string for now.
       auto builder = static_cast<arrow::StringDictionaryBuilder *>(builder_);
@@ -2142,8 +2142,8 @@ namespace grnarrow {
               "failed to write flushed record batch");
       }
 
-      int fields_count = record_batch_builder_->num_fields();
-      for(int i = 0; i < fields_count; i++) {
+      auto n_fields = record_batch_builder_->num_fields();
+      for (int i = 0; i < n_fields; ++i) {
         auto builder = record_batch_builder_->GetField(i);
         auto visitor = ArrayBuilderResetFullVisitor(ctx_, builder);
         builder->type()->Accept(&visitor);

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -1883,7 +1883,6 @@ namespace grnarrow {
       auto column_builder =
         record_batch_builder_->GetFieldAs<arrow::StringDictionaryBuilder>(
           current_column_index_++);
-
       auto status = column_builder->Append(value, value_length);
       if (!status.ok()) {
         return;
@@ -2034,7 +2033,6 @@ namespace grnarrow {
       auto column_builder =
         record_batch_builder_->GetFieldAs<arrow::StringDictionaryBuilder>(
           current_column_index_++);
-
       auto table = object_cache_[record->header.domain];
       char key[GRN_TABLE_MAX_KEY_SIZE];
       auto key_size = grn_table_get_key(ctx_,
@@ -2076,7 +2074,6 @@ namespace grnarrow {
         if (grn_obj_is_table_with_key(ctx_, domain)) {
           auto value_builder =
             static_cast<arrow::StringDictionaryBuilder *>(raw_value_builder);
-
           for (size_t i = 0; i < n; ++i) {
             auto record_id =
               *reinterpret_cast<grn_id *>(raw_elements + (element_size * i));

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -1880,15 +1880,10 @@ namespace grnarrow {
     }
 
     void add_column_string(const char *value, size_t value_length) {
-#if ARROW_VERSION_MAJOR >= 3
       auto column_builder =
         record_batch_builder_->GetFieldAs<arrow::StringDictionaryBuilder>(
           current_column_index_++);
-#else
-      auto column_builder =
-        record_batch_builder_->GetFieldAs<arrow::StringBuilder>(
-          current_column_index_++);
-#endif
+
       auto status = column_builder->Append(value, value_length);
       if (!status.ok()) {
         return;
@@ -2036,15 +2031,10 @@ namespace grnarrow {
     }
 
     void add_column_record(grn_obj *record) {
-#if ARROW_VERSION_MAJOR >= 3
       auto column_builder =
         record_batch_builder_->GetFieldAs<arrow::StringDictionaryBuilder>(
           current_column_index_++);
-#else
-      auto column_builder =
-        record_batch_builder_->GetFieldAs<arrow::StringBuilder>(
-          current_column_index_++);
-#endif
+
       auto table = object_cache_[record->header.domain];
       char key[GRN_TABLE_MAX_KEY_SIZE];
       auto key_size = grn_table_get_key(ctx_,
@@ -2084,13 +2074,9 @@ namespace grnarrow {
         auto n = GRN_BULK_VSIZE(uvector) / element_size;
         auto raw_value_builder = column_builder->value_builder();
         if (grn_obj_is_table_with_key(ctx_, domain)) {
-#if ARROW_VERSION_MAJOR >= 3
           auto value_builder =
             static_cast<arrow::StringDictionaryBuilder *>(raw_value_builder);
-#else
-          auto value_builder =
-            static_cast<arrow::StringBuilder *>(raw_value_builder);
-#endif
+
           for (size_t i = 0; i < n; ++i) {
             auto record_id =
               *reinterpret_cast<grn_id *>(raw_elements + (element_size * i));

--- a/test/command/suite/sharding/logical_range_filter/command_version/3/apache_arrow.expected
+++ b/test/command/suite/sharding/logical_range_filter/command_version/3/apache_arrow.expected
@@ -103,12 +103,12 @@ load --table Logs_20150205
 ]
 [[0,0.0,0.0],1]
 logical_range_filter Logs time   --command_version 3   --output_type apache-arrow
-_key: string
+_key: dictionary<values=string, indices=int32, ordered=0>
 int32: int32
 int32_vector: list<item: int32>
 int64: int64
-reference_short_text: string
-reference_short_text_vector: list<item: string>
+reference_short_text: dictionary<values=string, indices=int32, ordered=0>
+reference_short_text_vector: list<item: dictionary<values=string, indices=int32, ordered=0>>
 time: timestamp[ns]
 uint32: uint32
 	_key	int32	int32_vector	     int64	reference_short_text	reference_short_text_vector	                     time	uint32
@@ -116,32 +116,72 @@ uint32: uint32
   1,
   -2,
   3
-]	4294967296	Hello 2015-02-03    	[
-  "2015-02-03 1",
-  "2015-02-03 2"
-]	2015-02-03T23:59:58+09:00	    29
+]	4294967296	Hello 2015-02-03    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2"
+  ]
+-- indices:
+  [
+    0,
+    1
+  ]	2015-02-03T23:59:58+09:00	    29
 1	2015-02-03 23:59:59	  -29	[
   1,
   -2,
   3
-]	4294967296	Hello again 2015-02-03	[
-  "2015-02-03 3",
-  "2015-02-03 4"
-]	2015-02-03T23:59:59+09:00	  2929
+]	4294967296	Hello again 2015-02-03	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4"
+  ]
+-- indices:
+  [
+    2,
+    3
+  ]	2015-02-03T23:59:59+09:00	  2929
 2	2015-02-04 00:00:00	 -290	[
   10,
   -20,
   30
-]	4294967297	Hello 2015-02-04    	[
-  "2015-02-04 1",
-  "2015-02-04 2",
-  "2015-02-04 3"
-]	2015-02-04T00:00:00+09:00	   290
+]	4294967297	Hello 2015-02-04    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4",
+    "2015-02-04 1",
+    "2015-02-04 2",
+    "2015-02-04 3"
+  ]
+-- indices:
+  [
+    4,
+    5,
+    6
+  ]	2015-02-04T00:00:00+09:00	   290
 3	2015-02-05 00:00:00	-2900	[
   100,
   -200,
   300
-]	4294967298	Hello 2015-02-05    	[]                         	2015-02-05T00:00:00+09:00	  2900
+]	4294967298	Hello 2015-02-05    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4",
+    "2015-02-04 1",
+    "2015-02-04 2",
+    "2015-02-04 3"
+  ]
+-- indices:
+  []	2015-02-05T00:00:00+09:00	  2900
 ========================================
 return_code: int32
 start_time: timestamp[ns]
@@ -162,12 +202,12 @@ GROONGA:data_type: metadata
 #:000000000000000 send(0)
 #<000000000000000 rc=0
 logical_range_filter Logs time   --command_version 3   --output_type apache-arrow
-_key: string
+_key: dictionary<values=string, indices=int32, ordered=0>
 int32: int32
 int32_vector: list<item: int32>
 int64: int64
-reference_short_text: string
-reference_short_text_vector: list<item: string>
+reference_short_text: dictionary<values=string, indices=int32, ordered=0>
+reference_short_text_vector: list<item: dictionary<values=string, indices=int32, ordered=0>>
 time: timestamp[ns]
 uint32: uint32
 	_key	int32	int32_vector	     int64	reference_short_text	reference_short_text_vector	                     time	uint32
@@ -175,32 +215,72 @@ uint32: uint32
   1,
   -2,
   3
-]	4294967296	Hello 2015-02-03    	[
-  "2015-02-03 1",
-  "2015-02-03 2"
-]	2015-02-03T23:59:58+09:00	    29
+]	4294967296	Hello 2015-02-03    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2"
+  ]
+-- indices:
+  [
+    0,
+    1
+  ]	2015-02-03T23:59:58+09:00	    29
 1	2015-02-03 23:59:59	  -29	[
   1,
   -2,
   3
-]	4294967296	Hello again 2015-02-03	[
-  "2015-02-03 3",
-  "2015-02-03 4"
-]	2015-02-03T23:59:59+09:00	  2929
+]	4294967296	Hello again 2015-02-03	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4"
+  ]
+-- indices:
+  [
+    2,
+    3
+  ]	2015-02-03T23:59:59+09:00	  2929
 2	2015-02-04 00:00:00	 -290	[
   10,
   -20,
   30
-]	4294967297	Hello 2015-02-04    	[
-  "2015-02-04 1",
-  "2015-02-04 2",
-  "2015-02-04 3"
-]	2015-02-04T00:00:00+09:00	   290
+]	4294967297	Hello 2015-02-04    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4",
+    "2015-02-04 1",
+    "2015-02-04 2",
+    "2015-02-04 3"
+  ]
+-- indices:
+  [
+    4,
+    5,
+    6
+  ]	2015-02-04T00:00:00+09:00	   290
 3	2015-02-05 00:00:00	-2900	[
   100,
   -200,
   300
-]	4294967298	Hello 2015-02-05    	[]                         	2015-02-05T00:00:00+09:00	  2900
+]	4294967298	Hello 2015-02-05    	
+-- dictionary:
+  [
+    "2015-02-03 1",
+    "2015-02-03 2",
+    "2015-02-03 3",
+    "2015-02-03 4",
+    "2015-02-04 1",
+    "2015-02-04 2",
+    "2015-02-04 3"
+  ]
+-- indices:
+  []	2015-02-05T00:00:00+09:00	  2900
 ========================================
 return_code: int32
 start_time: timestamp[ns]

--- a/test/command/suite/sharding/logical_range_filter/command_version/3/apache_arrow.expected
+++ b/test/command/suite/sharding/logical_range_filter/command_version/3/apache_arrow.expected
@@ -103,7 +103,7 @@ load --table Logs_20150205
 ]
 [[0,0.0,0.0],1]
 logical_range_filter Logs time   --command_version 3   --output_type apache-arrow
-_key: dictionary<values=string, indices=int32, ordered=0>
+_key: string
 int32: int32
 int32_vector: list<item: int32>
 int64: int64
@@ -202,7 +202,7 @@ GROONGA:data_type: metadata
 #:000000000000000 send(0)
 #<000000000000000 rc=0
 logical_range_filter Logs time   --command_version 3   --output_type apache-arrow
-_key: dictionary<values=string, indices=int32, ordered=0>
+_key: string
 int32: int32
 int32_vector: list<item: int32>
 int64: int64


### PR DESCRIPTION
## OverView

Make `StreamWriter` write string type values as string type `DictionaryArray`.

Writing `DictionaryArray` on `FileDumper` is not supported because `arrow::FileWriter` does not support dictionary replacement. For writing `DictionaryArray` on `FileDumper`, we should create a single dictionary array for a filed including the case of using delta dictionaries, but it may cause memory exhaustion or exceeding a `ArrowArray` length limitation and so on when the dictionary is large.  
https://arrow.apache.org/docs/format/Columnar.html#ipc-file-format
https://arrow.apache.org/docs/format/Columnar.html#array-lengths

## Behavior

`StreamWriter` writes string type values as string type `DictionaryArray`.
Other type values are written as before because changing to write these types as `DictionaryArray`  does not improve performance/data size.
In order to avoid memory exhaustion or exceeding a `ArrowArray` length limitation and so on when the dictionary becames large, `DictionaryBuilder::ResetFull()` is executed when the dictionary length exceeds a certain size (10000). This size is not set on a special basis. It is set on the assumption that ten times the record batch length (1000) is sufficient.

## Test

### Test data

I have created a test file like a dump result (`testdata.grn`) from the attached python file.
(I wanted to attach a compressed dump file but it was over the github size limitation...)
[create_test_data.zip](https://github.com/groonga/groonga/files/7147965/create_test_data.zip)

I have compared performance before and after change.

Table records: 1,000,000
`high_cardinality` column values:  Generated based on random values from 0 to 500,000
`high_cardinality_vector` column values:  Generated based on random values from 0 to 500,000
`middle_cardinality` column values:  Generated based on random values from 0 to 50,000
`middle_cardinality_vector` column values:  Generated based on random values from 0 to 50,000
`low_cardinality` column values:  Generated based on random values from 0 to 5,000
`low_cardinality_vector` column values:  Generated based on random values from 0 to 5,000

Each column is a reference column.

### Result

<details>
<summary>Before log</summary>

```
2021-09-11 21:19:11.791000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=high_cardinality&cache=no
2021-09-11 21:19:11.791000|000000FCF11FFCD0|:000000000000000 select(1000000)
2021-09-11 21:19:12.086000|000000FCF11FFCD0|:000000295000000 output(1000000)
2021-09-11 21:19:12.090000|000000FCF11FFCD0|:000000299000000 send(25946284): 25946284/25946284
2021-09-11 21:19:12.090000|000000FCF11FFCD0|<000000299000000 rc=0
2021-09-11 21:19:16.994000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=high_cardinality_vector&cache=no
2021-09-11 21:19:16.995000|000000FCF11FFCD0|:000000001000000 select(1000000)
2021-09-11 21:19:17.791000|000000FCF11FFCD0|:000000797000000 output(1000000)
2021-09-11 21:19:17.807000|000000FCF11FFCD0|:000000813000000 send(81557012): 81557012/81557012
2021-09-11 21:19:17.807000|000000FCF11FFCD0|<000000813000000 rc=0
2021-09-11 21:19:21.472000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality&cache=no
2021-09-11 21:19:21.472000|000000FCF11FFCD0|:000000000000000 select(1000000)
2021-09-11 21:19:21.719000|000000FCF11FFCD0|:000000247000000 output(1000000)
2021-09-11 21:19:21.724000|000000FCF11FFCD0|:000000252000000 send(24945036): 24945036/24945036
2021-09-11 21:19:21.724000|000000FCF11FFCD0|<000000252000000 rc=0
2021-09-11 21:19:26.373000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality_vector&cache=no
2021-09-11 21:19:26.373000|000000FCF11FFCD0|:000000000000000 select(1000000)
2021-09-11 21:19:26.911000|000000FCF11FFCD0|:000000538000000 output(1000000)
2021-09-11 21:19:26.927000|000000FCF11FFCD0|:000000554000000 send(78555436): 78555436/78555436
2021-09-11 21:19:26.927000|000000FCF11FFCD0|<000000554000000 rc=0
2021-09-11 21:19:30.030000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=low_cardinality&cache=no
2021-09-11 21:19:30.030000|000000FCF11FFCD0|:000000000000000 select(1000000)
2021-09-11 21:19:30.218000|000000FCF11FFCD0|:000000188000000 output(1000000)
2021-09-11 21:19:30.223000|000000FCF11FFCD0|:000000193000000 send(23946460): 23946460/23946460
2021-09-11 21:19:30.223000|000000FCF11FFCD0|<000000193000000 rc=0
2021-09-11 21:19:33.923000|000000FCF11FFCD0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=low_cardinality_vector&cache=no
2021-09-11 21:19:33.923000|000000FCF11FFCD0|:000000000000000 select(1000000)
2021-09-11 21:19:34.347000|000000FCF11FFCD0|:000000424000000 output(1000000)
2021-09-11 21:19:34.364000|000000FCF11FFCD0|:000000441000000 send(75557372): 75557372/75557372
2021-09-11 21:19:34.364000|000000FCF11FFCD0|<000000441000000 rc=0
2021-09-11 22:26:00.101000|000000210E2FF6C0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality&sort_keys=middle_cardinality&cache=no
2021-09-11 22:26:00.101000|000000210E2FF6C0|:000000000000000 select(1000000)
2021-09-11 22:26:00.401000|000000210E2FF6C0|:000000300000000 sort(1000000): middle_cardinality
2021-09-11 22:26:00.765000|000000210E2FF6C0|:000000664000000 output(1000000)
2021-09-11 22:26:00.780000|000000210E2FF6C0|:000000679000000 send(24944732): 24944732/24944732
2021-09-11 22:26:00.780000|000000210E2FF6C0|<000000679000000 rc=0
```
</details>

<details>
<summary>After log</summary>

```
2021-09-11 21:12:23.373000|000000ACD22FF6A0|<000007081000000 rc=0
2021-09-11 21:12:27.793000|000000ACD23FFCA0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=high_cardinality&cache=no
2021-09-11 21:12:27.794000|000000ACD23FFCA0|:000000001000000 select(1000000)
2021-09-11 21:12:28.225000|000000ACD23FFCA0|:000000432000000 output(1000000)
2021-09-11 21:12:28.231000|000000ACD23FFCA0|:000000438000000 send(29844604): 29844604/29844604
2021-09-11 21:12:28.231000|000000ACD23FFCA0|<000000438000000 rc=0
2021-09-11 21:12:32.766000|000000ACD20FFD40|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=high_cardinality_vector&cache=no
2021-09-11 21:12:32.767000|000000ACD20FFD40|:000000001000000 select(1000000)
2021-09-11 21:12:33.889000|000000ACD20FFD40|:000001123000000 output(1000000)
2021-09-11 21:12:33.911000|000000ACD20FFD40|:000001145000000 send(92777708): 92777708/92777708
2021-09-11 21:12:33.911000|000000ACD20FFD40|<000001145000000 rc=0
2021-09-11 21:12:37.119000|000000ACD21FF780|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality&cache=no
2021-09-11 21:12:37.120000|000000ACD21FF780|:000000001000000 select(1000000)
2021-09-11 21:12:37.503000|000000ACD21FF780|:000000384000000 output(1000000)
2021-09-11 21:12:37.510000|000000ACD21FF780|:000000391000000 send(26521796): 26521796/26521796
2021-09-11 21:12:37.511000|000000ACD21FF780|<000000392000000 rc=0
2021-09-11 21:12:41.417000|000000ACD22FF6A0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality_vector&cache=no
2021-09-11 21:12:41.417000|000000ACD22FF6A0|:000000000000000 select(1000000)
2021-09-11 21:12:42.404000|000000ACD22FF6A0|:000000987000000 output(1000000)
2021-09-11 21:12:42.428000|000000ACD22FF6A0|:000001011000000 send(82308484): 82308484/82308484
2021-09-11 21:12:42.428000|000000ACD22FF6A0|<000001011000000 rc=0
2021-09-11 21:12:45.408000|000000ACD23FFCA0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=low_cardinality&cache=no
2021-09-11 21:12:45.408000|000000ACD23FFCA0|:000000000000000 select(1000000)
2021-09-11 21:12:45.684000|000000ACD23FFCA0|:000000276000000 output(1000000)
2021-09-11 21:12:45.686000|000000ACD23FFCA0|:000000278000000 send(4267683): 4267683/4267683
2021-09-11 21:12:45.686000|000000ACD23FFCA0|<000000278000000 rc=0
2021-09-11 21:12:49.656000|000000ACD20FFD40|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=low_cardinality_vector&cache=no
2021-09-11 21:12:49.656000|000000ACD20FFD40|:000000000000000 select(1000000)
2021-09-11 21:12:50.263000|000000ACD20FFD40|:000000607000000 output(1000000)
2021-09-11 21:12:50.267000|000000ACD20FFD40|:000000611000000 send(16318244): 16318244/16318244
2021-09-11 21:12:50.267000|000000ACD20FFD40|<000000611000000 rc=0
2021-09-11 22:37:19.654000|000000D5B18FF6C0|>/d/select?table=Logs&command_version=3&output_type=apache-arrow&limit=-1&output_columns=middle_cardinality&sort_keys=middle_cardinality&cache=no
2021-09-11 22:37:19.654000|000000D5B18FF6C0|:000000000000000 select(1000000)
2021-09-11 22:37:19.873000|000000D5B18FF6C0|:000000219000000 sort(1000000): middle_cardinality
2021-09-11 22:37:20.236000|000000D5B18FF6C0|:000000582000000 output(1000000)
2021-09-11 22:37:20.240000|000000D5B18FF6C0|:000000586000000 send(5569875): 5569875/5569875
2021-09-11 22:37:20.240000|000000D5B18FF6C0|<000000586000000 rc=0
```
</details>


**Summary**

|  Output data (output column)  | Before data size(byte) | After data size(byte) | Before elapsed time(sec) | After elapsed time(sec) |
| -------------------------- | ---------------------- | --------------------- | ------------------------ | ----------------------- |
| high_cardinality           | 25,946,284             | 29,844,604            | 0.3                      | 0.44                    |
| high_cardinality_vector    | 81,557,012             | 92,777,708            | 0.81                     | 1.15                    |
| middle_cardinality         | 24,945,036             | 26,521,796            | 0.25                     | 0.392                   |
| middle_cardinality(sorted) | 24,944,732             | 5,569,875             | 0.68                     | 0.586                   |
| middle_cardinality_vector  | 78,555,436             | 82,308,484            | 0.55                     | 1.011                   |
| low_cardinality            | 23,946,460             | 4,267,683             | 0.19                     | 0.278                   |
| low_cardinality_vector     | 75,557,372             | 16,318,244            | 0.44                     | 0.611                   |

Note: The error may be large because they are executed only once.

The higher the cardinality become, the bigger the data size become than before. 
This is expected behavior.
`DictionaryArray` just increases data size for indices if there is no duplicate data.

When the output data is sorted or the cardinality is low, the data size is smaller than before.
This is also expected behavior.

In these test cases, the elapsed time is always worsen because additional computing is required.
For cases `middle_cardinality(sorted)`, `low_cardinality` and `low_cardinality_vector`, it may be shorter than before when IO is a bottleneck because the data size is smaller than before.

## Others

I would like you to merge this PR after a new version of apache arrow with the following PR is merged is released.

https://github.com/apache/arrow/pull/10990

## Consideration

* It might be better to create a new argument for the `select` command and so on or a new environment variable to specify the output type of arrow array (`DictionaryArray` or `StringArray`).
  * This is discussed at #1181, but looking at the test result, I think it is better to reconsider this.
* It might be better to create a new environment variable to `specity dictionary_length_threshold`
* There might be some other faster way to send delta dictionaries