### PR TITLE
Update required apache arrow version to 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,7 +879,7 @@ endif()
 
 option(GRN_WITH_APACHE_ARROW "use Apache Arrow" OFF)
 if(GRN_WITH_APACHE_ARROW)
-  find_package(Arrow "1.0.0" REQUIRED)
+  find_package(Arrow "3.0.0" REQUIRED)
 endif()
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -946,7 +946,7 @@ AC_ARG_ENABLE(apache-arrow,
 if test "x$enable_apache_arrow" != "xno"; then
   m4_ifdef([PKG_CHECK_MODULES], [
     PKG_CHECK_MODULES([APACHE_ARROW],
-                      [arrow >= 0.17.0],
+                      [arrow >= 3.0.0],
                       [GRN_WITH_APACHE_ARROW=yes],
                       [GRN_WITH_APACHE_ARROW=no])
   ],

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -1168,12 +1168,8 @@ namespace grnarrow {
       };
 
       auto schema = std::make_shared<arrow::Schema>(fields);
-
-#if ARROW_VERSION_MAJOR >= 2
       auto writer_result = arrow::ipc::MakeFileWriter(output, schema);
-#else
-      auto writer_result = arrow::ipc::NewFileWriter(output, schema);
-#endif
+
       if (!check(ctx_,
                  writer_result,
                  "[arrow][dump] failed to create file format writer")) {
@@ -1808,11 +1804,8 @@ namespace grnarrow {
       schema_builder_.Reset();
       schema_ = *schema;
 
-#if ARROW_VERSION_MAJOR >= 2
       auto writer = arrow::ipc::MakeStreamWriter(&output_, schema_);
-#else
-      auto writer = arrow::ipc::NewStreamWriter(&output_, schema_);
-#endif
+
       if (!check(ctx_,
                  writer,
                  "[arrow][stream-writer][write-schema] "

--- a/lib/token_column.cpp
+++ b/lib/token_column.cpp
@@ -153,11 +153,8 @@ namespace grn {
         };
 
         std::vector<grn_id> ids;
-# if ARROW_VERSION_MAJOR >= 3
         std::vector<::arrow::Future<>> futures;
-# else
-        std::vector<::arrow::Future<::arrow::Status>> futures;
-# endif
+
         GRN_TABLE_EACH_BEGIN_FLAGS(ctx_, table_, cursor, id, GRN_CURSOR_BY_ID) {
           ids.push_back(id);
           if (ids.size() == chunk_size) {

--- a/lib/window_function_executor.cpp
+++ b/lib/window_function_executor.cpp
@@ -369,6 +369,7 @@ grn_window_function_executor_is_ascending(grn_ctx *ctx,
   return true;
 }
 
+#ifdef GRN_WITH_APACHE_ARROW
 namespace {
   struct GrnSortKeys {
     grn_table_sort_key *keys_;
@@ -732,6 +733,7 @@ namespace {
     std::vector<::arrow::compute::SortKey> arrow_sort_keys_;
   };
 }
+#endif
 
 static void
 grn_window_function_executor_execute_all_tables(
@@ -739,8 +741,10 @@ grn_window_function_executor_execute_all_tables(
   grn_window_function_executor *executor,
   const char *tag)
 {
+#ifdef GRN_WITH_APACHE_ARROW
   AllTablesExecutor all_tables_executor(ctx, executor, tag);
   all_tables_executor.execute();
+#endif
 }
 
 static void
@@ -1115,7 +1119,7 @@ grn_window_function_executor_execute(grn_ctx *ctx,
   }
 
   bool process_all_tables_at_once = false;
-#if defined(GRN_WITH_APACHE_ARROW)
+#ifdef GRN_WITH_APACHE_ARROW
   process_all_tables_at_once =
     grn_window_function_executor_all_tables_at_once_enable &&
     (n_tables > 1);

--- a/lib/window_function_executor.cpp
+++ b/lib/window_function_executor.cpp
@@ -369,7 +369,6 @@ grn_window_function_executor_is_ascending(grn_ctx *ctx,
   return true;
 }
 
-#if ARROW_VERSION_MAJOR >= 3
 namespace {
   struct GrnSortKeys {
     grn_table_sort_key *keys_;
@@ -733,7 +732,6 @@ namespace {
     std::vector<::arrow::compute::SortKey> arrow_sort_keys_;
   };
 }
-#endif
 
 static void
 grn_window_function_executor_execute_all_tables(
@@ -741,10 +739,8 @@ grn_window_function_executor_execute_all_tables(
   grn_window_function_executor *executor,
   const char *tag)
 {
-#if ARROW_VERSION_MAJOR >= 3
   AllTablesExecutor all_tables_executor(ctx, executor, tag);
   all_tables_executor.execute();
-#endif
 }
 
 static void
@@ -1119,7 +1115,7 @@ grn_window_function_executor_execute(grn_ctx *ctx,
   }
 
   bool process_all_tables_at_once = false;
-#if defined(GRN_WITH_APACHE_ARROW) && ARROW_VERSION_MAJOR >= 3
+#if defined(GRN_WITH_APACHE_ARROW)
   process_all_tables_at_once =
     grn_window_function_executor_all_tables_at_once_enable &&
     (n_tables > 1);


### PR DESCRIPTION
Update required apache arrow version to 3.0.0 in order to avoid complicating the source code.
Checking arrow version and branching by it are not so complicated for now, but they can be very complicated in the future.