### PR TITLE
Add a missing error check for grn_ii_posting_add_float()

### DIFF
--- a/lib/accessor.c
+++ b/lib/accessor.c
@@ -500,10 +500,13 @@ grn_accessor_resolve(grn_ctx *ctx, grn_obj *accessor, int depth,
       posting.sid = 1;
       posting.pos = 0;
       posting.weight_float = recinfo->score;
-      grn_ii_posting_add_float(ctx,
-                               (grn_posting *)(&posting),
-                               (grn_hash *)res,
-                               op);
+      rc = grn_ii_posting_add_float(ctx,
+                                    (grn_posting *)(&posting),
+                                    (grn_hash *)res,
+                                    op);
+      if (rc != GRN_SUCCESS) {
+        break;
+      }
     } GRN_HASH_EACH_END(ctx, cursor);
     grn_obj_unlink(ctx, current_res);
     grn_ii_resolve_sel_and(ctx, (grn_hash *)res, op);
@@ -514,6 +517,10 @@ grn_accessor_resolve(grn_ctx *ctx, grn_obj *accessor, int depth,
   }
 
   GRN_OBJ_FIN(ctx, &accessor_stack);
+
+  if (rc == GRN_SUCCESS && ctx->rc != GRN_SUCCESS) {
+    rc = ctx->rc;
+  }
   return rc;
 }
 

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -3126,6 +3126,7 @@ grn_io_hash_add(grn_ctx *ctx,
     GRN_OBJ_FIN(ctx, &inspected);
     goto exit;
   }
+  ctx->rc = rc;
 
   if (value) {
     *value = grn_hash_entry_get_value(ctx, hash, entry);


### PR DESCRIPTION
For example, if we execute ``request_cancel`` while we execute ``sub_filter``, Groonga may return ``GRN_SUCCESS`` even if we execute ``request_cancel`` depending on the timing of executing ``request_cancel``.

Because Groonga doesn't confirm return code of ``grn_ii_posting_add_float()`` currently.

This issue occurs in the search with an accessor.