### PR TITLE
packages: expand the maximum value of per page of the list artifacts

### DIFF
--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -154,7 +154,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
                                                   workflow_file_name,
                                                   branch: branch)
     workflow_runs_response.workflow_runs.each do |workflow_run|
-      artifacts_response = client.get(workflow_run.artifacts_url)
+      artifacts_response = client.get(workflow_run.artifacts_url, {per_page: 50})
       next if artifacts_response.total_count.zero?
 
       artifacts_response.artifacts.each do |artifact|

--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -154,7 +154,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
                                                   workflow_file_name,
                                                   branch: branch)
     workflow_runs_response.workflow_runs.each do |workflow_run|
-      artifacts_response = client.get(workflow_run.artifacts_url, {per_page: 50})
+      artifacts_response = client.get(workflow_run.artifacts_url, per_page: 50)
       next if artifacts_response.total_count.zero?
 
       artifacts_response.artifacts.each do |artifact|


### PR DESCRIPTION
The maximum value of per page of the list artifacts is 30 in default.
However, the number of packages of Mroonga is 35.
The number of per page of the list artifacts in default is not enough.