### PR TITLE
docs: Install any missing software

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,1 +1,17 @@
+# Copyright (C) 2024  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 Gemfile.lock

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -14,4 +14,4 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-Gemfile.lock
+/Gemfile.lock

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # Copyright (C) 2024  Abe Tomoaki <abe@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+# Copyright (C) 2024  Abe Tomoaki <abe@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
 source 'https://rubygems.org'
 
 gem 'gettext'

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'gettext'

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -40,9 +40,6 @@ msgstr ""
 msgid "OS X::"
 msgstr ""
 
-msgid "If the version of Python on your platform is too old, you'll need to install a newer version of Python 2.7 by your hand. For example, here are installation steps based on `pyenv <https://github.com/yyuu/pyenv>`_::"
-msgstr "プラットフォームに存在するPythonのバージョンが古すぎる場合は、Python 2.7のより新しいバージョンを手動でインストールする必要があります。例えば、 `pyenv <https://github.com/yyuu/pyenv>`_ を使ったインストール手順は以下の通りです::"
-
 msgid "Run ``cmake`` with ``--preset=doc``"
 msgstr "``cmake`` を ``--preset=doc`` 付きで実行"
 

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -17,19 +17,23 @@ Here are command lines to install Sphinx.
 
 Debian GNU/Linux, Ubuntu::
 
-  % sudo apt-get install -V -y python-sphinx
+  % sudo apt-get install -V -y python3-pip gettext
+  % sudo pip install -r doc/requirements.txt
+  % sudo gem install -g doc/Gemfile
 
 CentOS, Fedora::
 
-  % sudo yum install -y python-pip
-  % sudo pip install sphinx
+  % sudo yum install -y python-pip gettext
+  % sudo pip install -r doc/requirements.txt
+  % sudo gem install -g doc/Gemfile
 
 OS X::
 
   % brew install python
   % brew install gettext
   % export PATH=`brew --prefix gettext`/bin:$PATH
-  % pip install sphinx
+  % pip install -r doc/requirements.txt
+  % gem install -g doc/Gemfile
 
 If the version of Python on your platform is too old, you'll need to
 install a newer version of Python 2.7 by your hand. For example, here
@@ -38,7 +42,7 @@ are installation steps based on `pyenv
 
   % pyenv install 2.7.11
   % pyenv global 2.7.11
-  % pip install sphinx
+  % pip install -r doc/requirements.txt
 
 Run ``cmake`` with ``--preset=doc``
 -----------------------------------

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -19,13 +19,13 @@ Debian GNU/Linux, Ubuntu::
 
   % sudo apt-get install -V -y python3-pip gettext
   % sudo pip install -r doc/requirements.txt
-  % sudo gem install -g doc/Gemfile
+  % (cd doc && bundle install)
 
 CentOS, Fedora::
 
   % sudo yum install -y python-pip gettext
   % sudo pip install -r doc/requirements.txt
-  % sudo gem install -g doc/Gemfile
+  % (cd doc && bundle install)
 
 OS X::
 
@@ -33,7 +33,7 @@ OS X::
   % brew install gettext
   % export PATH=`brew --prefix gettext`/bin:$PATH
   % pip install -r doc/requirements.txt
-  % gem install -g doc/Gemfile
+  % (cd doc && bundle install)
 
 If the version of Python on your platform is too old, you'll need to
 install a newer version of Python 2.7 by your hand. For example, here

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -35,15 +35,6 @@ OS X::
   % pip install -r doc/requirements.txt
   % (cd doc && bundle install)
 
-If the version of Python on your platform is too old, you'll need to
-install a newer version of Python 2.7 by your hand. For example, here
-are installation steps based on `pyenv
-<https://github.com/yyuu/pyenv>`_::
-
-  % pyenv install 2.7.11
-  % pyenv global 2.7.11
-  % pip install -r doc/requirements.txt
-
 Run ``cmake`` with ``--preset=doc``
 -----------------------------------
 


### PR DESCRIPTION
```
CMake Error at cmake/GroongaSphinx.cmake:53 (find_program):
  Could not find XGETTEXT using the following names: xgettext
```
We installed `gettext` to resolve this error.

```
Extension error:
Could not import extension myst_parser (exception: No module named 'myst_parser')
```
We installed from `doc/requirements.txt` to resolve this error. Sphinx is included in `requirements.txt`.

Remove pyenv section. Python3 is provided on major platforms.

```
<internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- gettext/tools (LoadError)
    from <internal:/usr/lib/ruby/vendor_ruby/rubygems/core_ext/kernel_require.rb>:85:in `require'
    from /docs/doc/../doc/update-edit-po.rb:19:in `<main>'
```
We install 'gem gettext'.