### PR TITLE
packages: correct PackagesGroongaOrgPackageTask to reflect the modification of Apache Arrow 11.0.0

### DIFF
--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -1,5 +1,5 @@
 # Copyright(C) 2014-2021  Sutou Kouhei <kou@clear-code.com>
-# Copyright(C) 2020-2021  Horimoto Yasuhiro <horimoto@clear-code.com>
+# Copyright(C) 2020-2023  Horimoto Yasuhiro <horimoto@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,11 +15,13 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+require_relative "../vendor/apache-arrow-source/dev/tasks/linux-packages/helper"
 require_relative "../vendor/apache-arrow-source/dev/tasks/linux-packages/package-task"
 require_relative "launchpad-helper"
 require_relative "repository-helper"
 
 class PackagesGroongaOrgPackageTask < PackageTask
+  include Helper::ApacheArrow
   include LaunchpadHelper
   include RepositoryHelper
 


### PR DESCRIPTION
The Rakefile of packages.groonga.org use `#latest_commit_time` at https://github.com/groonga/packages.groonga.org/blob/master/groonga-release/Rakefile#L9.
However `#latest_commit_time` is moved to dev/tasks/linux-packages/helper.rb from dev/tasks/linux-packages/package-task.rb in https://github.com/apache/arrow/commit/f82501e763ff48af610077f9525ae83cc3ab2e95.

Therefore we include `Helper::ApacheArrow` module.