### PR TITLE
select: Include "grn_ctx.hpp" even if in an environment without Apache Arrow

### DIFF
--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "../grn_cache.h"
+#include "../grn_ctx.hpp"
 #include "../grn_ctx_impl.h"
 #include "../grn_expr.h"
 #include "../grn_group.h"
@@ -37,7 +38,6 @@
 
 #ifdef GRN_WITH_APACHE_ARROW
 # include "../grn_arrow.hpp"
-# include "../grn_ctx.hpp"
 # include <arrow/util/thread_pool.h>
 # include <mutex>
 # include <unordered_map>


### PR DESCRIPTION
Because we use "grn::ChildCtxReleaser" in "proc_select.cpp".
ChildCtxReleaser class is defined in "grn_ctx.hpp".
Therefore, if we don't include "grn_ctx.hpp", a build error occurs in an environment without Apache Arrow.