### PR TITLE
accessor: Add missing unref to pseudo column start with "m"

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -7181,9 +7181,7 @@ grn_obj_get_accessor(grn_ctx *ctx, grn_obj *obj, const char *name, uint32_t name
             goto exit;
           }
         } else {
-          if (!obj_is_referred) {
-            grn_obj_unref(ctx, obj);
-          }
+          grn_obj_unref(ctx, obj);
           goto exit;
         }
         break;

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
@@ -10,7 +10,7 @@ load --table Sites
 [[0,0.0,0.0],1]
 log_level --level dump 
 [[0,0.0,0.0],true]
-select Sites  --output_columns '_m_non_existant'
+select Sites  --output_columns '_m_non_existent'
 [[0,0.0,0.0],[[[1],[],[]]]]
 #|-| [obj][open] <256>(<Sites>):<48>(<table:hash_key>)
 #|-| [obj][close] <256>(<Sites>):<48>(<table:hash_key>)

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
@@ -13,5 +13,6 @@ log_level --level dump
 select Sites  --output_columns '_m_non_existant'
 [[0,0.0,0.0],[[[1],[],[]]]]
 #|-| [obj][open] <256>(<Sites>):<48>(<table:hash_key>)
+#|-| [obj][close] <256>(<Sites>):<48>(<table:hash_key>)
 log_level --level notice
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
@@ -10,7 +10,7 @@ load --table Sites
 [[0,0.0,0.0],1]
 log_level --level dump 
 [[0,0.0,0.0],true]
-select Sites  --output_columns '_m_non_existent'
+select Sites  --output_columns '_m_nonexistent'
 [[0,0.0,0.0],[[[1],[],[]]]]
 #|-| [obj][open] <256>(<Sites>):<48>(<table:hash_key>)
 #|-| [obj][close] <256>(<Sites>):<48>(<table:hash_key>)

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.expected
@@ -1,0 +1,17 @@
+table_create Sites TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Sites uri COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Sites
+[
+["_key","uri"],
+["groonga","http://groonga.org/"]
+]
+[[0,0.0,0.0],1]
+log_level --level dump 
+[[0,0.0,0.0],true]
+select Sites  --output_columns '_m_non_existant'
+[[0,0.0,0.0],[[[1],[],[]]]]
+#|-| [obj][open] <256>(<Sites>):<48>(<table:hash_key>)
+log_level --level notice
+[[0,0.0,0.0],true]

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
@@ -11,7 +11,7 @@ load --table Sites
 log_level --level dump 
 #@add-important-log-levels dump 
 #@add-ignore-log-pattern /\A\[io\]/
-select Sites  --output_columns '_m_non_existant'
+select Sites  --output_columns '_m_non_existent'
 log_level --level notice
 #@remove-ignore-log-pattern /\A\[io\]/
 #@remove-important-log-levels dump

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
@@ -11,7 +11,7 @@ load --table Sites
 log_level --level dump 
 #@add-important-log-levels dump 
 #@add-ignore-log-pattern /\A\[io\]/
-select Sites  --output_columns '_m_non_existent'
+select Sites  --output_columns '_m_nonexistent'
 log_level --level notice
 #@remove-ignore-log-pattern /\A\[io\]/
 #@remove-important-log-levels dump

--- a/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
+++ b/test/command/suite/select/output_columns/nonexistent/reference_count/pseudo_start_with_m.test
@@ -1,0 +1,17 @@
+#$GRN_ENABLE_REFERENCE_COUNT=yes
+table_create Sites TABLE_HASH_KEY ShortText
+column_create Sites uri COLUMN_SCALAR ShortText
+
+load --table Sites
+[
+["_key","uri"],
+["groonga","http://groonga.org/"]
+]
+
+log_level --level dump 
+#@add-important-log-levels dump 
+#@add-ignore-log-pattern /\A\[io\]/
+select Sites  --output_columns '_m_non_existant'
+log_level --level notice
+#@remove-ignore-log-pattern /\A\[io\]/
+#@remove-important-log-levels dump


### PR DESCRIPTION
 Fix to unref `obj` if a pseudo column starts with "m" is not a reserved column.
Derived from #1335.