### PR TITLE
grn_obj_get_accessor: Remove check whether obj->header.type is GRN_DB

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -7076,7 +7076,6 @@ grn_obj_get_accessor(grn_ctx *ctx, grn_obj *obj, const char *name, uint32_t name
               goto exit;
             }
             switch (obj->header.type) {
-            case GRN_DB :
             case GRN_TYPE :
               if (DB_OBJ((*rp)->obj)->range) {
                 (*rp)->action = GRN_ACCESSOR_GET_VALUE;


### PR DESCRIPTION
grn_obj_get_accessor: Remove check whether `obj->header.type` is `GRN_DB` from the case of pseudo column starts with v.

This case never passed because `grn_db` is never found by `grn_ctx_at()`.
We cannot add tests for this case because of that, so checking just the all existing tests are passed.