### PR TITLE
packages: download latest source archive in dist task

### DIFF
--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -42,6 +42,8 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def define_archive_task
+    source_archive_url = built_package_url(nil, @archive_base_name)
+    download(source_archive_url, "..")
     file @original_archive_name do
       File.symlink("../#{@original_archive_name}",
                    @original_archive_name)

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -42,9 +42,11 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def define_archive_task
-    file @original_archive_name do
+    file "../#{@original_archive_name}" do
       source_archive_url = built_package_url(nil, @archive_base_name)
       download(source_archive_url, "..")
+    end
+    file @original_archive_name => "../#{@original_archive_name}" do
       File.symlink("../#{@original_archive_name}",
                    @original_archive_name)
     end

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -42,9 +42,9 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def define_archive_task
-    source_archive_url = built_package_url(nil, @archive_base_name)
-    download(source_archive_url, "..")
     file @original_archive_name do
+      source_archive_url = built_package_url(nil, @archive_base_name)
+      download(source_archive_url, "..")
       File.symlink("../#{@original_archive_name}",
                    @original_archive_name)
     end

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -25,7 +25,6 @@ class PackagesGroongaOrgPackageTask < PackageTask
 
   def define
     super
-    define_source_task
     define_windows_task
     define_release_tasks
     define_ubuntu_tasks
@@ -38,14 +37,6 @@ class PackagesGroongaOrgPackageTask < PackageTask
       Time.parse(release_time_env).utc
     else
       Time.now.utc
-    end
-  end
-
-  def define_source_task
-    desc "Download the latest source archive"
-    task :source do
-      source_archive_url = built_package_url(nil, @archive_base_name)
-      download(source_archive_url, "..")
     end
   end
 

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -25,6 +25,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
 
   def define
     super
+    define_source_task
     define_windows_task
     define_release_tasks
     define_ubuntu_tasks
@@ -37,6 +38,14 @@ class PackagesGroongaOrgPackageTask < PackageTask
       Time.parse(release_time_env).utc
     else
       Time.now.utc
+    end
+  end
+
+  def define_source_task
+    desc "Download the latest source archive"
+    task :source do
+      source_archive_url = built_package_url(nil, @archive_base_name)
+      download(source_archive_url, "..")
     end
   end
 


### PR DESCRIPTION
By this change, we can download the latest source archive from the github release page into the top of the repository by executing "cd packages && rake dist".