### PR TITLE
packages yum: use ruby 3.1 in tests

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -86,6 +86,7 @@ if [ "${run_test}" = "yes" ]; then
       set -u
       ;;
     *)
+      ${DNF} module -y enable ruby:3.1
       ${DNF} install -y ruby-devel
       ;;
   esac


### PR DESCRIPTION
TODO: Test

The default version of Ruby on AlmaLinux 8 AppStream is 2.5.9. This version is old. Ruby 2.5.9 doesn't know a Range object such a "[x..]". Terefore, currently, some tests occur syntax error.

Ruby 2.6 or later support the Range object such a "[x..]". Therefore, This problem is resolved by using Ruby 3.1.