### PR TITLE
ii: add a condition for stopping making the result set on the way when fail to add the result set

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -12330,6 +12330,10 @@ grn_ii_select_regexp(grn_ctx *ctx, grn_ii *ii,
         grn_rset_posinfo pi = {posting->rid, posting->sid, pos};
         double record_score = 1.0;
         res_add(ctx, s, &pi, record_score, op);
+        if (ctx->rc != GRN_SUCCESS) {
+          rc = ctx->rc;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
Because if Groonga doesn't stop making the result set when failing to add the result set of the search of regular expressions, Groonga output many error logs.

Therefore, the command response is slow when the number of hits is many in this case.

This modification is stopping making the result set on the way when failing to add the result set.
Thereby, the command response quickly