### PR TITLE
NormalizerNFKC:  add `unify_katakana_z_sounds` option

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -44,6 +44,7 @@ typedef struct {
   grn_bool unify_middle_dot;
   grn_bool unify_katakana_v_sounds;
   grn_bool unify_katakana_bu_sound;
+  grn_bool unify_katakana_z_sounds;
   grn_bool unify_katakana_wo_sound;
   grn_bool unify_katakana_di_sound;
   grn_bool unify_katakana_g_sounds;

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -62,6 +62,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->unify_middle_dot = GRN_FALSE;
   options->unify_katakana_v_sounds = GRN_FALSE;
   options->unify_katakana_bu_sound = GRN_FALSE;
+  options->unify_katakana_z_sounds = GRN_FALSE;
   options->unify_katakana_wo_sound = GRN_FALSE;
   options->unify_katakana_di_sound = GRN_FALSE;
   options->unify_katakana_g_sounds = GRN_FALSE;
@@ -195,6 +196,12 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->unify_katakana_bu_sound);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_katakana_z_sounds")) {
+      options->unify_katakana_z_sounds =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_katakana_z_sounds);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_katakana_wo_sound")) {
       options->unify_katakana_wo_sound =
         grn_vector_get_element_bool(ctx,

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1477,6 +1477,83 @@ grn_nfkc_normalize_unify_katakana_bu_sound(grn_ctx *ctx,
 }
 
 static const unsigned char *
+grn_nfkc_normalize_unify_katakana_z_sounds(grn_ctx *ctx,
+                                           const unsigned char *start,
+                                           const unsigned char *current,
+                                           const unsigned char *end,
+                                           size_t *n_used_bytes,
+                                           size_t *n_used_characters,
+                                           unsigned char *unified_buffer,
+                                           size_t *n_unified_bytes,
+                                           size_t *n_unified_characters,
+                                           void *user_data)
+{
+  size_t char_length;
+
+  char_length = (size_t)grn_charlen_(ctx, current, end, GRN_ENC_UTF8);
+
+  *n_used_bytes = char_length;
+  *n_used_characters = 1;
+
+  if ((char_length == 3) &&
+      /* U+30C5 KATAKANA LETTER DU */
+      ((current[0] == 0xe3 && current[1] == 0x83 && current[2] == 0x85) ||
+      /* U+30BA KATAKANA LETTER ZU */
+       (current[0] == 0xe3 && current[1] == 0x82 && current[2] == 0xba))) {
+    const unsigned char *next = current + char_length;
+    size_t next_char_length;
+
+    next_char_length = (size_t)grn_charlen_(ctx, next, end, GRN_ENC_UTF8);
+    if (next_char_length == 3 &&
+        next[0] == 0xe3 &&
+        next[1] == 0x82) {
+      if (next[2] == 0xa1) { /* U+30A1 KATAKANA LETTER SMALL A */
+        /* U+30B6 KATAKANA LETTER ZA */
+        unified_buffer[(*n_unified_bytes)++] = current[0];
+        unified_buffer[(*n_unified_bytes)++] = 0x82;
+        unified_buffer[(*n_unified_bytes)++] = 0xb6;
+        (*n_unified_characters)++;
+        (*n_used_bytes) += next_char_length;
+        (*n_used_characters)++;
+        return unified_buffer;
+      } else if (next[2] == 0xa3) { /* U+30A3 KATAKANA LETTER SMALL I */
+        /* U+30B8 KATAKANA LETTER ZI */
+        unified_buffer[(*n_unified_bytes)++] = current[0];
+        unified_buffer[(*n_unified_bytes)++] = 0x82;
+        unified_buffer[(*n_unified_bytes)++] = 0xb8;
+        (*n_unified_characters)++;
+        (*n_used_bytes) += next_char_length;
+        (*n_used_characters)++;
+        return unified_buffer;
+      } else if (next[2] == 0xa7) { /* U+30A7 KATAKANA LETTER SMALL E */
+        /* U+30BC KATAKANA LETTER ZE */
+        unified_buffer[(*n_unified_bytes)++] = current[0];
+        unified_buffer[(*n_unified_bytes)++] = 0x82;
+        unified_buffer[(*n_unified_bytes)++] = 0xbC;
+        (*n_unified_characters)++;
+        (*n_used_bytes) += next_char_length;
+        (*n_used_characters)++;
+        return unified_buffer;
+      } else if (next[2] == 0xa9) { /* U+30A8 KATAKANA LETTER SMALL O */
+        /* U+30BE KATAKANA LETTER ZO */
+        unified_buffer[(*n_unified_bytes)++] = current[0];
+        unified_buffer[(*n_unified_bytes)++] = 0x82;
+        unified_buffer[(*n_unified_bytes)++] = 0xbe;
+        (*n_unified_characters)++;
+        (*n_used_bytes) += next_char_length;
+        (*n_used_characters)++;
+        return unified_buffer;
+      }
+    }
+  }
+
+  *n_unified_bytes = *n_used_bytes;
+  *n_unified_characters = *n_used_characters;
+
+  return current;
+}
+
+static const unsigned char *
 grn_nfkc_normalize_unify_katakana_wo_sound(grn_ctx *ctx,
                                            const unsigned char *start,
                                            const unsigned char *current,
@@ -1821,6 +1898,7 @@ grn_nfkc_normalize_unify(grn_ctx *ctx,
         data->options->unify_middle_dot ||
         data->options->unify_katakana_v_sounds ||
         data->options->unify_katakana_bu_sound ||
+        data->options->unify_katakana_z_sounds ||
         data->options->unify_katakana_wo_sound ||
         data->options->unify_katakana_di_sound ||
         data->options->unify_katakana_g_sounds ||
@@ -1885,6 +1963,40 @@ grn_nfkc_normalize_unify(grn_ctx *ctx,
                                       grn_nfkc_normalize_unify_katakana_bu_sound,
                                       NULL,
                                       "[unify][katakana-bu-sound]");
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    need_swap = GRN_TRUE;
+  }
+
+  if (data->options->unify_katakana_z_sounds) {
+    if (need_swap) {
+      grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);
+      grn_nfkc_normalize_context_rewind(ctx, &unify);
+    }
+    grn_nfkc_normalize_unify_stateful(ctx,
+                                      data,
+                                      &unify,
+                                      grn_nfkc_normalize_unify_katakana_z_sounds,
+                                      NULL,
+                                      "[unify][katakana-z-sounds]");
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    need_swap = GRN_TRUE;
+  }
+
+  if (data->options->unify_katakana_wo_sound) {
+    if (need_swap) {
+      grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);
+      grn_nfkc_normalize_context_rewind(ctx, &unify);
+    }
+    grn_nfkc_normalize_unify_stateful(ctx,
+                                      data,
+                                      &unify,
+                                      grn_nfkc_normalize_unify_katakana_wo_sound,
+                                      NULL,
+                                      "[unify][katakana-wo-sound]");
     if (ctx->rc != GRN_SUCCESS) {
       goto exit;
     }

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -2003,23 +2003,6 @@ grn_nfkc_normalize_unify(grn_ctx *ctx,
     need_swap = GRN_TRUE;
   }
 
-  if (data->options->unify_katakana_wo_sound) {
-    if (need_swap) {
-      grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);
-      grn_nfkc_normalize_context_rewind(ctx, &unify);
-    }
-    grn_nfkc_normalize_unify_stateful(ctx,
-                                      data,
-                                      &unify,
-                                      grn_nfkc_normalize_unify_katakana_wo_sound,
-                                      NULL,
-                                      "[unify][katakana-wo-sound]");
-    if (ctx->rc != GRN_SUCCESS) {
-      goto exit;
-    }
-    need_swap = GRN_TRUE;
-  }
-
   if (data->options->unify_katakana_di_sound) {
     if (need_swap) {
       grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1495,11 +1495,11 @@ grn_nfkc_normalize_unify_katakana_z_sounds(grn_ctx *ctx,
   *n_used_bytes = char_length;
   *n_used_characters = 1;
 
-  if ((char_length == 3) &&
-      /* U+30C5 KATAKANA LETTER DU */
-      ((current[0] == 0xe3 && current[1] == 0x83 && current[2] == 0x85) ||
+  if (char_length == 3 &&
       /* U+30BA KATAKANA LETTER ZU */
-       (current[0] == 0xe3 && current[1] == 0x82 && current[2] == 0xba))) {
+      current[0] == 0xe3 && 
+      current[1] == 0x82 && 
+      current[2] == 0xba) {
     const unsigned char *next = current + char_length;
     size_t next_char_length;
 

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ""   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,13 +6,8 @@ normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                 
     0.0
   ],
   {
-    "normalized": "ザジズゼゾザジヅゼゾ",
+    "normalized": "ザジズゼゾ",
     "types": [
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
       "katakana",
       "katakana",
       "katakana",
@@ -34,21 +29,6 @@ normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                 
       0,
       6,
       0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
-      0,
-      3,
-      0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
       0
     ],
     "offsets": [
@@ -56,12 +36,7 @@ normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                 
       6,
       12,
       15,
-      21,
-      27,
-      33,
-      39,
-      42,
-      48
+      21
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.expected
@@ -1,0 +1,67 @@
+normalize   'NormalizerNFKC100("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ""   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾザジヅゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21,
+      27,
+      33,
+      39,
+      42,
+      48
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_katakana_z_sounds", true, \
+                     "report_source_offset", true)' \
+  "ズァズィズズェズォヅァヅィヅヅェヅォ"" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
+  "ズァズィズズェズォ" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC100("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォヅァヅィヅヅェヅォ"" \
+  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ""   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ""   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ""   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,13 +6,8 @@ normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                 
     0.0
   ],
   {
-    "normalized": "ザジズゼゾザジヅゼゾ",
+    "normalized": "ザジズゼゾ",
     "types": [
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
       "katakana",
       "katakana",
       "katakana",
@@ -34,21 +29,6 @@ normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                 
       0,
       6,
       0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
-      0,
-      3,
-      0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
       0
     ],
     "offsets": [
@@ -56,12 +36,7 @@ normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                 
       6,
       12,
       15,
-      21,
-      27,
-      33,
-      39,
-      42,
-      48
+      21
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.expected
@@ -1,0 +1,67 @@
+normalize   'NormalizerNFKC121("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ""   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾザジヅゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21,
+      27,
+      33,
+      39,
+      42,
+      48
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC121("unify_katakana_z_sounds", true, \
+                     "report_source_offset", true)' \
+  "ズァズィズズェズォヅァヅィヅヅェヅォ"" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC121("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォヅァヅィヅヅェヅォ"" \
+  "ズァズィズズェズォ"" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC121("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォ"" \
+  "ズァズィズズェズォ" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,13 +6,8 @@ normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                 
     0.0
   ],
   {
-    "normalized": "ザジズゼゾザジヅゼゾ",
+    "normalized": "ザジズゼゾ",
     "types": [
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
       "katakana",
       "katakana",
       "katakana",
@@ -34,21 +29,6 @@ normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                 
       0,
       6,
       0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
-      0,
-      3,
-      0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
       0
     ],
     "offsets": [
@@ -56,12 +36,7 @@ normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                 
       6,
       12,
       15,
-      21,
-      27,
-      33,
-      39,
-      42,
-      48
+      21
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.expected
@@ -1,0 +1,67 @@
+normalize   'NormalizerNFKC130("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾザジヅゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21,
+      27,
+      33,
+      39,
+      42,
+      48
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC130("unify_katakana_z_sounds", true, \
+                     "report_source_offset", true)' \
+  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC130("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
+  "ズァズィズズェズォ" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォ"   WITH_CHECKS|WITH_TYPES
 [
   [
     0,
@@ -6,13 +6,8 @@ normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                 
     0.0
   ],
   {
-    "normalized": "ザジズゼゾザジヅゼゾ",
+    "normalized": "ザジズゼゾ",
     "types": [
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
-      "katakana",
       "katakana",
       "katakana",
       "katakana",
@@ -34,21 +29,6 @@ normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                 
       0,
       6,
       0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
-      0,
-      3,
-      0,
-      0,
-      6,
-      0,
-      0,
-      6,
-      0,
       0
     ],
     "offsets": [
@@ -56,12 +36,7 @@ normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                 
       6,
       12,
       15,
-      21,
-      27,
-      33,
-      39,
-      42,
-      48
+      21
     ]
   }
 ]

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.expected
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.expected
@@ -1,0 +1,67 @@
+normalize   'NormalizerNFKC150("unify_katakana_z_sounds", true,                      "report_source_offset", true)'   "ズァズィズズェズォヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾザジヅゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21,
+      27,
+      33,
+      39,
+      42,
+      48
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.test
@@ -1,5 +1,5 @@
 normalize \
   'NormalizerNFKC150("unify_katakana_z_sounds", true, \
                      "report_source_offset", true)' \
-  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
+  "ズァズィズズェズォ" \
   WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.test
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_z_sounds.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC150("unify_katakana_z_sounds", true, \
+                     "report_source_offset", true)' \
+  "ズァズィズズェズォヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES


### PR DESCRIPTION
When `unify_katakana_z_sounds` is specified, `NormalizerNFKC*` normalize characters as below.

ズァ -> ザ
ズィ -> ジ
ズェ -> ゼ
ズォ -> ゾ


Usage: 

```
normalize \
  'NormalizerNFKC130("unify_katakana_z_sounds", true, \
                     "report_source_offset", true)' \
  "ズァズィズェズォ" \
  WITH_CHECKS|WITH_TYPES
```