### PR TITLE
ii near-phrase-family: fix interval calculation when we use additional_last_interval

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -13122,8 +13122,8 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
     return (interval <= data->max_interval);
   }
 
-  token_info *max_token_info = NULL;
   token_info *min_token_info = NULL;
+  token_info *max_token_info = NULL;
   int min_without_last_token = -1;
   int max_without_last_token = -1;
   if (data->mode == GRN_OP_ORDERED_NEAR_PHRASE_PRODUCT) {
@@ -13179,10 +13179,9 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
     return true;
   }
 
-  int interval_without_last_token =
-    max_without_last_token - min_without_last_token;
-  interval_without_last_token -= min_token_info->n_tokens_in_phrase;
-
+  int interval_without_last_token = max_without_last_token -
+                                    min_without_last_token -
+                                    min_token_info->n_tokens_in_phrase;
   if (data->additional_last_interval < 0) {
     return (interval_without_last_token <= data->max_interval);
   } else {

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -13123,7 +13123,6 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
   }
 
   token_info *min_token_info = NULL;
-  token_info *max_token_info = NULL;
   int min_without_last_token = -1;
   int max_without_last_token = -1;
   if (data->mode == GRN_OP_ORDERED_NEAR_PHRASE_PRODUCT) {
@@ -13137,7 +13136,6 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
-        max_token_info = ti;
       }
     }
   } else if (data->mode == GRN_OP_NEAR_PHRASE_PRODUCT) {
@@ -13154,7 +13152,6 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
-        max_token_info = ti;
       }
     }
   } else {
@@ -13171,11 +13168,10 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
-        max_token_info = ti;
       }
     }
   }
-  if (!max_token_info) {
+  if (!min_token_info) {
     return true;
   }
 

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -13123,6 +13123,7 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
   }
 
   token_info *max_token_info = NULL;
+  token_info *min_token_info = NULL;
   int min_without_last_token = -1;
   int max_without_last_token = -1;
   if (data->mode == GRN_OP_ORDERED_NEAR_PHRASE_PRODUCT) {
@@ -13132,6 +13133,7 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       token_info *ti = data->phrase_groups[i].btree->min;
       if (min_without_last_token == -1 || ti->pos < min_without_last_token) {
         min_without_last_token = ti->pos;
+        min_token_info = ti;
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
@@ -13148,6 +13150,7 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       }
       if (min_without_last_token == -1 || ti->pos < min_without_last_token) {
         min_without_last_token = ti->pos;
+        min_token_info = ti;
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
@@ -13164,6 +13167,7 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
       }
       if (min_without_last_token == -1 || ti->pos < min_without_last_token) {
         min_without_last_token = ti->pos;
+        min_token_info = ti;
       }
       if (max_without_last_token == -1 || ti->pos > max_without_last_token) {
         max_without_last_token = ti->pos;
@@ -13175,9 +13179,10 @@ grn_ii_select_data_is_matched_near_phrase_real(grn_ctx *ctx,
     return true;
   }
 
-  int interval_without_last_token = max_without_last_token -
-                                    min_without_last_token -
-                                    (max_token_info->n_tokens_in_phrase - 1);
+  int interval_without_last_token =
+    max_without_last_token - min_without_last_token;
+  interval_without_last_token -= min_token_info->n_tokens_in_phrase;
+
   if (data->additional_last_interval < 0) {
     return (interval_without_last_token <= data->max_interval);
   } else {

--- a/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.expected
+++ b/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.expected
@@ -12,9 +12,9 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
-[[0,0.0,0.0],4]
+[[0,0.0,0.0],5]
 select   --table Memos   --filter 'content *NP3,-1 "a c .$"'   --output_columns _score,_key,content
 [
   [

--- a/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.expected
+++ b/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.expected
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 [[0,0.0,0.0],4]
 select   --table Memos   --filter 'content *NP3,-1 "a c .$"'   --output_columns _score,_key,content
@@ -24,7 +25,7 @@ select   --table Memos   --filter 'content *NP3,-1 "a c .$"'   --output_columns 
   [
     [
       [
-        3
+        4
       ],
       [
         [
@@ -54,6 +55,11 @@ select   --table Memos   --filter 'content *NP3,-1 "a c .$"'   --output_columns 
         1,
         "alphabets3",
         "a b x c d e f ."
+      ],
+      [
+        1,
+        "alphabets4",
+        "a b x x c d e f ."
       ]
     ]
   ]

--- a/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.test
+++ b/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.test
@@ -12,7 +12,7 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.test
+++ b/test/command/suite/select/filter/near_phrase/additional_last_interval/negative.test
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/filter/near_phrase/max_element_intervals/additional_last_interval.expected
+++ b/test/command/suite/select/filter/near_phrase/max_element_intervals/additional_last_interval.expected
@@ -32,7 +32,7 @@ select   --table Memos   --filter 'content *NP2,1,2|1 "a$ 2 c"'   --output_colum
   [
     [
       [
-        4
+        5
       ],
       [
         [
@@ -59,6 +59,10 @@ select   --table Memos   --filter 'content *NP2,1,2|1 "a$ 2 c"'   --output_colum
       [
         1,
         "2 x c x a"
+      ],
+      [
+        1,
+        "2 x x c a"
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.expected
@@ -12,9 +12,9 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
-[[0,0.0,0.0],4]
+[[0,0.0,0.0],5]
 select   --table Memos   --filter 'content *ONP3,-1 "a c ."'   --output_columns _score,_key,content
 [
   [

--- a/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.expected
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 [[0,0.0,0.0],4]
 select   --table Memos   --filter 'content *ONP3,-1 "a c ."'   --output_columns _score,_key,content
@@ -24,7 +25,7 @@ select   --table Memos   --filter 'content *ONP3,-1 "a c ."'   --output_columns 
   [
     [
       [
-        3
+        4
       ],
       [
         [
@@ -54,6 +55,11 @@ select   --table Memos   --filter 'content *ONP3,-1 "a c ."'   --output_columns 
         1,
         "alphabets3",
         "a b x c d e f ."
+      ],
+      [
+        1,
+        "alphabets4",
+        "a b x x c d e f ."
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.test
@@ -12,7 +12,7 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/additional_last_interval/negative.test
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.expected
+++ b/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.expected
@@ -12,9 +12,9 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
-[[0,0.0,0.0],4]
+[[0,0.0,0.0],5]
 select   --table Memos   --match_columns content   --query '*NP3,-1"a c .$"'   --output_columns _score,_key,content
 [
   [

--- a/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.expected
+++ b/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.expected
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 [[0,0.0,0.0],4]
 select   --table Memos   --match_columns content   --query '*NP3,-1"a c .$"'   --output_columns _score,_key,content
@@ -24,7 +25,7 @@ select   --table Memos   --match_columns content   --query '*NP3,-1"a c .$"'   -
   [
     [
       [
-        3
+        4
       ],
       [
         [
@@ -54,6 +55,11 @@ select   --table Memos   --match_columns content   --query '*NP3,-1"a c .$"'   -
         1,
         "alphabets3",
         "a b x c d e f ."
+      ],
+      [
+        1,
+        "alphabets4",
+        "a b x x c d e f ."
       ]
     ]
   ]

--- a/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.test
+++ b/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.test
@@ -12,7 +12,7 @@ load --table Memos
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
 {"_key":"alphabets4", "content": "a b x x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x x c d e f ."}
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.test
+++ b/test/command/suite/select/query/near_phrase/last/additional_last_interval/negative.test
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets4", "content": "a b x x x c d e f ."}
 ]
 
 select \

--- a/test/command/suite/select/query/near_phrase/max_element_intervals/additional_last_interval.expected
+++ b/test/command/suite/select/query/near_phrase/max_element_intervals/additional_last_interval.expected
@@ -32,7 +32,7 @@ select   --table Memos   --match_columns content   --query '*NP2,1,2|1"a$ 2 c"' 
   [
     [
       [
-        4
+        5
       ],
       [
         [
@@ -59,6 +59,10 @@ select   --table Memos   --match_columns content   --query '*NP2,1,2|1"a$ 2 c"' 
       [
         1,
         "2 x c x a"
+      ],
+      [
+        1,
+        "2 x x c a"
       ]
     ]
   ]

--- a/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.expected
+++ b/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.expected
@@ -15,7 +15,9 @@ load --table Memos
 {"content": "a b x c d e f ."},
 {"content": "1 2 x 3 4 5 6 ,"},
 {"content": "a b x x c d e f ."},
-{"content": "1 2 x x 3 4 5 6 ,"}
+{"content": "1 2 x x 3 4 5 6 ,"},
+{"content": "a b x x x c d e f ."},
+{"content": "1 2 x x x 3 4 5 6 ,"}
 ]
 [[0,0.0,0.0],8]
 select   --table Memos   --match_columns content   --query '*NPP3,-1"(a 1) (c 3) (,$ .$)"'   --output_columns _score,content
@@ -28,7 +30,7 @@ select   --table Memos   --match_columns content   --query '*NPP3,-1"(a 1) (c 3)
   [
     [
       [
-        6
+        8
       ],
       [
         [
@@ -63,6 +65,14 @@ select   --table Memos   --match_columns content   --query '*NPP3,-1"(a 1) (c 3)
       [
         1,
         "1 2 x 3 4 5 6 ,"
+      ],
+      [
+        1,
+        "a b x x c d e f ."
+      ],
+      [
+        1,
+        "1 2 x x 3 4 5 6 ,"
       ]
     ]
   ]

--- a/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.expected
+++ b/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.expected
@@ -19,7 +19,7 @@ load --table Memos
 {"content": "a b x x x c d e f ."},
 {"content": "1 2 x x x 3 4 5 6 ,"}
 ]
-[[0,0.0,0.0],8]
+[[0,0.0,0.0],10]
 select   --table Memos   --match_columns content   --query '*NPP3,-1"(a 1) (c 3) (,$ .$)"'   --output_columns _score,content
 [
   [

--- a/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.test
+++ b/test/command/suite/select/query/near_phrase_product/last/additional_last_interval/negative.test
@@ -15,7 +15,9 @@ load --table Memos
 {"content": "a b x c d e f ."},
 {"content": "1 2 x 3 4 5 6 ,"},
 {"content": "a b x x c d e f ."},
-{"content": "1 2 x x 3 4 5 6 ,"}
+{"content": "1 2 x x 3 4 5 6 ,"},
+{"content": "a b x x x c d e f ."},
+{"content": "1 2 x x x 3 4 5 6 ,"}
 ]
 
 select \

--- a/test/command/suite/select/query/ordered_near_phrase/additional_last_interval/negative.expected
+++ b/test/command/suite/select/query/ordered_near_phrase/additional_last_interval/negative.expected
@@ -11,9 +11,10 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
-[[0,0.0,0.0],4]
+[[0,0.0,0.0],5]
 select   --table Memos   --match_columns content   --query '*ONP3,-1"a c ."'   --output_columns _score,_key,content
 [
   [
@@ -24,7 +25,7 @@ select   --table Memos   --match_columns content   --query '*ONP3,-1"a c ."'   -
   [
     [
       [
-        3
+        4
       ],
       [
         [
@@ -54,6 +55,11 @@ select   --table Memos   --match_columns content   --query '*ONP3,-1"a c ."'   -
         1,
         "alphabets3",
         "a b x c d e f ."
+      ],
+      [
+        1,
+        "alphabets4",
+        "a b x x c d e f ."
       ]
     ]
   ]

--- a/test/command/suite/select/query/ordered_near_phrase/additional_last_interval/negative.test
+++ b/test/command/suite/select/query/ordered_near_phrase/additional_last_interval/negative.test
@@ -11,7 +11,8 @@ load --table Memos
 {"_key":"alphabets1", "content": "a c d ."},
 {"_key":"alphabets2", "content": "a b c d e f ."},
 {"_key":"alphabets3", "content": "a b x c d e f ."},
-{"_key":"alphabets4", "content": "a b x x c d e f ."}
+{"_key":"alphabets4", "content": "a b x x c d e f ."},
+{"_key":"alphabets5", "content": "a b x x x c d e f ."}
 ]
 
 select \


### PR DESCRIPTION
Currently, interval calculation is wrong as below when we use additional_last_interval.

* Input: "AaaxxxBbbcdefghi."
* query: '*NP3,-1"aaa bbb .$"'

Expected:

  The number of tokens between "Aaa" and "Bbb" is 3.

Before:

  The number of tokens between "Aaa" and "Bbb" is 7.

Current implementation expecte min_without_last_token's potision shows the potition of the last character of "Aaa" and max_without_last_token's potision shows the potition of the last character of "Bbb".

However, in fact, min_without_last_token's potision shows "A"'s potition and max_without_last_token's potision shows "B"'s potition.