### PR TITLE
Add necessary unref to grn_obj_get_accessor

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -7242,6 +7242,9 @@ grn_obj_get_accessor(grn_ctx *ctx, grn_obj *obj, const char *name, unsigned int 
           next_obj_id = obj->header.domain;
           if (!next_obj_id) {
             // ERR(GRN_INVALID_ARGUMENT, "no such column: <%s>", name);
+            if (obj_is_referred) {
+              grn_obj_unref(ctx, obj);
+            }
             if (!is_chained) {
               grn_obj_close(ctx, (grn_obj *)res);
             }

--- a/test/command/suite/select/columns/stage/filtered/time_reference_count.expected
+++ b/test/command/suite/select/columns/stage/filtered/time_reference_count.expected
@@ -1,0 +1,26 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Logs TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+[[0,0.0,0.0],4]
+log_level --level dump
+[[0,0.0,0.0],true]
+select Logs   --columns[day].stage filtered   --columns[day].type Time   --columns[day].flags COLUMN_SCALAR   --columns[day].value 'time_classify_day(timestamp-36000000000)'   --output_columns _id
+[[0,0.0,0.0],[[[4],[["_id","UInt32"]],[1],[2],[3],[4]]]]
+#|-| [obj][open] <266>(<Logs>):<51>(<table:no_key>)
+#|-| [obj][open] <267>(<Logs.timestamp>):<64>(<column:fix_size>)
+#|-| [obj][close] <267>(<Logs.timestamp>):<64>(<column:fix_size>)
+#|-| [obj][close] <266>(<Logs>):<51>(<table:no_key>)
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/columns/stage/filtered/time_reference_count.test
+++ b/test/command/suite/select/columns/stage/filtered/time_reference_count.test
@@ -1,0 +1,25 @@
+#$GRN_ENABLE_REFERENCE_COUNT=yes
+plugin_register functions/time
+table_create Logs TABLE_NO_KEY
+column_create Logs timestamp COLUMN_SCALAR Time
+column_create Logs price COLUMN_SCALAR UInt32
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+
+#@add-important-log-levels dump
+#@add-ignore-log-pattern /\A\[io\]/
+log_level --level dump
+select Logs \
+  --columns[day].stage filtered \
+  --columns[day].type Time \
+  --columns[day].flags COLUMN_SCALAR \
+  --columns[day].value 'time_classify_day(timestamp-36000000000)' \
+  --output_columns _id
+log_level --level notice
+#@remove-ignore-log-pattern /\A\[io\]/
+#@remove-important-log-levels dump

--- a/test/command/suite/select/columns/window_function/window_sum/reference_count.expected
+++ b/test/command/suite/select/columns/window_function/window_sum/reference_count.expected
@@ -1,0 +1,28 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Logs TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+[[0,0.0,0.0],4]
+log_level --level dump
+[[0,0.0,0.0],true]
+select Logs   --columns[price_per_day].stage filtered   --columns[price_per_day].type UInt32   --columns[price_per_day].flags COLUMN_SCALAR   --columns[price_per_day].value 'window_sum(price)'   --columns[price_per_day].window.group_keys 'timestamp'   --output_columns _id
+[[0,0.0,0.0],[[[4],[["_id","UInt32"]],[1],[2],[3],[4]]]]
+#|-| [obj][open] <266>(<Logs>):<51>(<table:no_key>)
+#|-| [obj][open] <268>(<Logs.price>):<64>(<column:fix_size>)
+#|-| [obj][open] <267>(<Logs.timestamp>):<64>(<column:fix_size>)
+#|-| [obj][close] <268>(<Logs.price>):<64>(<column:fix_size>)
+#|-| [obj][close] <267>(<Logs.timestamp>):<64>(<column:fix_size>)
+#|-| [obj][close] <266>(<Logs>):<51>(<table:no_key>)
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/columns/window_function/window_sum/reference_count.test
+++ b/test/command/suite/select/columns/window_function/window_sum/reference_count.test
@@ -1,0 +1,26 @@
+#$GRN_ENABLE_REFERENCE_COUNT=yes
+plugin_register functions/time
+table_create Logs TABLE_NO_KEY
+column_create Logs timestamp COLUMN_SCALAR Time
+column_create Logs price COLUMN_SCALAR UInt32
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+
+#@add-important-log-levels dump
+#@add-ignore-log-pattern /\A\[io\]/
+log_level --level dump
+select Logs \
+  --columns[price_per_day].stage filtered \
+  --columns[price_per_day].type UInt32 \
+  --columns[price_per_day].flags COLUMN_SCALAR \
+  --columns[price_per_day].value 'window_sum(price)' \
+  --columns[price_per_day].window.group_keys 'timestamp' \
+  --output_columns _id
+log_level --level notice
+#@remove-ignore-log-pattern /\A\[io\]/
+#@remove-important-log-levels dump

--- a/test/command/suite/select/output_columns/nonexistent/with_filter.expected
+++ b/test/command/suite/select/output_columns/nonexistent/with_filter.expected
@@ -1,0 +1,24 @@
+table_create Logs TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+[[0,0.0,0.0],4]
+log_level --level dump
+[[0,0.0,0.0],true]
+select Logs   --filter 'price >= 300' --output_columns '_id, nonexistent'
+[[0,0.0,0.0],[[[3],[["_id","UInt32"]],[1],[2],[3]]]]
+#|-| [obj][open] <256>(<Logs>):<51>(<table:no_key>)
+#|-| [obj][open] <258>(<Logs.price>):<64>(<column:fix_size>)
+#|-| [obj][close] <258>(<Logs.price>):<64>(<column:fix_size>)
+#|-| [obj][close] <256>(<Logs>):<51>(<table:no_key>)
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/output_columns/nonexistent/with_filter.test
+++ b/test/command/suite/select/output_columns/nonexistent/with_filter.test
@@ -1,0 +1,18 @@
+#$GRN_ENABLE_REFERENCE_COUNT=yes
+table_create Logs TABLE_NO_KEY
+column_create Logs timestamp COLUMN_SCALAR Time
+column_create Logs price COLUMN_SCALAR UInt32
+load --table Logs
+[
+{"timestamp": "2017/03/15 00:00:00", "price": 1000},
+{"timestamp": "2017/03/15 11:00:00", "price":  900},
+{"timestamp": "2017/03/15 12:00:00", "price":  300},
+{"timestamp": "2017/03/15 13:00:00", "price":  200}
+]
+#@add-important-log-levels dump
+#@add-ignore-log-pattern /\A\[io\]/
+log_level --level dump
+select Logs   --filter 'price >= 300' --output_columns '_id, nonexistent'
+log_level --level notice
+#@remove-ignore-log-pattern /\A\[io\]/
+#@remove-important-log-levels dump


### PR DESCRIPTION
This is a patch for https://github.com/groonga/groonga/pull/1330/files#r827579558

An opened table is not closed in cases below.

1. using `time_classify_xxx` with dynamic column
2. using `window` function with dynamic column
3. specifying a non existent column on `output_column` with specifying `filter`

`select` command also has these issues so I guess this is not the matter of `logical_range_filter`.
The commands to reproduce these are below.


**common**
```
plugin_register functions/time
table_create Logs_20170315 TABLE_NO_KEY
column_create Logs_20170315 timestamp COLUMN_SCALAR Time
column_create Logs_20170315 price COLUMN_SCALAR UInt32
load --table Logs_20170315
[
{"timestamp": "2017/03/15 00:00:00", "price": 1000},
{"timestamp": "2017/03/15 11:00:00", "price":  900},
{"timestamp": "2017/03/15 12:00:00", "price":  300},
{"timestamp": "2017/03/15 13:00:00", "price":  200}
]
log_level --level dump
```


**Case 1: using `time_classify_xxx` with dynamic column**
```
select Logs_20170315   --columns[day].stage filtered   --columns[day].type Time   --columns[day].flags COLUMN_SCALAR   --columns[day].value 'time_classify_day(timestamp-36000000000)'   --output_columns _id
[[0,0.0,0.0],[[[4],[["_id","UInt32"]],[1],[2],[3],[4]]]]
#|-| [obj][open] <272>(<Logs_20170315>):<51>(<table:no_key>)
#|-| [obj][open] <273>(<Logs_20170315.timestamp>):<64>(<column:fix_size>)
#|-| [obj][close] <273>(<Logs_20170315.timestamp>):<64>(<column:fix_size>)
```

**Case 2: using `window` function with dynamic column**
```
select Logs_20170315   --columns[price_per_day].stage filtered   --columns[price_per_day].type UInt32   --columns[price_per_day].flags COLUMN_SCALAR   --columns[price_per_day].value 'window_sum(price)'   --columns[price_per_day].window.group_keys 'timestamp'   --output_columns _id
[[0,0.0,0.0],[[[4],[["_id","UInt32"]],[1],[2],[3],[4]]]]
#|-| [obj][open] <272>(<Logs_20170315>):<51>(<table:no_key>)
#|-| [obj][open] <274>(<Logs_20170315.price>):<64>(<column:fix_size>)
#|-| [obj][open] <273>(<Logs_20170315.timestamp>):<64>(<column:fix_size>)
#|-| [obj][close] <274>(<Logs_20170315.price>):<64>(<column:fix_size>)
#|-| [obj][close] <273>(<Logs_20170315.timestamp>):<64>(<column:fix_size>)
```

**Case 3: specifying a non existent column with `output_column`**
```
select Logs_20170315   --filter 'price >= 300'   --output_columns _id,non_existent
[[0,0.0,0.0],[[[3],[["_id","UInt32"]],[1],[2],[3]]]]
#|-| [obj][open] <272>(<Logs_20170315>):<51>(<table:no_key>)
#|-| [obj][open] <274>(<Logs_20170315.price>):<64>(<column:fix_size>)
#|-| [obj][close] <274>(<Logs_20170315.price>):<64>(<column:fix_size>)
```