### PR TITLE
packages almalinux 9: Use gcc 12

### DIFF
--- a/packages/yum/almalinux-9/Dockerfile
+++ b/packages/yum/almalinux-9/Dockerfile
@@ -1,6 +1,9 @@
 ARG FROM=almalinux:9
 FROM ${FROM}
 
+ENV \
+  SCL=gcc-toolset-12
+
 ARG DEBUG
 ARG APACHE_ARROW_VERSION
 
@@ -18,7 +21,8 @@ RUN \
     arrow-devel-${APACHE_ARROW_VERSION} \
     ccache \
     cmake \
-    gcc-c++ \
+    ${SCL}-gcc-c++ \
+    ${SCL}-annobin-plugin-gcc \
     intltool \
     mecab-devel \
     libedit-devel \

--- a/packages/yum/almalinux-9/Dockerfile
+++ b/packages/yum/almalinux-9/Dockerfile
@@ -18,11 +18,10 @@ RUN \
   dnf config-manager --set-enabled crb && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \
+    ${SCL} \
     arrow-devel-${APACHE_ARROW_VERSION} \
     ccache \
     cmake \
-    ${SCL}-gcc-c++ \
-    ${SCL}-annobin-plugin-gcc \
     intltool \
     mecab-devel \
     libedit-devel \


### PR DESCRIPTION
Because build for RPM package fail as below when we use gcc 11. https://github.com/groonga/groonga/actions/runs/7026368743/job/19119118727#step:8:4050

Probablly, the cause of this problem is gcc.
Because this problem is internal compiler error and this problem occures even if Groonga's source code does not change.

So, I use gcc 12 instead of gcc 11.