### PR TITLE
Re-add `unify_to_katakana` tests (`katakana_hiragana_voiced_sound_mark.*` - `ra.*`)

### DIFF
--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_voiced_sound_mark.expected
@@ -1,0 +1,24 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "゛"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "゙",
+    "types": [
+      "hiragana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/katakana_hiragana_voiced_sound_mark.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "゛" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ma.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ma.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "まみむめも"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "マミムメモ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ma.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ma.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "まみむめも" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/na.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/na.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "なにぬねの"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ナニヌネノ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/na.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/na.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "なにぬねの" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/pa.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/pa.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "ぱぴぷぺぽ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "パピプペポ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/pa.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/pa.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "ぱぴぷぺぽ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ra.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ra.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "らりるれろ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ラリルレロ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ra.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ra.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "らりるれろ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
* katakana_hiragana_voiced_sound_mark.*
* ma.*
* na.*
* pa.*
* ra.*

#1673