### PR TITLE
Fix typo in grnslap

### DIFF
--- a/doc/source/reference/executables/grnslap.rst
+++ b/doc/source/reference/executables/grnslap.rst
@@ -62,5 +62,5 @@ http://localhost:10041/d/status に、多重度100でリクエストを行う。
 ::
 
   > yes /d/status | head -n 100 | grnslap -P http -m 100 localhost:10041
-  2009-11-12 19:34:09.998696|begin: max_concurrency=100 max_tp=10000
-  2009-11-12 19:34:10.011208|end  : n=100 min=46 max=382 avg=0 qps=7992.966190 etime=0.012511
+  2023-05-30 16:21:18.204835|begin: protocol=h max_concurrency=100 max_tp=10000
+  2023-05-30 16:21:19.018364|end  : n=100 min=97 max=485 avg=0 qps=122.921248 etime=0.813529

--- a/src/grnslap.c
+++ b/src/grnslap.c
@@ -246,7 +246,7 @@ do_client()
       if (!THREAD_CREATE(thread, receiver, NULL)) {
         int cnt = 0;
         gettimeofday(&tvb, NULL);
-        lprint(ctx, "begin: procotol=%c max_concurrency=%d max_tp=%d", proto, max_con, max_tp);
+        lprint(ctx, "begin: protocol=%c max_concurrency=%d max_tp=%d", proto, max_con, max_tp);
         while (fgets(buf, BUFSIZE, stdin)) {
           size_t size = strlen(buf) - 1;
           session *s = session_alloc(ctx, dests + (cnt++ % dest_cnt));


### PR DESCRIPTION
procotol ->
protocol

The example run results in the documentation was out of date, so I have updated it.