### PR TITLE
packages: fix a typo of an environment variable

### DIFF
--- a/packages/launchpad-helper.rb
+++ b/packages/launchpad-helper.rb
@@ -45,7 +45,7 @@ module LaunchpadHelper
   end
 
   def dput_configuration_name
-    env_value("DPUT_CONFIGUARATION_NAME")
+    env_value("DPUT_CONFIGURATION_NAME")
   end
 
   def dput_incoming


### PR DESCRIPTION
`DPUT_CONFIGUARATION_NAME` seems a typo of `DPUT_CONFIGURATION_NAME`.