### PR TITLE
snip: add support for regular expression to find delimiter

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -954,6 +954,15 @@ GRN_API grn_rc grn_snip_add_cond(grn_ctx *ctx, grn_obj *snip,
 GRN_API grn_rc grn_snip_set_normalizer(grn_ctx *ctx, grn_obj *snip,
                                        grn_obj *normalizer);
 GRN_API grn_obj *grn_snip_get_normalizer(grn_ctx *ctx, grn_obj *snip);
+GRN_API grn_rc
+grn_snip_set_delimiter_regexp(grn_ctx *ctx,
+                              grn_obj *snip,
+                              const char *pattern,
+                              int pattern_length);
+GRN_API const char *
+grn_snip_get_delimiter_regexp(grn_ctx *ctx,
+                              grn_obj *snip,
+                              size_t *pattern_length);
 GRN_API grn_rc grn_snip_exec(grn_ctx *ctx, grn_obj *snip,
                              const char *string, unsigned int string_len,
                              unsigned int *nresults, unsigned int *max_tagged_len);

--- a/lib/grn_snip.h
+++ b/lib/grn_snip.h
@@ -1,5 +1,6 @@
 /*
-  Copyright(C) 2009-2016 Brazil
+  Copyright(C) 2009-2016  Brazil
+  Copyright(C) 2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -20,6 +21,7 @@
 #include "grn.h"
 #include "grn_str.h"
 #include "grn_db.h"
+#include "grn_onigmo.h"
 
 #define ASIZE                   256U
 #define MAX_SNIP_TAG_COUNT      512U
@@ -110,6 +112,12 @@ typedef struct _grn_snip
   size_t max_tagged_len;
 
   grn_obj *normalizer;
+
+  char *delimiter_pattern;
+  size_t delimiter_pattern_length;
+#ifdef GRN_SUPPORT_REGEXP
+  OnigRegex delimiter_regex;
+#endif
 } grn_snip;
 
 grn_rc grn_snip_close(grn_ctx *ctx, grn_snip *snip);

--- a/lib/proc/proc_snippet.c
+++ b/lib/proc/proc_snippet.c
@@ -1,6 +1,6 @@
 /*
   Copyright(C) 2009-2016  Brazil
-  Copyright(C) 2019-2020  Sutou Kouhei <kou@clear-code.com>
+  Copyright(C) 2019-2021  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -115,6 +115,7 @@ func_snippet(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data)
     grn_obj *default_close_tag = NULL;
     int n_args_without_option = nargs;
     grn_obj *default_return_value = NULL;
+    grn_obj *delimiter_regexp = NULL;
 
     if (end_arg->header.type == GRN_TABLE_HASH_KEY) {
       grn_obj *options = end_arg;
@@ -152,6 +153,9 @@ func_snippet(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data)
                                          "default",
                                          GRN_PROC_OPTION_VALUE_RAW,
                                          &default_return_value,
+                                         "delimiter_regexp",
+                                         GRN_PROC_OPTION_VALUE_RAW,
+                                         &delimiter_regexp,
                                          NULL);
       if (rc != GRN_SUCCESS) {
         goto exit;
@@ -226,6 +230,15 @@ func_snippet(grn_ctx *ctx, int nargs, grn_obj **args, grn_user_data *user_data)
                                  GRN_TEXT_LEN(keyword_args[i]),
                                  NULL, 0,
                                  NULL, 0);
+        }
+      }
+      if (grn_obj_is_text_family_bulk(ctx, delimiter_regexp)) {
+        grn_snip_set_delimiter_regexp(ctx,
+                                      snip,
+                                      GRN_TEXT_VALUE(delimiter_regexp),
+                                      GRN_TEXT_LEN(delimiter_regexp));
+        if (ctx->rc != GRN_SUCCESS) {
+          goto exit;
         }
       }
       snippets = snippet_exec(ctx,

--- a/test/command/suite/select/function/snippet/delimiter_regexp/invalid.expected
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/invalid.expected
@@ -1,0 +1,37 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "aaa. bbb. ccc. AAA. BBB. CCC. xxx. yyy. zzz."}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet(content,   "ccc", "[", "]",   {"delimiter_regexp": "("})'
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[snip][delimiter-regexp][set][regexp][new] failed to create regular expression object: <(>: end pattern with unmatched parenthe"
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet",
+          null
+        ]
+      ],
+      [
+        "[snip][delimiter-regexp][set][regexp][new] failed to create regular expression object: <(>: end pattern with unmatched parenthe"
+      ]
+    ]
+  ]
+]
+#|e| [snip][delimiter-regexp][set][regexp][new] failed to create regular expression object: <(>: end pattern with unmatched parenthesis

--- a/test/command/suite/select/function/snippet/delimiter_regexp/invalid.test
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/invalid.test
@@ -1,0 +1,13 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "aaa. bbb. ccc. AAA. BBB. CCC. xxx. yyy. zzz."}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet(content, \
+  "ccc", "[", "]", \
+  {"delimiter_regexp": "("})'

--- a/test/command/suite/select/function/snippet/delimiter_regexp/multiple.expected
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/multiple.expected
@@ -1,0 +1,11 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "aaa. bbb. ccc. AAA. BBB. CCC. xxx. yyy. zzz."}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet(content,   "ccc", "[", "]",   {"width": 10,    "delimiter_regexp": "\\\\."})'
+[[0,0.0,0.0],[[[1],[["snippet",null]],[[" [ccc]"," [CCC]"]]]]]

--- a/test/command/suite/select/function/snippet/delimiter_regexp/multiple.test
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/multiple.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "aaa. bbb. ccc. AAA. BBB. CCC. xxx. yyy. zzz."}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet(content, \
+  "ccc", "[", "]", \
+  {"width": 10, \
+   "delimiter_regexp": "\\\\."})'

--- a/test/command/suite/select/function/snippet/delimiter_regexp/overlap.expected
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/overlap.expected
@@ -1,0 +1,36 @@
+table_create Entries TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Entries content COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Entries
+[
+{"content": "aaa. bbb ccc AAA. BBB CCC xxx yyy. zzz."}
+]
+[[0,0.0,0.0],1]
+select Entries   --output_columns '   snippet(content,   "ccc", "[", "]",   {"width": 40,    "delimiter_regexp": "\\\\."})'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "snippet",
+          null
+        ]
+      ],
+      [
+        [
+          " bbb [ccc] AAA",
+          " BBB [CCC] xxx yyy"
+        ]
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/function/snippet/delimiter_regexp/overlap.test
+++ b/test/command/suite/select/function/snippet/delimiter_regexp/overlap.test
@@ -1,0 +1,14 @@
+table_create Entries TABLE_NO_KEY
+column_create Entries content COLUMN_SCALAR ShortText
+
+load --table Entries
+[
+{"content": "aaa. bbb ccc AAA. BBB CCC xxx yyy. zzz."}
+]
+
+select Entries \
+  --output_columns ' \
+  snippet(content, \
+  "ccc", "[", "]", \
+  {"width": 40, \
+   "delimiter_regexp": "\\\\."})'


### PR DESCRIPTION
Use case: Use only text in one sentence as snippet by finding "." (for
English) or U+3002 IDEOGRAPHIC FULL STOP (for Japanese).

Note that found delimiters aren't included in snippet. For example,
"." isn't included in snippet with /\./ regular expression. This is
useful for the use case.