### PR TITLE
logical_range_filter: Move order to StreamExcuteContext

### DIFF
--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -101,7 +101,6 @@ module Groonga
         include KeysParsable
 
         attr_reader :use_range_index
-        attr_reader :order
         attr_reader :offset
         attr_reader :limit
         attr_reader :sort_keys
@@ -113,7 +112,6 @@ module Groonga
         def initialize(input)
           super("logical_range_filter", input)
           @use_range_index = parse_use_range_index(@input[:use_range_index])
-          @order = parse_order(@input, :order)
           @offset = (@input[:offset] || 0).to_i
           @limit = (@input[:limit] || 10).to_i
           @sort_keys = parse_keys(@input[:sort_keys])
@@ -147,23 +145,6 @@ module Groonga
             false
           else
             nil
-          end
-        end
-
-        def parse_order(input, name)
-          order = input[name]
-          return :ascending if order.nil?
-
-          case order
-          when "ascending"
-            :ascending
-          when "descending"
-            :descending
-          else
-            message =
-              "[logical_range_filter] #{name} must be " +
-              "\"ascending\" or \"descending\": <#{order}>"
-            raise InvalidArgument, message
           end
         end
 

--- a/plugins/sharding/stream_execute_context.rb
+++ b/plugins/sharding/stream_execute_context.rb
@@ -8,6 +8,7 @@ module Groonga
       attr_reader :time_classify_types
       attr_reader :order
       def initialize(command_name, input)
+        @command_name = command_name
         @input = input
         @enumerator = LogicalEnumerator.new(command_name,
                                             @input,
@@ -69,7 +70,7 @@ module Groonga
           :descending
         else
           message =
-            "[logical_range_filter] #{name} must be " +
+            "[#{@command_name}] #{name} must be " +
             "\"ascending\" or \"descending\": <#{order}>"
           raise InvalidArgument, message
         end

--- a/plugins/sharding/stream_execute_context.rb
+++ b/plugins/sharding/stream_execute_context.rb
@@ -6,6 +6,7 @@ module Groonga
       attr_reader :post_filter
       attr_reader :dynamic_columns
       attr_reader :time_classify_types
+      attr_reader :order
       def initialize(command_name, input)
         @input = input
         @enumerator = LogicalEnumerator.new(command_name,
@@ -19,6 +20,7 @@ module Groonga
         @temporary_tables_queue = []
         @time_classify_types = detect_time_classify_types
         @referred_objects_queue = []
+        @order = parse_order(@input, :order)
       end
 
       def temporary_tables
@@ -54,6 +56,23 @@ module Groonga
         return false unless @dynamic_columns.have_window_function?
         return false unless @time_classify_types.empty?
         true
+      end
+
+      def parse_order(input, name)
+        order = input[name]
+        return :ascending if order.nil?
+
+        case order
+        when "ascending"
+          :ascending
+        when "descending"
+          :descending
+        else
+          message =
+            "[logical_range_filter] #{name} must be " +
+            "\"ascending\" or \"descending\": <#{order}>"
+          raise InvalidArgument, message
+        end
       end
 
       def detect_time_classify_types


### PR DESCRIPTION
Move the `order` attribute to `StreamExcuteContext` from `ExecuteContext`