### PR TITLE
db: add a new condition for stopping result set marge when fail to add the result set

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -6081,23 +6081,22 @@ grn_table_setoperation_or(grn_ctx *ctx,
         } else {
           break;
         }
-      } else {
-        if (added) {
-          grn_memcpy(value_dest, value_src, data->value_size);
-          grn_rset_recinfo *ri_dest = value_dest;
-          ri_dest->score *= data->weight_factor;
-        } else {
-          grn_rset_recinfo *ri_dest = value_dest;
-          grn_rset_recinfo *ri_src = value_src;
-          grn_table_add_subrec(ctx,
-                               data->table_dest,
-                               ri_dest,
-                               ri_src->score * data->weight_factor,
-                               NULL,
-                               0);
-        }
-        grn_table_setoperation_merge_columns(ctx, data, id_dest, id_src);
       }
+      if (added) {
+        grn_memcpy(value_dest, value_src, data->value_size);
+        grn_rset_recinfo *ri_dest = value_dest;
+        ri_dest->score *= data->weight_factor;
+      } else {
+        grn_rset_recinfo *ri_dest = value_dest;
+        grn_rset_recinfo *ri_src = value_src;
+        grn_table_add_subrec(ctx,
+                             data->table_dest,
+                             ri_dest,
+                             ri_src->score * data->weight_factor,
+                             NULL,
+                             0);
+      }
+      grn_table_setoperation_merge_columns(ctx, data, id_dest, id_src);
     } GRN_TABLE_EACH_END(ctx, cursor);
   } else {
     GRN_TABLE_EACH_BEGIN(ctx, data->table_src, cursor, id_src) {
@@ -6116,9 +6115,8 @@ grn_table_setoperation_or(grn_ctx *ctx,
         } else {
           break;
         }
-      } else {
-        grn_table_setoperation_merge_columns(ctx, data, id_dest, id_src);
       }
+      grn_table_setoperation_merge_columns(ctx, data, id_dest, id_src);
     } GRN_TABLE_EACH_END(ctx, cursor);
   }
 }

--- a/lib/db.c
+++ b/lib/db.c
@@ -6076,7 +6076,11 @@ grn_table_setoperation_or(grn_ctx *ctx,
                                               &value_dest,
                                               &added);
       if (id_dest == GRN_ID_NIL) {
-        break;
+        if (ctx->rc == GRN_SUCCESS) {
+          continue;
+        } else {
+          break;
+        }
       } else {
         if (added) {
           grn_memcpy(value_dest, value_src, data->value_size);

--- a/lib/db.c
+++ b/lib/db.c
@@ -6110,7 +6110,13 @@ grn_table_setoperation_or(grn_ctx *ctx,
                                               key_src_size,
                                               &value_dest,
                                               NULL);
-      if (id_dest != GRN_ID_NIL) {
+      if (id_dest == GRN_ID_NIL) {
+        if (ctx->rc == GRN_SUCCESS) {
+          continue;
+        } else {
+          break;
+        }
+      } else {
         grn_table_setoperation_merge_columns(ctx, data, id_dest, id_src);
       }
     } GRN_TABLE_EACH_END(ctx, cursor);

--- a/lib/db.c
+++ b/lib/db.c
@@ -6075,7 +6075,9 @@ grn_table_setoperation_or(grn_ctx *ctx,
                                               key_src_size,
                                               &value_dest,
                                               &added);
-      if (id_dest != GRN_ID_NIL) {
+      if (id_dest == GRN_ID_NIL) {
+        break;
+      } else {
         if (added) {
           grn_memcpy(value_dest, value_src, data->value_size);
           grn_rset_recinfo *ri_dest = value_dest;


### PR DESCRIPTION
Currently, Groonga doesn't stop making a result set when failing to
add the result set of a OR search.

Therefore, when the number of results of the OR search is many and a
query has many OR conditions, Groonga may response slow with the
"request_cancel" command.

if we execute the "request_cancel" command while Groonga adds the
result set of the OR search, the addition to the result set fails.

Therefore, Groonga output  a error of "failed to add:".
Groonga may output this error a lot because this error occurs every
failing to add the result set.

If Groonga output this error a lot, Groonga's response is very slow.

This modification is stopping making the result set on the way when
failing to add the result set.
Thereby, the command responds quickly.