### PR TITLE
reference_acquire: remove surfeit a decrease of reference count

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -2472,7 +2472,6 @@ grn_db_command_processed(grn_ctx *ctx, grn_obj *db)
           grn_obj *object = grn_ctx_at(ctx, deferred_id);
           if (object) {
             grn_obj_unref(ctx, object);
-            grn_obj_unref(ctx, object);
           }
         }
         GRN_OBJ_FIN(ctx, &(deferred_unref->ids));


### PR DESCRIPTION
"grn_ctx_at" increase a reference count by one.
However, Groonga execute two "grn_obj_unref()" against a same object in this processing.
Therefore, reference count decrease one too many.