### PR TITLE
highlight: use more suitable name

### DIFF
--- a/include/groonga/highlighter.h
+++ b/include/groonga/highlighter.h
@@ -42,12 +42,12 @@ grn_highlighter_set_lexicon(grn_ctx *ctx,
 GRN_API grn_obj *
 grn_highlighter_get_lexicon(grn_ctx *ctx, grn_highlighter *highlighter);
 GRN_API grn_rc
-grn_highlighter_set_cycled_class_tag_mode(grn_ctx *ctx,
-                                          grn_highlighter *highlighter,
-                                          bool mode);
+grn_highlighter_set_sequential_class_tag_mode(grn_ctx *ctx,
+                                              grn_highlighter *highlighter,
+                                              bool mode);
 GRN_API bool
-grn_highlighter_get_cycled_class_tag_mode(grn_ctx *ctx,
-                                          grn_highlighter *highlighter);
+grn_highlighter_get_sequential_class_tag_mode(grn_ctx *ctx,
+                                              grn_highlighter *highlighter);
 GRN_API grn_rc
 grn_highlighter_set_default_open_tag(grn_ctx *ctx,
                                      grn_highlighter *highlighter,

--- a/lib/highlighter.c
+++ b/lib/highlighter.c
@@ -53,11 +53,11 @@ struct _grn_highlighter {
   bool need_prepared;
   grn_obj raw_keywords;
 
-  bool is_cycled_class_tag_mode;
+  bool is_sequential_class_tag_mode;
   struct {
     grn_obj open;
     grn_obj close;
-  } cycled_class_tag;
+  } sequential_class_tag;
 
   struct {
     grn_obj open;
@@ -112,9 +112,9 @@ grn_highlighter_open(grn_ctx *ctx)
   highlighter->need_prepared = true;
   GRN_TEXT_INIT(&(highlighter->raw_keywords), GRN_OBJ_VECTOR);
 
-  highlighter->is_cycled_class_tag_mode = false;
-  GRN_TEXT_INIT(&(highlighter->cycled_class_tag.open), 0);
-  GRN_TEXT_INIT(&(highlighter->cycled_class_tag.close), 0);
+  highlighter->is_sequential_class_tag_mode = false;
+  GRN_TEXT_INIT(&(highlighter->sequential_class_tag.open), 0);
+  GRN_TEXT_INIT(&(highlighter->sequential_class_tag.close), 0);
 
   GRN_TEXT_INIT(&(highlighter->default_tag.open), 0);
   grn_highlighter_set_default_open_tag(ctx,
@@ -182,8 +182,8 @@ grn_highlighter_close(grn_ctx *ctx, grn_highlighter *highlighter)
   GRN_OBJ_FIN(ctx, &(highlighter->default_tag.open));
   GRN_OBJ_FIN(ctx, &(highlighter->default_tag.close));
 
-  GRN_OBJ_FIN(ctx, &(highlighter->cycled_class_tag.open));
-  GRN_OBJ_FIN(ctx, &(highlighter->cycled_class_tag.close));
+  GRN_OBJ_FIN(ctx, &(highlighter->sequential_class_tag.open));
+  GRN_OBJ_FIN(ctx, &(highlighter->sequential_class_tag.close));
 
   GRN_OBJ_FIN(ctx, &(highlighter->raw_keywords));
   GRN_FREE(highlighter);
@@ -461,19 +461,19 @@ grn_highlighter_highlight_get_ith_tag(grn_ctx *ctx,
                                       const char **close_tag,
                                       size_t *close_tag_length)
 {
-  if (highlighter->is_cycled_class_tag_mode) {
+  if (highlighter->is_sequential_class_tag_mode) {
     size_t n_keywords = grn_vector_size(ctx, &(highlighter->raw_keywords));
     i = i % n_keywords;
-    GRN_BULK_REWIND(&(highlighter->cycled_class_tag.open));
+    GRN_BULK_REWIND(&(highlighter->sequential_class_tag.open));
     grn_text_printf(ctx,
-                    &(highlighter->cycled_class_tag.open),
+                    &(highlighter->sequential_class_tag.open),
                     "<mark class=\"keyword-%" GRN_FMT_SIZE "\">",
                     i);
-    GRN_TEXT_SETS(ctx, &(highlighter->cycled_class_tag.close), "</mark>");
-    *open_tag = GRN_TEXT_VALUE(&(highlighter->cycled_class_tag.open));
-    *open_tag_length = GRN_TEXT_LEN(&(highlighter->cycled_class_tag.open));
-    *close_tag = GRN_TEXT_VALUE(&(highlighter->cycled_class_tag.close));
-    *close_tag_length = GRN_TEXT_LEN(&(highlighter->cycled_class_tag.close));
+    GRN_TEXT_SETS(ctx, &(highlighter->sequential_class_tag.close), "</mark>");
+    *open_tag = GRN_TEXT_VALUE(&(highlighter->sequential_class_tag.open));
+    *open_tag_length = GRN_TEXT_LEN(&(highlighter->sequential_class_tag.open));
+    *close_tag = GRN_TEXT_VALUE(&(highlighter->sequential_class_tag.close));
+    *close_tag_length = GRN_TEXT_LEN(&(highlighter->sequential_class_tag.close));
   } else if (highlighter->n_tags == 0) {
     *open_tag = GRN_TEXT_VALUE(&(highlighter->default_tag.open));
     *open_tag_length = GRN_TEXT_LEN(&(highlighter->default_tag.open)) - 1;
@@ -1070,20 +1070,20 @@ grn_highlighter_get_default_close_tag(grn_ctx *ctx,
 }
 
 grn_rc
-grn_highlighter_set_cycled_class_tag_mode(grn_ctx *ctx,
+grn_highlighter_set_sequential_class_tag_mode(grn_ctx *ctx,
                                           grn_highlighter *highlighter,
                                           bool mode)
 {
   GRN_API_ENTER;
-  highlighter->is_cycled_class_tag_mode = mode;
+  highlighter->is_sequential_class_tag_mode = mode;
   GRN_API_RETURN(ctx->rc);
 }
 
 bool
-grn_highlighter_get_cycled_class_tag_mode(grn_ctx *ctx,
+grn_highlighter_get_sequential_class_tag_mode(grn_ctx *ctx,
                                           grn_highlighter *highlighter)
 {
-  return highlighter->is_cycled_class_tag_mode;
+  return highlighter->is_sequential_class_tag_mode;
 }
 
 grn_rc

--- a/lib/highlighter.c
+++ b/lib/highlighter.c
@@ -473,7 +473,8 @@ grn_highlighter_highlight_get_ith_tag(grn_ctx *ctx,
     *open_tag = GRN_TEXT_VALUE(&(highlighter->sequential_class_tag.open));
     *open_tag_length = GRN_TEXT_LEN(&(highlighter->sequential_class_tag.open));
     *close_tag = GRN_TEXT_VALUE(&(highlighter->sequential_class_tag.close));
-    *close_tag_length = GRN_TEXT_LEN(&(highlighter->sequential_class_tag.close));
+    *close_tag_length =
+      GRN_TEXT_LEN(&(highlighter->sequential_class_tag.close));
   } else if (highlighter->n_tags == 0) {
     *open_tag = GRN_TEXT_VALUE(&(highlighter->default_tag.open));
     *open_tag_length = GRN_TEXT_LEN(&(highlighter->default_tag.open)) - 1;
@@ -1071,8 +1072,8 @@ grn_highlighter_get_default_close_tag(grn_ctx *ctx,
 
 grn_rc
 grn_highlighter_set_sequential_class_tag_mode(grn_ctx *ctx,
-                                          grn_highlighter *highlighter,
-                                          bool mode)
+                                              grn_highlighter *highlighter,
+                                              bool mode)
 {
   GRN_API_ENTER;
   highlighter->is_sequential_class_tag_mode = mode;
@@ -1081,7 +1082,7 @@ grn_highlighter_set_sequential_class_tag_mode(grn_ctx *ctx,
 
 bool
 grn_highlighter_get_sequential_class_tag_mode(grn_ctx *ctx,
-                                          grn_highlighter *highlighter)
+                                              grn_highlighter *highlighter)
 {
   return highlighter->is_sequential_class_tag_mode;
 }

--- a/lib/proc/proc_highlight.c
+++ b/lib/proc/proc_highlight.c
@@ -117,7 +117,7 @@ func_highlight(grn_ctx *ctx,
         bool html_mode = false;
         grn_raw_string default_open_tag = {NULL, 0};
         grn_raw_string default_close_tag = {NULL, 0};
-        bool cycled_class_tag_mode = false;
+        bool sequential_class_tag_mode = false;
         grn_proc_options_parse(ctx,
                                end_arg,
                                tag,
@@ -139,9 +139,9 @@ func_highlight(grn_ctx *ctx,
                                "default_close_tag",
                                GRN_PROC_OPTION_VALUE_RAW_STRING,
                                &default_close_tag,
-                               "cycled_class_tag_mode",
+                               "sequential_class_tag_mode",
                                GRN_PROC_OPTION_VALUE_BOOL,
-                               &cycled_class_tag_mode,
+                               &sequential_class_tag_mode,
                                NULL);
         if (ctx->rc != GRN_SUCCESS) {
           goto exit;
@@ -169,12 +169,12 @@ func_highlight(grn_ctx *ctx,
                                                 default_close_tag.length);
         }
 
-        if (cycled_class_tag_mode) {
+        if (sequential_class_tag_mode) {
           need_tag_in_variable_args = false;
         }
-        grn_highlighter_set_cycled_class_tag_mode(ctx,
+        grn_highlighter_set_sequential_class_tag_mode(ctx,
                                                   highlighter,
-                                                  cycled_class_tag_mode);
+                                                  sequential_class_tag_mode);
       }
 
       grn_obj **keyword_args = args + N_REQUIRED_ARGS;
@@ -499,20 +499,20 @@ func_highlight_html(grn_ctx *ctx,
     if (grn_obj_is_tiny_hash_table(ctx, end_arg)) {
       n_args_without_option--;
 
-      bool cycled_class_tag_mode = false;
+      bool sequential_class_tag_mode = false;
       grn_proc_options_parse(ctx,
                              end_arg,
                              tag,
-                             "cycled_class_tag_mode",
+                             "sequential_class_tag_mode",
                              GRN_PROC_OPTION_VALUE_BOOL,
-                             &cycled_class_tag_mode,
+                             &sequential_class_tag_mode,
                              NULL);
       if (ctx->rc != GRN_SUCCESS) {
         goto exit;
       }
-      grn_highlighter_set_cycled_class_tag_mode(ctx,
+      grn_highlighter_set_sequential_class_tag_mode(ctx,
                                                 highlighter,
-                                                cycled_class_tag_mode);
+                                                sequential_class_tag_mode);
     }
 
     if (n_args_without_option == 2) {

--- a/lib/proc/proc_highlight.c
+++ b/lib/proc/proc_highlight.c
@@ -172,9 +172,10 @@ func_highlight(grn_ctx *ctx,
         if (sequential_class_tag_mode) {
           need_tag_in_variable_args = false;
         }
-        grn_highlighter_set_sequential_class_tag_mode(ctx,
-                                                  highlighter,
-                                                  sequential_class_tag_mode);
+        grn_highlighter_set_sequential_class_tag_mode(
+          ctx,
+          highlighter,
+          sequential_class_tag_mode);
       }
 
       grn_obj **keyword_args = args + N_REQUIRED_ARGS;
@@ -511,8 +512,8 @@ func_highlight_html(grn_ctx *ctx,
         goto exit;
       }
       grn_highlighter_set_sequential_class_tag_mode(ctx,
-                                                highlighter,
-                                                sequential_class_tag_mode);
+                                                    highlighter,
+                                                    sequential_class_tag_mode);
     }
 
     if (n_args_without_option == 2) {

--- a/test/command/suite/select/function/highlight/sequential_class_tag_mode.expected
+++ b/test/command/suite/select/function/highlight/sequential_class_tag_mode.expected
@@ -7,7 +7,7 @@ load --table Entries
 {"body": "<b>Rroonga</b> is a Ruby binding of Groonga."}
 ]
 [[0,0.0,0.0],1]
-select Entries --output_columns   'highlight(body,   "groonga", "rroonga",   {"cycled_class_tag_mode": true} )'
+select Entries --output_columns   'highlight(body,   "groonga", "rroonga",   {"sequential_class_tag_mode": true} )'
 [
   [
     0,

--- a/test/command/suite/select/function/highlight/sequential_class_tag_mode.test
+++ b/test/command/suite/select/function/highlight/sequential_class_tag_mode.test
@@ -9,5 +9,5 @@ load --table Entries
 select Entries --output_columns \
   'highlight(body, \
   "groonga", "rroonga", \
-  {"cycled_class_tag_mode": true} \
+  {"sequential_class_tag_mode": true} \
 )'

--- a/test/command/suite/select/function/highlight_html/sequential_class_tag_mode.expected
+++ b/test/command/suite/select/function/highlight_html/sequential_class_tag_mode.expected
@@ -11,7 +11,7 @@ load --table Entries
 {"body": "Mroonga is a ＭｙＳＱＬ storage engine based on Groonga. <b>Rroonga</b> is a Ruby binding of Groonga."}
 ]
 [[0,0.0,0.0],1]
-select Entries   --match_columns body --query 'groonga OR mroonga'   --output_columns 'highlight_html(body, {"cycled_class_tag_mode": true})'
+select Entries   --match_columns body --query 'groonga OR mroonga'   --output_columns 'highlight_html(body, {"sequential_class_tag_mode": true})'
 [
   [
     0,

--- a/test/command/suite/select/function/highlight_html/sequential_class_tag_mode.test
+++ b/test/command/suite/select/function/highlight_html/sequential_class_tag_mode.test
@@ -11,4 +11,4 @@ load --table Entries
 
 select Entries \
   --match_columns body --query 'groonga OR mroonga' \
-  --output_columns 'highlight_html(body, {"cycled_class_tag_mode": true})'
+  --output_columns 'highlight_html(body, {"sequential_class_tag_mode": true})'


### PR DESCRIPTION
Because "cycled" has a meaning that a return to the initial position.
However, "cycled_class_tag" isn't behavior of the return to the initial position.
Therefore, we use sequential "instead" of "cycled".