### PR TITLE
doc: add bootstrap.js/css into files.am

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -4291,9 +4291,11 @@ html_files_relative_from_locale_dir = \
 	html/_static/minus.png \
 	html/_static/plus.png \
 	html/_static/pygments.css \
+	html/_static/scripts/bootstrap.js \
 	html/_static/scripts/pydata-sphinx-theme.js \
 	html/_static/searchtools.js \
 	html/_static/sphinx_highlight.js \
+	html/_static/styles/bootstrap.css \
 	html/_static/styles/pydata-sphinx-theme.css \
 	html/_static/styles/theme.css \
 	html/_static/switcher.json \


### PR DESCRIPTION
`bootstrap.js` and `bootstrap.css` are necessary to the latest document site.
They are copied (moved) into result files of `make update-document` by adding them into files.am.

The reason why we need to add `bootstrap.js` and `bootstrap.css`  is because `pydata-sphinx-theme` split bootstrap and theme styling.

https://github.com/pydata/pydata-sphinx-theme/pull/994