### PR TITLE
packages windows: redirect to GitHub Releases to download latest Groonga

### DIFF
--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -177,9 +177,9 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
     File.open("#{repositories_dir}/.htaccess", "w") do |htaccess|
       __send__("#{target_namespace}_targets").each do |target|
         redirect_url = built_package_url(target_namespace, target)
-        redirect_target_base = target.gsub(@version, "latest")
-        redirect_target = "^.+/#{Regexp.escape(redirect_target_base)}$"
-        htaccess.puts("RedirectMatch #{redirect_target} #{redirect_url}")  
+        redirect_target_file = target.gsub(@version, "latest")
+        redirect_target = "/#{target_namespace}/#{@package}/#{redirect_target_file}"
+        htaccess.puts("Redirect #{redirect_target} #{redirect_url}")  
       end
     end
   end

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -171,17 +171,16 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
 
   def create_htaccess(target_namespace)
     return unless target_namespace == :windows
-
+    
     repositories_dir = download_repositories_dir(target_namespace)
     mkdir_p(repositories_dir)
-    htaccess_path = "#{repositories_dir}/.htaccess"
-    rm_rf(htaccess_path)
-    
-    __send__("#{target_namespace}_targets").each do |target|
-      redirect_url = built_package_url(target_namespace, target)
-      redirect_target = target.gsub(@version, "latest")
-      htaccesss_value = "RewriteRule #{redirect_target} #{redirect_url}\n"
-      File.write(htaccess_path, htaccesss_value, mode: "a+")  
+
+    File.open("#{repositories_dir}/.htaccess", "w") do |htaccess|
+      __send__("#{target_namespace}_targets").each do |target|
+        redirect_url = built_package_url(target_namespace, target)
+        redirect_target = target.gsub(@version, "latest")
+        htaccess.puts("RewriteRule #{redirect_target} #{redirect_url}")  
+      end
     end
   end
 end

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -169,7 +169,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
     super
   end
 
-  def create_htaccess(target_namespace)
+  def prepare(target_namespace)
     return unless target_namespace == :windows
     
     repositories_dir = download_repositories_dir(target_namespace)

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -165,8 +165,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def download_packages(target_namespace)
-    return if target_namespace == :windows
-    super
+    super unless target_namespace == :windows
   end
 
   def prepare(target_namespace)

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -169,7 +169,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def prepare(target_namespace)
-    return unless target_namespace == :windows
+    return super unless target_namespace == :windows
     
     repositories_dir = download_repositories_dir(target_namespace)
     mkdir_p(repositories_dir)

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -178,7 +178,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
       __send__("#{target_namespace}_targets").each do |target|
         redirect_url = built_package_url(target_namespace, target)
         redirect_target_base = target.gsub(@version, "latest")
-        redirect_target = "^(.+)/#{Regexp.escape(redirect_target_base)}$"
+        redirect_target = "^.+/#{Regexp.escape(redirect_target_base)}$"
         htaccess.puts("RedirectMatch #{redirect_target} #{redirect_url}")  
       end
     end

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -163,6 +163,27 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   def built_package_n_split_components
     3
   end
+
+  def download_packages(target_namespace)
+    return if target_namespace == :windows
+    super
+  end
+
+  def create_htaccess(target_namespace)
+    return unless target_namespace == :windows
+
+    repositories_dir = download_repositories_dir(target_namespace)
+    mkdir_p(repositories_dir)
+
+    htaccess_path = "#{repositories_dir}/.htaccess"
+    rm_rf(htaccess_path)
+    __send__("#{target_namespace}_targets").each do |target|
+      redirect_url = built_package_url(target_namespace, target)
+      redirect_target = target.gsub(@version, "latest")
+      htaccesss_value = "RewriteRule #{redirect_target} #{redirect_url}\n"
+      File.write(htaccess_path, htaccesss_value, mode: "a+")  
+    end
+  end
 end
 
 task = GroongaPackageTask.new

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -174,9 +174,9 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
 
     repositories_dir = download_repositories_dir(target_namespace)
     mkdir_p(repositories_dir)
-
     htaccess_path = "#{repositories_dir}/.htaccess"
     rm_rf(htaccess_path)
+    
     __send__("#{target_namespace}_targets").each do |target|
       redirect_url = built_package_url(target_namespace, target)
       redirect_target = target.gsub(@version, "latest")

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -179,7 +179,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
       __send__("#{target_namespace}_targets").each do |target|
         redirect_url = built_package_url(target_namespace, target)
         redirect_target = target.gsub(@version, "latest")
-        htaccess.puts("RewriteRule #{redirect_target} #{redirect_url}")  
+        htaccess.puts("Redirect #{redirect_target} #{redirect_url}")  
       end
     end
   end

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -178,8 +178,9 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
     File.open("#{repositories_dir}/.htaccess", "w") do |htaccess|
       __send__("#{target_namespace}_targets").each do |target|
         redirect_url = built_package_url(target_namespace, target)
-        redirect_target = target.gsub(@version, "latest")
-        htaccess.puts("Redirect #{redirect_target} #{redirect_url}")  
+        redirect_target_base = target.gsub(@version, "latest")
+        redirect_target = "^(.+)/#{Regexp.escape(redirect_target_base)}$"
+        htaccess.puts("RedirectMatch #{redirect_target} #{redirect_url}")  
       end
     end
   end

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -248,7 +248,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
           tasks << "#{target_namespace}:download"
         end
         
-        desc "Prepare for #{target_namespace} packages"
+        desc "Prepare #{target_namespace} packages"
         task :prepare do
           prepare(target_namespace) if enabled
         end

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -222,6 +222,9 @@ class PackagesGroongaOrgPackageTask < PackageTask
     end
   end
 
+  def create_htaccess(target_namespace)
+  end
+
   def release(target_namespace)
     base_dir = __send__("#{target_namespace}_dir")
     repositories_dir = "#{base_dir}/repositories"
@@ -253,6 +256,12 @@ class PackagesGroongaOrgPackageTask < PackageTask
             download_packages(target_namespace) if enabled
           end
           tasks << "#{target_namespace}:download"
+
+          desc "Make .htaccess for #{target_namespace} packages"
+          task :create_htaccess do
+            create_htaccess(target_namespace) if enabled
+          end
+          tasks << "#{target_namespace}:create_htaccess"
         end
 
         desc "Release #{target_namespace} packages"

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -212,7 +212,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
     end
   end
 
-  def create_htaccess(target_namespace)
+  def prepare(target_namespace)
   end
 
   def release(target_namespace)
@@ -246,13 +246,13 @@ class PackagesGroongaOrgPackageTask < PackageTask
             download_packages(target_namespace) if enabled
           end
           tasks << "#{target_namespace}:download"
-
-          desc "Make .htaccess for #{target_namespace} packages"
-          task :create_htaccess do
-            create_htaccess(target_namespace) if enabled
-          end
-          tasks << "#{target_namespace}:create_htaccess"
         end
+        
+        desc "Prepare for #{target_namespace} packages"
+        task :prepare do
+          prepare(target_namespace) if enabled
+        end
+        tasks << "#{target_namespace}:prepare"
 
         desc "Release #{target_namespace} packages"
         task :release do

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -180,7 +180,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
     htaccess_path = "#{repositories_dir}/.htaccess"
 
     if (target_namespace == :windows)
-      htaccesss_value = "RewriteRule groonga-((1[2-9]|[2-9][0-9])[\\d\\.]+?)-.+?-vs(?!.*(2012|2013|2015|2017)).+?\\.zip"\
+      htaccesss_value = "RewriteRule groonga-((1[2-9]|[2-9][0-9])[\\d\\.]+?)-.+?-vs(?!(2012|2013|2015|2017)).+?\\.zip"\
                         " #{github_releases_base_url}/v$1/$0\n"
       File.write(htaccess_path, htaccesss_value, mode: "w")
       chmod(0604, htaccess_path)

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -175,19 +175,32 @@ class PackagesGroongaOrgPackageTask < PackageTask
     mkdir_p(repositories_dir)
     download_dir = "#{base_dir}/tmp/downloads/#{@version}"
     mkdir_p(download_dir)
+    
+    github_releases_base_url = "https://github.com/groonga/groonga/releases/download"
+    htaccess_path = "#{repositories_dir}/.htaccess"
+
+    if (target_namespace == :windows)
+      htaccesss_value = "RewriteRule groonga-((1[2-9]|[2-9][0-9])[\\d\\.]+?)-.+?-vs(?!.*(2012|2013|2015|2017)).+?\\.zip"\
+                        " #{github_releases_base_url}/v$1/$0\n"
+      File.write(htaccess_path, htaccesss_value, mode: "w")
+      chmod(0604, htaccess_path)
+    end
+
     __send__("#{target_namespace}_targets").each do |target|
       branch = ENV["BRANCH"]
-      if branch
-        artifact_name = github_actions_artifact_name(target_namespace, target)
-        url = detect_built_package_url_github_actions(target_namespace,
-                                                      target,
-                                                      branch,
-                                                      artifact_name)
-        download_path = "#{download_dir}/#{artifact_name}.zip"
-        archive = download(url, download_path)
-      else
-        url = built_package_url(target_namespace, target)
-        archive = download(url, download_dir)
+      unless target_namespace == :windows
+        if branch
+          artifact_name = github_actions_artifact_name(target_namespace, target)
+          url = detect_built_package_url_github_actions(target_namespace,
+                                                        target,
+                                                        branch,
+                                                        artifact_name)
+          download_path = "#{download_dir}/#{artifact_name}.zip"
+          archive = download(url, download_path)
+        else
+          url = built_package_url(target_namespace, target)
+          archive = download(url, download_dir)
+        end
       end
       case target_namespace
       when :apt, :yum
@@ -202,12 +215,9 @@ class PackagesGroongaOrgPackageTask < PackageTask
           end
         end
       when :windows
-        cd(repositories_dir) do
-          cp(archive, ".")
-          archive_base_name = File.basename(archive)
-          latest_link_base_name = archive_base_name.gsub(@version, "latest")
-          ln_sf(archive_base_name, latest_link_base_name)
-        end
+        latest_link_base_name = target.gsub(@version, "latest")
+        htaccesss_value = "RewriteRule #{latest_link_base_name} #{github_releases_base_url}/v#{@version}/#{target}\n"
+        File.write(htaccess_path, htaccesss_value, mode: "a+")
       end
     end
   end

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -180,7 +180,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
     htaccess_path = "#{repositories_dir}/.htaccess"
 
     if (target_namespace == :windows)
-      htaccesss_value = "RewriteRule groonga-((1[2-9]|[2-9][0-9])[\\d\\.]+?)-.+?-vs(?!(2012|2013|2015|2017)).+?\\.zip"\
+      htaccesss_value = "RewriteRule groonga-((1[2-9]|[2-9][0-9])[\\d\\.]+?)-.+?-vs(?!.*(2012|2013|2015|2017)).+?\\.zip"\
                         " #{github_releases_base_url}/v$1/$0\n"
       File.write(htaccess_path, htaccesss_value, mode: "w")
       chmod(0604, htaccess_path)


### PR DESCRIPTION
Changed to redirect to GitHub Releases by `.htaccess` to download latest Groonga.

Changes

* Skip downloading Groonga packages to local machine when target is Windows.
* Create a new task named `prepare`.
  * This task creates `.htaccess` for redirecting when target is Windows.

Created `.htaccess` is like below.

```
Redirect /windows/groonga/groonga-latest-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x64-vs2022.zip
Redirect /windows/groonga/groonga-latest-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x64-vs2019.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x64-vs2019-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x86-vs2019.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x86-vs2019.zip
Redirect /windows/groonga/groonga-latest-x86-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v12.0.9/groonga-12.0.9-x86-vs2019-with-vcruntime.zip
```