### PR TITLE
near-phrase: make sort order stable

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -9392,7 +9392,9 @@ token_compare(const void *a, const void *b)
   const token_info *t1 = *((token_info **)a), *t2 = *((token_info **)b);
   if (t1->phrase_group_id == t2->phrase_group_id) {
     if (t1->phrase_id == t2->phrase_id) {
-      return t1->size - t2->size;
+      return t1->size == t2->size
+             ? t1->offset - t2->offset
+             : t1->size - t2->size;
     } else {
       return t1->phrase_id - t2->phrase_id;
     }


### PR DESCRIPTION
This change fixes a bug that `additional_last_interval` don't work correctly in some environments.

e.g. https://github.com/groonga/groonga/actions/runs/4280133750/jobs/7451550455#step:25:294

In the case above, `def$` of `'*NPP10,2,,11"(abc bcd) (def$)"'` is tokenized to `de` and `ef`, and `must_last` of `de` is false and `ef` is true.
When quick-sorting token_infos, they were compared with token size, and the sizes of `de` and `ef` were same, so the order of `de` and `ef` was undefined, that means sort order depended on environment.
When `ef` is the last of token_infos, `data->bt->n_must_lasts` in  `grn_ii_select_cursor_next_find_near` is `1` and work correctly.
On the other hand,  when `de` is the last of token_infos, `data->bt->n_must_lasts` in  `grn_ii_select_cursor_next_find_near` is `0` even actually it contains the last phrase ( specified  `$` suffix ) and don't work correctly.