### PR TITLE
ci: add a new step for detecting update of nginx 

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,10 +48,11 @@ jobs:
           upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           bundled_version=`cat nginx_version`
           if [ "${upstream_version}" != "${bundled_version}" ]; then
-            gh pr checkout -b update-bundled-nginx
+            git switch -c update-bundled-nginx
             pushd vendor
             ./update_nginx.sh ${upstream_version}
             gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master
+            git switch master
             popd
           fi
         env:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,8 +52,12 @@ jobs:
       - name: Create nginx version up request
         if: steps.detect-nginx-update.conclusion == 'failure'
         run: |
+          upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           gh pr checkout -b update-bundled-nginx
-          gh pr create --fill --draft --title "nginx: update bundles version" --base master
+          pushd vendor
+          ./update_nginx.sh ${upstream_version}
+          gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master
+          popd
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate configure

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,21 +43,17 @@ jobs:
           cd ..
           git clone --depth 1 https://github.com/groonga/groonga.org.git
           git clone --depth 1 https://github.com/clear-code/cutter.git
-      - name: Detect nginx update
-        id: detect-nginx-update
+      - name: Create nginx update request
         run: |
           upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           bundled_version=`cat nginx_version`
-          test "${upstream_version}" = "${bundled_version}"
-      - name: Create nginx version up request
-        if: steps.detect-nginx-update.conclusion == 'failure'
-        run: |
-          upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
-          gh pr checkout -b update-bundled-nginx
-          pushd vendor
-          ./update_nginx.sh ${upstream_version}
-          gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master
-          popd
+          if [ "${upstream_version}" != "${bundled_version}" ]; then
+            gh pr checkout -b update-bundled-nginx
+            pushd vendor
+            ./update_nginx.sh ${upstream_version}
+            gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master
+            popd
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate configure

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,6 +43,11 @@ jobs:
           cd ..
           git clone --depth 1 https://github.com/groonga/groonga.org.git
           git clone --depth 1 https://github.com/clear-code/cutter.git
+      - name: Detect nginx update
+        run: |
+          upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
+          bundled_version=`cat nginx_version`
+          test "${upstream_version}" = "${bundled_version}"
       - name: Generate configure
         run: |
           ./autogen.sh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,10 +44,18 @@ jobs:
           git clone --depth 1 https://github.com/groonga/groonga.org.git
           git clone --depth 1 https://github.com/clear-code/cutter.git
       - name: Detect nginx update
+        id: detect-nginx-update
         run: |
           upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           bundled_version=`cat nginx_version`
           test "${upstream_version}" = "${bundled_version}"
+      - name: Create nginx version up request
+        if: steps.detect-nginx-update.conclusion == 'failure'
+        run: |
+          gh pr checkout -b update-bundled-nginx
+          gh pr create --fill --draft --title "nginx: update bundles version" --base master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate configure
         run: |
           ./autogen.sh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 'maintenance/**'
+      - 'detect-nginx-update'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,10 +47,10 @@ jobs:
         run: |
           upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           bundled_version=`cat nginx_version`
-          branch_name=update-bundled-nginx
+          pr_branch_name=update-bundled-nginx
           if [ "${upstream_version}" != "${bundled_version}" ]; then
-            git switch -c ${branch_name}
-            git push -u origin ${branch_name}
+            git switch -c ${pr_branch_name}
+            git push -u origin ${pr_branch_name}
             pushd vendor
             ./update_nginx.sh ${upstream_version}
             gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Install dependencies
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -54,7 +54,7 @@ jobs:
             git push -u origin ${pr_branch_name}
             pushd vendor
             ./update_nginx.sh ${upstream_version}
-            gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master
+            gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}"
             git switch master
             popd
           fi

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,8 +47,10 @@ jobs:
         run: |
           upstream_version=`curl -s "https://nginx.org/en/CHANGES" | awk 'NR==2{print $4}'`
           bundled_version=`cat nginx_version`
+          branch_name=update-bundled-nginx
           if [ "${upstream_version}" != "${bundled_version}" ]; then
-            git switch -c update-bundled-nginx
+            git switch -c ${branch_name}
+            git push -u origin ${branch_name}
             pushd vendor
             ./update_nginx.sh ${upstream_version}
             gh pr create --fill --draft --title "nginx: update bundles version ${upstream_version}" --base master


### PR DESCRIPTION
GitHub Actions detect whether we need to update bundled nginx or not
by comparing the latest version of nginx of upstream and the version
of bundled nginx.

Currently, we confirm the latest version of nginx manually.
However, in this method, we often forget to update nginx that is
bundled with Groonga.