### PR TITLE
Fix to not break table when column_create fails (for #1300)

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -927,8 +927,6 @@ grn_column_create_similar_internal(grn_ctx *ctx,
                 "%s base column's source doesn't exist: %u",
                 tag,
                 base_source_column_id);
-            grn_obj_remove(ctx, column);
-            column = NULL;
             break;
           }
           char source_column_name[GRN_TABLE_MAX_KEY_SIZE];
@@ -951,8 +949,6 @@ grn_column_create_similar_internal(grn_ctx *ctx,
                 name,
                 source_column_name_length,
                 source_column_name);
-            grn_obj_remove(ctx, column);
-            column = NULL;
             break;
           }
           GRN_RECORD_PUT(ctx, &source_ids, DB_OBJ(source_column)->id);
@@ -965,7 +961,10 @@ grn_column_create_similar_internal(grn_ctx *ctx,
       }
       GRN_OBJ_FIN(ctx, &base_source_ids);
       if (ctx->rc != GRN_SUCCESS) {
+        grn_rc original_rc = ctx->rc;
+        ctx->rc = GRN_SUCCESS;
         grn_obj_remove(ctx, column);
+        ctx->rc = original_rc;
         return NULL;
       }
     }

--- a/lib/proc/proc_column.c
+++ b/lib/proc/proc_column.c
@@ -277,7 +277,10 @@ command_column_create(grn_ctx *ctx, int nargs, grn_obj **args,
     }
     GRN_OBJ_FIN(ctx, &source_ids);
     if (rc != GRN_SUCCESS) {
+      grn_rc original_rc = ctx->rc;
+      ctx->rc = GRN_SUCCESS;
       grn_obj_remove(ctx, column);
+      ctx->rc = original_rc;
       succeeded = GRN_FALSE;
       goto exit;
     }

--- a/lib/store.c
+++ b/lib/store.c
@@ -2398,8 +2398,6 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
 {
   const char *tag = "[ja][replace]";
   grn_ja_wal_add_entry_data wal_data = {0};
-  grn_rc original_rc = ctx->rc;
-  ctx->rc = GRN_SUCCESS;
   wal_data.ja = ja;
   wal_data.need_lock = false;
   wal_data.tag = tag;
@@ -2418,11 +2416,7 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
   uint32_t lseg = id >> JA_W_EINFO_IN_A_SEGMENT;
   uint32_t pos = id & JA_M_EINFO_IN_A_SEGMENT;
   if (grn_io_lock(ctx, ja->io, grn_lock_timeout) != GRN_SUCCESS) {
-    if(ctx->rc != GRN_SUCCESS) {
-      return ctx->rc;
-    }
-    ctx->rc = original_rc;
-    return GRN_SUCCESS;
+    return ctx->rc;
   }
   wal_data.segment = ja->header->element_segs[lseg];
   if (wal_data.segment == JA_ELEMENT_SEG_VOID) {
@@ -2510,11 +2504,7 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
   grn_ja_free(ctx, ja, &eback);
 exit :
   grn_io_unlock(ctx, ja->io);
-  if(ctx->rc != GRN_SUCCESS) {
-    return ctx->rc;
-  }
-  ctx->rc = original_rc;
-  return GRN_SUCCESS;
+  return ctx->rc;
 }
 
 #define JA_N_GARBAGES_TH 10

--- a/lib/store.c
+++ b/lib/store.c
@@ -2398,6 +2398,8 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
 {
   const char *tag = "[ja][replace]";
   grn_ja_wal_add_entry_data wal_data = {0};
+  grn_rc original_rc = ctx->rc;
+  ctx->rc = GRN_SUCCESS;
   wal_data.ja = ja;
   wal_data.need_lock = false;
   wal_data.tag = tag;
@@ -2416,7 +2418,11 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
   uint32_t lseg = id >> JA_W_EINFO_IN_A_SEGMENT;
   uint32_t pos = id & JA_M_EINFO_IN_A_SEGMENT;
   if (grn_io_lock(ctx, ja->io, grn_lock_timeout) != GRN_SUCCESS) {
-    return ctx->rc;
+    if(ctx->rc != GRN_SUCCESS) {
+      return ctx->rc;
+    }
+    ctx->rc = original_rc;
+    return GRN_SUCCESS;
   }
   wal_data.segment = ja->header->element_segs[lseg];
   if (wal_data.segment == JA_ELEMENT_SEG_VOID) {
@@ -2504,7 +2510,11 @@ grn_ja_replace(grn_ctx *ctx, grn_ja *ja, grn_id id,
   grn_ja_free(ctx, ja, &eback);
 exit :
   grn_io_unlock(ctx, ja->io);
-  return ctx->rc;
+  if(ctx->rc != GRN_SUCCESS) {
+    return ctx->rc;
+  }
+  ctx->rc = original_rc;
+  return GRN_SUCCESS;
 }
 
 #define JA_N_GARBAGES_TH 10

--- a/test/command/suite/column_create/index/source/mismatch/table_key_reference/column_builtin.expected
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_reference/column_builtin.expected
@@ -19,3 +19,12 @@ column_create TagsIndex sites_tags COLUMN_INDEX Sites tags
   false
 ]
 #|e| [column][index][source] index table's key must equal source type: <Tags> -> <ShortText>: index-column:<TagsIndex.sites_tags> source:<Sites.tags>
+dump
+table_create Sites TABLE_HASH_KEY ShortText
+column_create Sites tags COLUMN_VECTOR ShortText
+
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create TagsIndex TABLE_HASH_KEY Tags
+table_remove TagsIndex
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/mismatch/table_key_reference/column_builtin.test
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_reference/column_builtin.test
@@ -5,3 +5,6 @@ column_create Sites tags COLUMN_VECTOR ShortText
 
 table_create TagsIndex TABLE_HASH_KEY Tags
 column_create TagsIndex sites_tags COLUMN_INDEX Sites tags
+
+dump
+table_remove TagsIndex

--- a/test/command/suite/column_create/index/source/mismatch/table_key_reference/table_key_builtin.expected
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_reference/table_key_builtin.expected
@@ -17,3 +17,11 @@ column_create TagsIndex sites_tags COLUMN_INDEX TagPriorities _key
   false
 ]
 #|e| [column][index][source] index table's key must equal source type: <Tags> -> <ShortText>: index-column:<TagsIndex.sites_tags> source:<TagPriorities._key>
+dump
+table_create TagPriorities TABLE_HASH_KEY ShortText
+
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create TagsIndex TABLE_HASH_KEY Tags
+table_remove TagsIndex
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/mismatch/table_key_reference/table_key_builtin.test
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_reference/table_key_builtin.test
@@ -4,3 +4,6 @@ table_create TagPriorities TABLE_HASH_KEY ShortText
 
 table_create TagsIndex TABLE_HASH_KEY Tags
 column_create TagsIndex sites_tags COLUMN_INDEX TagPriorities _key
+
+dump
+table_remove TagsIndex

--- a/test/command/suite/column_create/index/source/mismatch/table_key_type/column_reference.expected
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_type/column_reference.expected
@@ -19,3 +19,13 @@ column_create TagsIndex sites_tags COLUMN_INDEX Sites tags
   false
 ]
 #|e| [column][index][source] index table must equal to source type: <TagsIndex> -> <Tags>: index-column:<TagsIndex.sites_tags> source:<Sites.tags>
+dump
+table_create Sites TABLE_HASH_KEY ShortText
+
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create TagsIndex TABLE_HASH_KEY ShortText
+
+column_create Sites tags COLUMN_VECTOR Tags
+table_remove TagsIndex
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/mismatch/table_key_type/column_reference.test
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_type/column_reference.test
@@ -5,3 +5,6 @@ column_create Sites tags COLUMN_VECTOR Tags
 
 table_create TagsIndex TABLE_HASH_KEY ShortText
 column_create TagsIndex sites_tags COLUMN_INDEX Sites tags
+
+dump
+table_remove TagsIndex

--- a/test/command/suite/column_create/index/source/mismatch/table_key_type/table_key_reference.expected
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_type/table_key_reference.expected
@@ -17,3 +17,11 @@ column_create TagsIndex sites_tags COLUMN_INDEX TagPriorities _key
   false
 ]
 #|e| [column][index][source] index table must equal to source type: <TagsIndex> -> <Tags>: index-column:<TagsIndex.sites_tags> source:<TagPriorities._key>
+dump
+table_create TagPriorities TABLE_HASH_KEY Tags
+
+table_create Tags TABLE_HASH_KEY ShortText
+
+table_create TagsIndex TABLE_HASH_KEY ShortText
+table_remove TagsIndex
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/mismatch/table_key_type/table_key_reference.test
+++ b/test/command/suite/column_create/index/source/mismatch/table_key_type/table_key_reference.test
@@ -4,3 +4,6 @@ table_create TagPriorities TABLE_HASH_KEY Tags
 
 table_create TagsIndex TABLE_HASH_KEY ShortText
 column_create TagsIndex sites_tags COLUMN_INDEX TagPriorities _key
+
+dump
+table_remove TagsIndex

--- a/test/command/suite/column_create/index/source/multi_column/vector_full_text_search.expected
+++ b/test/command/suite/column_create/index/source/multi_column/vector_full_text_search.expected
@@ -21,3 +21,13 @@ column_create Words docs_content   COLUMN_INDEX|WITH_SECTION|WITH_POSITION Docs 
   false
 ]
 #|e| grn_obj_set_info(): GRN_INFO_SOURCE: multi column full text index with vector column isn't supported yet: <Words.docs_content>
+dump
+plugin_register functions/index_column
+
+table_create Docs TABLE_NO_KEY
+column_create Docs sentences COLUMN_VECTOR Text
+column_create Docs title COLUMN_SCALAR ShortText
+
+table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
+table_remove Words
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/multi_column/vector_full_text_search.test
+++ b/test/command/suite/column_create/index/source/multi_column/vector_full_text_search.test
@@ -7,3 +7,6 @@ column_create Docs sentences COLUMN_VECTOR Text
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
 column_create Words docs_content \
   COLUMN_INDEX|WITH_SECTION|WITH_POSITION Docs title,sentences
+
+dump
+table_remove Words

--- a/test/command/suite/column_create/index/source/multi_column/without_section.expected
+++ b/test/command/suite/column_create/index/source/multi_column/without_section.expected
@@ -19,3 +19,11 @@ column_create Terms memos_index COLUMN_INDEX Memos title,content
   false
 ]
 #|e| grn_obj_set_info(): GRN_INFO_SOURCE: multi column index must be created with WITH_SECTION flag: <Terms.memos_index>
+dump
+table_create Memos TABLE_NO_KEY
+column_create Memos content COLUMN_SCALAR Text
+column_create Memos title COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+table_remove Terms
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/multi_column/without_section.test
+++ b/test/command/suite/column_create/index/source/multi_column/without_section.test
@@ -6,3 +6,6 @@ table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
   --normalizer NormalizerAuto
 column_create Terms memos_index COLUMN_INDEX Memos title,content
+
+dump
+table_remove Terms

--- a/test/command/suite/column_create/index/source/nonexistent.expected
+++ b/test/command/suite/column_create/index/source/nonexistent.expected
@@ -12,3 +12,5 @@ table_create Memos TABLE_NO_KEY
 column_create Memos content COLUMN_SCALAR Text
 
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+table_remove Terms
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/nonexistent.test
+++ b/test/command/suite/column_create/index/source/nonexistent.test
@@ -7,3 +7,4 @@ table_create Terms TABLE_PAT_KEY ShortText \
 column_create Terms memos_index COLUMN_INDEX|WITH_POSITION Memos nonexistent
 
 dump
+table_remove Terms

--- a/test/command/suite/column_create/index/source/pseudo_column/_id.expected
+++ b/test/command/suite/column_create/index/source/pseudo_column/_id.expected
@@ -22,3 +22,5 @@ table_create Memos TABLE_NO_KEY
 column_create Memos content COLUMN_SCALAR Text
 
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram --normalizer NormalizerAuto
+table_remove Terms
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/pseudo_column/_id.test
+++ b/test/command/suite/column_create/index/source/pseudo_column/_id.test
@@ -7,3 +7,4 @@ table_create Terms TABLE_PAT_KEY ShortText \
 column_create Terms memos_index COLUMN_INDEX|WITH_POSITION Memos _id
 
 dump
+table_remove Terms

--- a/test/command/suite/column_create/index/source/vector_column/full_text_search_without_section.expected
+++ b/test/command/suite/column_create/index/source/vector_column/full_text_search_without_section.expected
@@ -19,3 +19,12 @@ column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
   false
 ]
 #|e| grn_obj_set_info(): GRN_INFO_SOURCE: full text index for vector column must be created with WITH_SECTION flag: <Words.docs_sentences>
+dump
+plugin_register functions/index_column
+
+table_create Docs TABLE_NO_KEY
+column_create Docs sentences COLUMN_VECTOR Text
+
+table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
+table_remove Words
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/index/source/vector_column/full_text_search_without_section.test
+++ b/test/command/suite/column_create/index/source/vector_column/full_text_search_without_section.test
@@ -5,3 +5,6 @@ column_create Docs sentences COLUMN_VECTOR Text
 
 table_create Words TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
 column_create Words docs_sentences COLUMN_INDEX|WITH_POSITION Docs sentences
+
+dump
+table_remove Words

--- a/test/command/suite/column_create/path/nonexistent/not_windows.expected
+++ b/test/command/suite/column_create/path/nonexistent/not_windows.expected
@@ -13,3 +13,7 @@ column_create Data number COLUMN_SCALAR Int64   --path nonexistent/directory/dat
   false
 ]
 #|e| system call error: No such file or directory: failed to open file info path: <nonexistent/directory/data/number>
+dump
+table_create Data TABLE_NO_KEY
+table_remove Data
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/path/nonexistent/not_windows.test
+++ b/test/command/suite/column_create/path/nonexistent/not_windows.test
@@ -3,3 +3,6 @@
 table_create Data TABLE_NO_KEY
 column_create Data number COLUMN_SCALAR Int64 \
   --path nonexistent/directory/data/number
+
+dump
+table_remove Data

--- a/test/command/suite/column_create/path/nonexistent/windows.expected
+++ b/test/command/suite/column_create/path/nonexistent/windows.expected
@@ -13,3 +13,7 @@ column_create Data number COLUMN_SCALAR Int64   --path nonexistent/directory/dat
   false
 ]
 #|e| system error[3]: The system cannot find the path specified.: CreateFile(<nonexistent/directory/data/number>, <O_RDWR|O_CREAT|O_EXCL>) failed
+dump
+table_create Data TABLE_NO_KEY
+table_remove Data
+[[0,0.0,0.0],true]

--- a/test/command/suite/column_create/path/nonexistent/windows.test
+++ b/test/command/suite/column_create/path/nonexistent/windows.test
@@ -3,3 +3,6 @@
 table_create Data TABLE_NO_KEY
 column_create Data number COLUMN_SCALAR Int64 \
   --path nonexistent/directory/data/number
+
+dump
+table_remove Data


### PR DESCRIPTION
**Details of #1300**

Sample  queries
```
table_create Statuses TABLE_NO_KEY
column_create Statuses start_time COLUMN_SCALAR UInt16
column_create Statuses end_time COLUMN_SCALAR UInt16
 
table_create Times TABLE_PAT_KEY UInt16
column_create Times statuses COLUMN_INDEX Statuses start_time,end_time *1
# [[-22,1639037503.16114,0.003981828689575195,"grn_obj_set_info(): GRN_INFO_SOURCE: multi column index must be created with WITH_SECTION flag: <Times.statuses>",[["grn_obj_set_info_source_validate","../../groonga/lib/db.c",9605],["/tmp/d.grn",6,"column_create Times statuses COLUMN_INDEX Statuses start_time,end_time"]]],false]
table_remove Times *2
# [[-22,1639037503.16515,0.0005414485931396484,"[object][remove] column is broken: <Times.statuses>",[["remove_columns","../../groonga/lib/db.c",10649],["/tmp/d.grn",8,"table_remove Times"]]],false]
```


https://github.com/groonga/groonga/blob/master/lib/proc/proc_column.c#L280

`grn->rc` is `GRN_INVALID_ARGUMENT` at the line above when executing the `column_create` (*1), and the `grn_obj_remove` above reaches the line below.

https://github.com/groonga/groonga/blob/master/lib/db.c#L11309

`_grn_obj_remove_spec` returns a return code of `grn_ja_replace` in this case.
(https://github.com/groonga/groonga/blob/master/lib/store.c#L3204)

If `grn_ja_replace` returns the original `grn->rc` when it succeed, it returns `GRN_INVALID_ARGUMENT` in this case.
It means that `_grn_obj_remove_spec` returns `GRN_INVALID_ARGUMENT` and the `grn_obj_delete_by_id` below is skipped.
As a result, the information that should be deleted is not deleted and the column (table) is broken.
The `table_remove` (*2) fails because of this.

https://github.com/groonga/groonga/blob/master/lib/db.c#L11311

**Modification**

- Fix to temporarily reset `ctx->rc` in callers of `grn_obj_remove` in `column_create` and `column_create_similar`.
  - #1300 mentions only to `column_create` but  `column_create_similar` has same problem.
- Add schema and removability checks for invalid cases of `column_create` tests.
  - I felt verbose a little to add to the all cases, but I did so for consistency.

Tests for `column_create_similar` have not be changed because it is difficult to reproduce the problem from command line ( I mean `.test` file ).
I have tested the modification of `column_create_similar` by forcibly changing parameters with debugger.