### PR TITLE
ci linux: use ubuntu-22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
             configure-options: >-
               CC=clang
               CXX=clang++
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -175,7 +175,7 @@ jobs:
             id: cmake-clang
             cc: clang
             cxx: clang++
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -269,7 +269,7 @@ jobs:
             id: cmake-gcc
           - label: "CMake: Clang"
             id: cmake-clang
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   source:
     name: Source
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Because Apache Arrow requires C++17.