### PR TITLE
ci mingw: follow a package name change

### DIFF
--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -43,7 +43,7 @@ jobs:
             binutils
             git
             msys2-devel
-            pactoys-git
+            pactoys
       - name: Prepare
         shell: msys2 {0}
         run: |


### PR DESCRIPTION
Because pactoys-git renamed in upstream at the following commit.
https://github.com/msys2/MSYS2-packages/commit/0235754b07cbf708d28841aa59c0eddbe5ddd7a7#diff-27400a81bc42a425824029a2cf68650fea9de0875c5fb0c7c4b53ccd8665b9d7