### PR TITLE
mruby windows: enable presym

### DIFF
--- a/vendor/mruby/build_config.rb
+++ b/vendor/mruby/build_config.rb
@@ -5,10 +5,6 @@ MRuby::Lockfile.disable if MRuby.const_defined?(:Lockfile)
 MRuby::Build.new do |conf|
   if ENV["MRUBY_VC"] || ENV["VisualStudioVersion"] || ENV["VSINSTALLDIR"]
     conf.toolchain :visualcpp
-    # Because presym doesn't support Windows style path such as
-    # "C:\Users\...". We need to escape "\" in C string literal like
-    # "C:\\Users\\...".
-    conf.disable_presym
   else
     conf.toolchain :gcc
   end
@@ -60,5 +56,5 @@ MRuby::Build.new do |conf|
   conf.gem :github => "ksss/mruby-file-stat",
            :checksum_hash => "f3e858f01361b9b4a8e77ada52470068630c9530"
   conf.gem :github => "mattn/mruby-onig-regexp",
-           :checksum_hash => "0af2124b095474bd2897021df669e61eac4743ec"
+           :checksum_hash => "2ae5ec5cde0b54fc9c3f81a8cf81f7dac574cff6"
 end

--- a/vendor/mruby/mruby_build.rb
+++ b/vendor/mruby/mruby_build.rb
@@ -35,10 +35,7 @@ FileUtils.cp("#{mruby_build_dir}/host/LEGAL", "./")
 FileUtils.cp("#{mruby_build_dir}/host/mrblib/mrblib.c", "./")
 
 FileUtils.rm_rf("mruby-include")
-include_dir = "#{mruby_build_dir}/host/include/"
-# This directory doesn't exist on Windows because we disable presym on Windows.
-# See also build_config.rb.
-FileUtils.cp_r(include_dir, "mruby-include/") if File.exist?(include_dir)
+FileUtils.cp_r("#{mruby_build_dir}/host/include/", "mruby-include/")
 
 File.open("mrbgems_init.c", "w") do |mrbgems_init|
   Dir.glob("#{mruby_build_dir}/host/mrbgems/**/gem_init.c") do |gem_init|


### PR DESCRIPTION
Because the performance of Groonga degrades when presym disable.
In addition, the mruby's issues about escape has arleady fixed in upstream probably.
Therefore, we use the master branch of mruby in this PR.