### PR TITLE
ci: Add support for Visual Studio 2022

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -122,7 +122,12 @@ jobs:
           Write-Output "FULL_INSTALL_FOLDER_WITH_VCRUNTIME=${FULL_INSTALL_FOLDER_WITH_VCRUNTIME}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-          $VC_PREFIX = "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs-version }}\Enterprise\VC"
+          if ${{ matrix.vs-version }} -ge 2022 {
+            $VC_PREFIX = "C:\Program Files\Microsoft Visual Studio\${{ matrix.vs-version }}\Enterprise\VC"
+          }
+          else {
+            $VC_PREFIX = "C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs-version }}\Enterprise\VC"
+          }
           Write-Output "VC_PREFIX=${VC_PREFIX}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -122,7 +122,7 @@ jobs:
           Write-Output "FULL_INSTALL_FOLDER_WITH_VCRUNTIME=${FULL_INSTALL_FOLDER_WITH_VCRUNTIME}" | `
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-          if ${{ matrix.vs-version }} -ge 2022 {
+          if (${{ matrix.vs-version }} -ge 2022) {
             $VC_PREFIX = "C:\Program Files\Microsoft Visual Studio\${{ matrix.vs-version }}\Enterprise\VC"
           }
           else {

--- a/packages/windows/vcruntime/vs2022/readme.txt
+++ b/packages/windows/vcruntime/vs2022/readme.txt
@@ -1,0 +1,17 @@
+Subject to Microsoft Visual Studio Community 2022 EULA [1], This package
+ contains Visual C++ Runtime files as redistributable code:
+
+[1] https://visualstudio.microsoft.com/license-terms/vs2022-ga-community/
+
+Japanese version: https://visualstudio.microsoft.com/ja/license-terms/vs2022-ga-community/
+
+See section 4. DISTRIBUTABLE CODE, "b. Distribution Requirements" and
+"c. Distribution Restrictions" for distribution.
+
+These files are bundled with this package without modification.
+
+* bin/vcruntime140.dll
+* bin/msvcp140.dll
+
+See https://docs.microsoft.com/en-us/visualstudio/releases/2022/redistribution#visual-c-runtime-files
+about above redistributable code details.


### PR DESCRIPTION
Visual studio 2022 is installed to `Program Files` not `Program Files (x86)`