### PR TITLE
db: optimize built-in objects reference

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,8 +301,7 @@ jobs:
           sudo apt update -o="APT::Acquire::Retries=3"
       - name: Install test dependencies
         run: |
-          which conda || :
-          sudo env MAKEFLAGS=-j$(nproc) gem install --verbose \
+          sudo env MAKEFLAGS=-j$(nproc) gem install \
             grntest \
             pkg-config \
             red-arrow

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,7 +301,8 @@ jobs:
           sudo apt update -o="APT::Acquire::Retries=3"
       - name: Install test dependencies
         run: |
-          sudo env MAKEFLAGS=-j$(nproc) gem install \
+          which conda || :
+          sudo env MAKEFLAGS=-j$(nproc) gem install --verbose \
             grntest \
             pkg-config \
             red-arrow

--- a/lib/db.c
+++ b/lib/db.c
@@ -13028,8 +13028,13 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
             grn_ja_unref(ctx, &iw);
           }
           if (grn_enable_reference_count) {
-            if (!vp->ptr) {
+            if (vp->ptr->header.type == GRN_TYPE
+                || vp->ptr->header.type == GRN_EXPR) {
               grn_db_value_unlock(ctx, id, vp);
+            } else {
+              if (!vp->ptr) {
+                grn_db_value_unlock(ctx, id, vp);
+              }
             }
           } else {
             grn_db_value_unlock(ctx, id, vp);

--- a/lib/db.c
+++ b/lib/db.c
@@ -12766,7 +12766,6 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
                               DB_OBJ(res)->reference_count);
     }
   } else {
-    grn_log_reference_count("%p: at: start: %u\n", ctx, id);
     grn_db *s = (grn_db *)ctx->impl->db;
     if (s) {
       db_value *vp;
@@ -12774,17 +12773,17 @@ grn_ctx_at(grn_ctx *ctx, grn_id id)
       if (!(vp = grn_tiny_array_at(&s->values, id))) {
         goto exit;
       }
-      /* If reference count mode enable, Groonga maintain lock of
-       * a object until the object is gone refrence.
-       * However, if we many object open,
-       * the number of lock count may be over flow.
-       *
-       * Therefore, we unload unreserved objects.
-       */
-      if (id <= GRN_N_RESERVED_TYPES && vp->ptr) {
+      /* We can skip opened check with lock for built-in objects
+       * because built-in objects are opened on DB open and never
+       * closed until DB is closed at least with the current
+       * design. So the object is opened (vp->ptr != NULL, vp->ptr is
+       * NULL only when no associated object), we can safely return
+       * the opened object directly without lock. */
+      if (id < GRN_N_RESERVED_TYPES && vp->ptr) {
         res = vp->ptr;
         goto exit;
       }
+      grn_log_reference_count("%p: at: start: %u\n", ctx, id);
       if (grn_enable_reference_count) {
         if (!grn_db_value_lock(ctx, id, vp, &lock)) {
           const char *name;
@@ -14146,6 +14145,12 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
       grn_obj_close(ctx, obj);
       return;
     }
+  }
+
+  /* Don't unlink built-in objects. We must update the same condition
+   * in grn_ctx_at() when we need to unlink built-in objects. */
+  if (id < GRN_N_RESERVED_TYPES) {
+    return;
   }
 
   if (!grn_enable_reference_count) {


### PR DESCRIPTION
Skip lock/unlock built-in objects because built-in objects must be kept opening by the current design.