### PR TITLE
doc: use "analytics" instead of "google_analytics_id"

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -150,7 +150,9 @@ html_theme_options = {
     "version-switcher.html",
   ],
   "use_edit_page_button": use_edit_page_button,
-  "google_analytics_id": "UA-7532323-1",
+  "analytics": {
+    "google_analytics_id": "UA-7532323-1"
+  },
   "show_nav_level": 2,
 }
 


### PR DESCRIPTION
`google_analytics_id` is deprecated in pydata-sphinx-theme after 0.12. Use `analytics` instead.

Ref: https://github.com/pydata/pydata-sphinx-theme/issues/903