### PR TITLE
ci: increase timeout for HTTP chunked test

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,7 +163,6 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
-            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark
       - name: "Test: HTTP: load: Apache Arrow"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,12 +163,14 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark
       - name: "Test: HTTP: load: Apache Arrow"
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --input-type=apache-arrow \
@@ -177,6 +179,7 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --interface=http \
@@ -185,6 +188,7 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --interface=http \
@@ -194,6 +198,7 @@ jobs:
           mkdir -p /tmp/local/var/log/groonga/httpd/
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --testee groonga-httpd
@@ -202,6 +207,7 @@ jobs:
           export GRN_ENABLE_REFERENCE_COUNT=yes
           bash -x test/command/run-test.sh \
             --n-retries=3 \
+            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --interface=http

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -169,7 +169,6 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
-            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --input-type=apache-arrow \
@@ -178,7 +177,6 @@ jobs:
         run: |
           bash -x test/command/run-test.sh \
             --n-retries=3 \
-            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --interface=http \
@@ -197,7 +195,6 @@ jobs:
           mkdir -p /tmp/local/var/log/groonga/httpd/
           bash -x test/command/run-test.sh \
             --n-retries=3 \
-            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --testee groonga-httpd
@@ -206,7 +203,6 @@ jobs:
           export GRN_ENABLE_REFERENCE_COUNT=yes
           bash -x test/command/run-test.sh \
             --n-retries=3 \
-            --timeout=10 \
             --read-timeout=30 \
             --reporter=mark \
             --interface=http

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,7 +87,6 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
-              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark
       - name: "Test: HTTP: load: Apache Arrow"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,6 +87,7 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
+              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark
       - name: "Test: HTTP: load: Apache Arrow"
@@ -95,6 +96,7 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
+              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --input-type=apache-arrow \
@@ -105,6 +107,7 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
+              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --interface=http \
@@ -115,6 +118,7 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
+              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --interface=http \
@@ -126,6 +130,7 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
+              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --interface=http

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -95,7 +95,6 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
-              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --input-type=apache-arrow \
@@ -106,7 +105,6 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
-              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --interface=http \
@@ -129,7 +127,6 @@ jobs:
           BUILD_DIR=$PWD/test/command \
             bash -x ../groonga/test/command/run-test.sh \
               --n-retries=3 \
-              --timeout=10 \
               --read-timeout=30 \
               --reporter=mark \
               --interface=http


### PR DESCRIPTION
HTTP chunked test is slower than others. We should improve performance for HTTP chunked
but we increase timeout for now.