### PR TITLE
Separate Executor to an independent class

### DIFF
--- a/plugins/sharding.rb
+++ b/plugins/sharding.rb
@@ -5,6 +5,7 @@ require "sharding/keys_parsable"
 require "sharding/window"
 require "sharding/stream_execute_context"
 require "sharding/stream_shard_executor"
+require "sharding/stream_executor"
 
 require "sharding/dynamic_columns"
 

--- a/plugins/sharding/sources.am
+++ b/plugins/sharding/sources.am
@@ -12,4 +12,5 @@ sharding_scripts =				\
 	dynamic_columns.rb			\
 	window.rb			\
 	stream_execute_context.rb		\
-	stream_shard_executor.rb
+	stream_shard_executor.rb		\
+	stream_executor.rb

--- a/plugins/sharding/stream_executor.rb
+++ b/plugins/sharding/stream_executor.rb
@@ -1,0 +1,45 @@
+module Groonga
+  module Sharding
+    class StreamExecutor
+      def initialize(context, shard_executor_class)
+        @context = context
+        @shard_executor_class = shard_executor_class
+      end
+
+      protected
+      def each_shard_executor(&block)
+        enumerator = @context.enumerator
+        target_range = enumerator.target_range
+        if @context.order == :descending
+          each_method = :reverse_each
+        else
+          each_method = :each
+        end
+        if @context.need_look_ahead?
+          previous_executor = nil
+          enumerator.send(each_method) do |shard, shard_range|
+            @context.push
+            current_executor = @shard_executor_class.new(@context, shard, shard_range)
+            if previous_executor
+              previous_executor.next_executor = current_executor
+              current_executor.previous_executor = previous_executor
+              yield(previous_executor)
+              @context.shift unless previous_executor.shard.first?
+            end
+            if shard.last?
+              yield(current_executor)
+              @context.shift
+            end
+            previous_executor = current_executor
+          end
+        else
+          enumerator.send(each_method) do |shard, shard_range|
+            @context.push
+            yield(@shard_executor_class.new(@context, shard, shard_range))
+            @context.shift
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a preparation for #1341.

A purpose is make `each_shard_executor` sharable with `logical_range_filter` and `logical_count`.