### PR TITLE
ci: use Sphinx 5.x instead of Sphinx 6.x

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           sudo pip3 install -U \
             Jinja2 \
-            Sphinx \
+            "Sphinx==5.3.0" \
             pydata_sphinx_theme
       - name: Install Bundler
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,7 +36,7 @@ jobs:
           sudo pip3 install -U \
             Jinja2 \
             Pygments \
-            Sphinx \
+            "Sphinx==5.3.0" \
             pydata_sphinx_theme
       - name: Clone dependencies
         run: |


### PR DESCRIPTION
Because pydata-sphinx-theme occurs problem of https://github.com/pydata/pydata-sphinx-theme/issues/1094 when we use Sphinx 6.0.0.

The cause of this problem is the following change of Sphinx.

* https://github.com/sphinx-doc/sphinx/issues/11062
* https://github.com/sphinx-doc/sphinx/pull/11063

Therefore we use Sphinx 5.x until pydata-sphinx-theme resolve this problem.