### PR TITLE
ci: workflows except Package workflow ignore the modification of documents

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,7 +6,11 @@ on:
       - 'maintenance/**'
     tags:
       - '*'
+    paths-ignore:
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,11 @@ on:
       - 'maintenance/**'
     tags:
       - '*'
+    paths-ignore:
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -7,7 +7,11 @@ on:
       - ci-mingw
     tags:
       - '*'
+    paths-ignore:
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -6,7 +6,11 @@ on:
       - 'maintenance/**'
     tags:
       - '*'
+    paths-ignore:
+      - 'doc/**'
   pull_request:
+    paths-ignore:
+      - 'doc/**'
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Because tests of linux, macos, windows-mingw, and windows-msvc
are not affected by the modification of documents.

Currently, when we modify documents, many ci are executed.
Thereby a queue of GitHub Actions is full.
This is inefficient.

Therefore, we enable ignore the modification of documents in these workflows.