### PR TITLE
ci package: remove a task for installing qemu-user-static from Impish

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -126,30 +126,8 @@ jobs:
           sudo apt update
           sudo apt -V install \
             devscripts \
+            qemu-user-static \
             ruby
-      # qemu-user-static in Ubuntu 20.04 has the following bug.
-      # https://bugs.launchpad.net/qemu/+bug/1749393
-      # This bug has already fixed in Ubuntu 21.10.
-      # However, this fix is not included in Ubuntu 20.04.
-      # Therefore, we temporaly use qemu-user-static in Ubuntu 21.10.
-      # We remove this step when qemu-user-static in Ubuntu 20.04 will include above remediation.
-      - name: Install QEMU from Impish
-        run: |
-          sudo tee /etc/apt/preferences.d/qemu <<EOF
-          Package: *
-          Pin: release n=focal
-          Pin-Priority: 900
-          Package: *
-          Pin: release n=impish
-          Pin-Priority: 400
-          EOF
-          sudo tee /etc/apt/sources.list.d/impish.list <<EOF
-          deb http://jp.archive.ubuntu.com/ubuntu impish universe
-          deb http://jp.archive.ubuntu.com/ubuntu impish-updates universe
-          deb http://security.ubuntu.com/ubuntu impish-security universe
-          EOF
-          sudo apt update
-          sudo apt install -t impish qemu-user-static
       - uses: actions/download-artifact@v2
         with:
           name: source


### PR DESCRIPTION
Because the following bug has already resolved in Ubuntu 20.04.
https://bugs.launchpad.net/qemu/+bug/1749393

Therefore, "Install QEMU from Impish" is needless.
