### PR TITLE
doc: Remove `slices.table` description

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/commands/select.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/commands/select.po
@@ -3241,9 +3241,6 @@ msgstr ""
 msgid "``--slices[${LABEL}].limit``"
 msgstr ""
 
-msgid "``--slices[${LABEL}].table``"
-msgstr ""
-
 msgid "``slices[${LABEL}].match_columns``"
 msgstr ""
 
@@ -3269,9 +3266,6 @@ msgid "``slices[${LABEL}].offset``"
 msgstr ""
 
 msgid "``slices[${LABEL}].limit``"
-msgstr ""
-
-msgid "``slices[${LABEL}].table``"
 msgstr ""
 
 msgid "Cache related parameter"

--- a/doc/source/reference/commands/select.rst
+++ b/doc/source/reference/commands/select.rst
@@ -2586,8 +2586,6 @@ Here are parameters for slice:
      - Optional
    * - ``--slices[${LABEL}].limit``
      - Optional
-   * - ``--slices[${LABEL}].table``
-     - Optional
 
 .. _select-slices-label-match-columns:
 
@@ -2648,13 +2646,6 @@ TODO
 .. _select-slices-label-limit:
 
 ``slices[${LABEL}].limit``
-""""""""""""""""""""""""""
-
-TODO
-
-.. _select-slices-label-table:
-
-``slices[${LABEL}].table``
 """"""""""""""""""""""""""
 
 TODO


### PR DESCRIPTION
The feature `slices.table` is not implemented.
Maybe it was intended `drilldowns.table`.