### PR TITLE
Re-add `unify_to_katakana` tests (`sa.*` - `za.*`)

### DIFF
--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/sa.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/sa.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "さしすせそ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "サシスセソ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/sa.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/sa.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "さしすせそ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ta.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ta.expected
@@ -1,0 +1,49 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "たちつってと"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "タチツッテト",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      18
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ta.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ta.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "たちつってと" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/wa.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/wa.expected
@@ -1,0 +1,49 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "わゎゐゑをん"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ワヮヰヱヲン",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      18
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/wa.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/wa.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "わゎゐゑをん" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ya.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ya.expected
@@ -1,0 +1,49 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "やゃゆゅよょ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ヤャユュヨョ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15,
+      18
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/ya.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/ya.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "やゃゆゅよょ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/za.expected
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/za.expected
@@ -1,0 +1,44 @@
+normalize   'NormalizerNFKC("unify_to_katakana", true,                   "report_source_offset", true)'   "ざじずぜぞ"   WITH_CHECKS|WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ザジズゼゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": [
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0,
+      3,
+      0,
+      0
+    ],
+    "offsets": [
+      0,
+      3,
+      6,
+      9,
+      12,
+      15
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_to_katakana/za.test
+++ b/test/command/suite/normalizers/nfkc/unify_to_katakana/za.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_to_katakana", true, \
+                  "report_source_offset", true)' \
+  "ざじずぜぞ" \
+  WITH_CHECKS|WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
* sa.*
* ta.*
* wa.*
* ya.*
* za.*

#1673