### PR TITLE
Re-add `unify_to_katakana` tests (`etc.*` - `katakana_hiragana_semi_voiced_sound_mark.*`)

### DIFF
--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/etc.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/etc.expected
@@ -1,0 +1,54 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "ゔゕゖゝゞゟ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ヴヵヶヽヾヨリ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      -1,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      15,
+      18
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/etc.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/etc.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "ゔゕゖゝゞゟ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ga.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ga.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "がぎぐげご"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ガギグゲゴ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ga.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ga.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "がぎぐげご" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ha.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ha.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "はひふへほ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ハヒフヘホ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ha.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ha.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "はひふへほ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ka.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ka.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "かきくけこ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "カキクケコ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ka.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ka.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "かきくけこ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.expected
@@ -1,0 +1,24 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "゜"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゚",
+    "types": [
+      "hiragana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_semi_voiced_sound_mark.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "゜" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
* etc.*
* ga.*
* ha.*
* ka.*
* katakana_hiragana_semi_voiced_sound_mark.*