### PR TITLE
NormalizerNFKC: add `unify_katakana_du_sound` option

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -44,6 +44,7 @@ typedef struct {
   grn_bool unify_middle_dot;
   grn_bool unify_katakana_v_sounds;
   grn_bool unify_katakana_bu_sound;
+  grn_bool unify_katakana_du_sound;
   grn_bool unify_katakana_zu_small_sounds;
   grn_bool unify_katakana_du_small_sounds;
   grn_bool unify_katakana_wo_sound;

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -62,6 +62,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->unify_middle_dot = GRN_FALSE;
   options->unify_katakana_v_sounds = GRN_FALSE;
   options->unify_katakana_bu_sound = GRN_FALSE;
+  options->unify_katakana_du_sound = GRN_FALSE;
   options->unify_katakana_zu_small_sounds = GRN_FALSE;
   options->unify_katakana_du_small_sounds = GRN_FALSE;
   options->unify_katakana_wo_sound = GRN_FALSE;
@@ -197,6 +198,12 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->unify_katakana_bu_sound);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_katakana_du_sound")) {
+      options->unify_katakana_du_sound =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_katakana_du_sound);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_katakana_zu_small_sounds")) {
       options->unify_katakana_zu_small_sounds =
         grn_vector_get_element_bool(ctx,

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1477,6 +1477,44 @@ grn_nfkc_normalize_unify_katakana_bu_sound(grn_ctx *ctx,
 }
 
 static const unsigned char *
+grn_nfkc_normalize_unify_katakana_du_sound(grn_ctx *ctx,
+                                           const unsigned char *start,
+                                           const unsigned char *current,
+                                           const unsigned char *end,
+                                           size_t *n_used_bytes,
+                                           size_t *n_used_characters,
+                                           unsigned char *unified_buffer,
+                                           size_t *n_unified_bytes,
+                                           size_t *n_unified_characters,
+                                           void *user_data)
+{
+  size_t char_length;
+
+  char_length = (size_t)grn_charlen_(ctx, current, end, GRN_ENC_UTF8);
+
+  *n_used_bytes = char_length;
+  *n_used_characters = 1;
+
+  if (char_length == 3 &&
+      /* U+30C5 KATAKANA LETTER DU */
+      current[0] == 0xe3 &&
+      current[1] == 0x83 &&
+      current[2] == 0x85) {
+    /* U+30BA KATAKANA LETTER ZU */
+    unified_buffer[(*n_unified_bytes)++] = current[0];
+    unified_buffer[(*n_unified_bytes)++] = 0x82;
+    unified_buffer[(*n_unified_bytes)++] = 0xba;
+    (*n_unified_characters)++;
+    return unified_buffer;
+  }
+
+  *n_unified_bytes = *n_used_bytes;
+  *n_unified_characters = *n_used_characters;
+
+  return current;
+}
+
+static const unsigned char *
 grn_nfkc_normalize_unify_katakana_zu_small_sounds(grn_ctx *ctx,
                                                   const unsigned char *start,
                                                   const unsigned char *current,
@@ -1975,6 +2013,7 @@ grn_nfkc_normalize_unify(grn_ctx *ctx,
         data->options->unify_middle_dot ||
         data->options->unify_katakana_v_sounds ||
         data->options->unify_katakana_bu_sound ||
+        data->options->unify_katakana_du_sound ||
         data->options->unify_katakana_zu_small_sounds ||
         data->options->unify_katakana_du_small_sounds ||
         data->options->unify_katakana_wo_sound ||
@@ -2041,6 +2080,23 @@ grn_nfkc_normalize_unify(grn_ctx *ctx,
                                       grn_nfkc_normalize_unify_katakana_bu_sound,
                                       NULL,
                                       "[unify][katakana-bu-sound]");
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    need_swap = GRN_TRUE;
+  }
+
+  if (data->options->unify_katakana_du_sound) {
+    if (need_swap) {
+      grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);
+      grn_nfkc_normalize_context_rewind(ctx, &unify);
+    }
+    grn_nfkc_normalize_unify_stateful(ctx,
+                                      data,
+                                      &unify,
+                                      grn_nfkc_normalize_unify_katakana_du_sound,
+                                      NULL,
+                                      "[unify][katakana-du-sound]");
     if (ctx->rc != GRN_SUCCESS) {
       goto exit;
     }

--- a/test/command/suite/normalizers/nfkc100/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
+++ b/test/command/suite/normalizers/nfkc100/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC100("unify_katakana_du_sound", true,                      "unify_katakana_zu_small_sounds", true,                      "report_source_offset", true)'   "ヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/mix/unify_katakana_du_sound_and_zu_small_sounds.test
+++ b/test/command/suite/normalizers/nfkc100/mix/unify_katakana_du_sound_and_zu_small_sounds.test
@@ -1,0 +1,6 @@
+normalize \
+  'NormalizerNFKC100("unify_katakana_du_sound", true, \
+                     "unify_katakana_zu_small_sounds", true, \
+                     "report_source_offset", true)' \
+  "ヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_du_sound.expected
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_du_sound.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC100("unify_katakana_du_sound", true,                      "report_source_offset", true)'   "ヅ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ズ",
+    "types": [
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc100/unify_katakana_du_sound.test
+++ b/test/command/suite/normalizers/nfkc100/unify_katakana_du_sound.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC100("unify_katakana_du_sound", true, \
+                     "report_source_offset", true)' \
+  "ヅ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc121/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
+++ b/test/command/suite/normalizers/nfkc121/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC121("unify_katakana_du_sound", true,                      "unify_katakana_zu_small_sounds", true,                      "report_source_offset", true)'   "ヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc121/mix/unify_katakana_du_sound_and_zu_small_sounds.test
+++ b/test/command/suite/normalizers/nfkc121/mix/unify_katakana_du_sound_and_zu_small_sounds.test
@@ -1,0 +1,6 @@
+normalize \
+  'NormalizerNFKC121("unify_katakana_du_sound", true, \
+                     "unify_katakana_zu_small_sounds", true, \
+                     "report_source_offset", true)' \
+  "ヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_du_sound.expected
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_du_sound.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC121("unify_katakana_du_sound", true,                      "report_source_offset", true)'   "ヅ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ズ",
+    "types": [
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc121/unify_katakana_du_sound.test
+++ b/test/command/suite/normalizers/nfkc121/unify_katakana_du_sound.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC121("unify_katakana_du_sound", true, \
+                     "report_source_offset", true)' \
+  "ヅ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc130/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
+++ b/test/command/suite/normalizers/nfkc130/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC130("unify_katakana_du_sound", true,                      "unify_katakana_zu_small_sounds", true,                      "report_source_offset", true)'   "ヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc130/mix/unify_katakana_du_sound_and_zu_small_sounds.test
+++ b/test/command/suite/normalizers/nfkc130/mix/unify_katakana_du_sound_and_zu_small_sounds.test
@@ -1,0 +1,6 @@
+normalize \
+  'NormalizerNFKC130("unify_katakana_du_sound", true, \
+                     "unify_katakana_zu_small_sounds", true, \
+                     "report_source_offset", true)' \
+  "ヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_du_sound.expected
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_du_sound.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC130("unify_katakana_du_sound", true,                      "report_source_offset", true)'   "ヅ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ズ",
+    "types": [
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc130/unify_katakana_du_sound.test
+++ b/test/command/suite/normalizers/nfkc130/unify_katakana_du_sound.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC130("unify_katakana_du_sound", true, \
+                     "report_source_offset", true)' \
+  "ヅ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc150/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
+++ b/test/command/suite/normalizers/nfkc150/mix/unify_katakana_du_sound_and_zu_small_sounds.expected
@@ -1,0 +1,42 @@
+normalize   'NormalizerNFKC150("unify_katakana_du_sound", true,                      "unify_katakana_zu_small_sounds", true,                      "report_source_offset", true)'   "ヅァヅィヅヅェヅォ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana"
+    ],
+    "checks": [
+      6,
+      0,
+      0,
+      6,
+      0,
+      0,
+      3,
+      0,
+      0,
+      6,
+      0,
+      0,
+      6,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      6,
+      12,
+      15,
+      21
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc150/mix/unify_katakana_du_sound_and_zu_small_sounds.test
+++ b/test/command/suite/normalizers/nfkc150/mix/unify_katakana_du_sound_and_zu_small_sounds.test
@@ -1,0 +1,6 @@
+normalize \
+  'NormalizerNFKC150("unify_katakana_du_sound", true, \
+                     "unify_katakana_zu_small_sounds", true, \
+                     "report_source_offset", true)' \
+  "ヅァヅィヅヅェヅォ" \
+  WITH_CHECKS|WITH_TYPES

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_du_sound.expected
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_du_sound.expected
@@ -1,0 +1,22 @@
+normalize   'NormalizerNFKC150("unify_katakana_du_sound", true,                      "report_source_offset", true)'   "ヅ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ズ",
+    "types": [
+      "katakana"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc150/unify_katakana_du_sound.test
+++ b/test/command/suite/normalizers/nfkc150/unify_katakana_du_sound.test
@@ -1,0 +1,5 @@
+normalize \
+  'NormalizerNFKC150("unify_katakana_du_sound", true, \
+                     "report_source_offset", true)' \
+  "ヅ" \
+  WITH_CHECKS|WITH_TYPES


### PR DESCRIPTION
When `unify_katakana_du_sound` is specified, `NormalizerNFKC*` normalize characters as below.

ヅ -> ズ

```
normalize \
  'NormalizerNFKC150("unify_katakana_du_sound", true, \
                     "report_source_offset", true)' \
  "ヅ" \
  WITH_CHECKS|WITH_TYPES
```

We can use `unify_katakana_du_sound` with `unify_katakana_zu_small_sounds`.

```
normalize \
  'NormalizerNFKC150("unify_katakana_du_sound", true, \
                     "unify_katakana_zu_small_sounds", true, \
                     "report_source_offset", true)' \
  "ヅァヅィヅヅェヅォ" \
  WITH_CHECKS|WITH_TYPES
```

The normalized value of `ヅァヅィヅヅェヅォ` is `ザジズゼゾ`.
Considering the case of `ヅァ`,  `unify_katakana_du_sound` normalizes `ヅァ` to `ズァ`, and `unify_katakana_zu_small_sounds` normalizes that `ズァ` to `ザ`.