### PR TITLE
ci package: use qemu-user-static on Impish 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -129,27 +129,27 @@ jobs:
             ruby
       # qemu-user-static in Ubuntu 20.04 has the following bug.
       # https://bugs.launchpad.net/qemu/+bug/1749393
-      # This bug has already fixed in Ubuntu 20.10.
+      # This bug has already fixed in Ubuntu 21.10.
       # However, this fix is not included in Ubuntu 20.04.
-      # Therefore, we temporaly use qemu-user-static in Ubuntu 20.10.
+      # Therefore, we temporaly use qemu-user-static in Ubuntu 21.10.
       # We remove this step when qemu-user-static in Ubuntu 20.04 will include above remediation.
-      - name: Install QEMU from Groovy
+      - name: Install QEMU from Impish
         run: |
           sudo tee /etc/apt/preferences.d/qemu <<EOF
           Package: *
           Pin: release n=focal
           Pin-Priority: 900
           Package: *
-          Pin: release n=groovy
+          Pin: release n=impish
           Pin-Priority: 400
           EOF
-          sudo tee /etc/apt/sources.list.d/groovy.list <<EOF
-          deb http://jp.archive.ubuntu.com/ubuntu groovy universe
-          deb http://jp.archive.ubuntu.com/ubuntu groovy-updates universe
-          deb http://security.ubuntu.com/ubuntu groovy-security universe
+          sudo tee /etc/apt/sources.list.d/impish.list <<EOF
+          deb http://jp.archive.ubuntu.com/ubuntu impish universe
+          deb http://jp.archive.ubuntu.com/ubuntu impish-updates universe
+          deb http://security.ubuntu.com/ubuntu impish-security universe
           EOF
           sudo apt update
-          sudo apt install -t groovy qemu-user-static
+          sudo apt install -t impish qemu-user-static
       - uses: actions/download-artifact@v2
         with:
           name: source


### PR DESCRIPTION
Because qemu-user-static in Ubuntu 20.04 has a crash bug as below.

  * https://bugs.launchpad.net/qemu/+bug/1749393
  * https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=971537

This bug has been already fixed in Ubuntu 20.10.
However, Ubuntu 20.10 already has been EOL.
Therefore, we use qemu-user-static on Ubuntu 21.10.