### PR TITLE
docs: Add `n_jobs` and `memory_map_size` to the status reference

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
@@ -211,7 +211,7 @@ msgid "``memory_map_size``"
 msgstr ""
 
 msgid "The total mapped memory size by this Groonga process in bytes."
-msgstr "このGroongaプロセスのメモリーマップサイズの合計です。"
+msgstr "このGroongaプロセスのメモリーマップサイズの合計です。単位はバイトです。"
 
 msgid "``2929``"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
@@ -186,6 +186,15 @@ msgstr "このGroongaプロセスのバージョンです。"
 msgid "``5.0.7``"
 msgstr ""
 
+msgid "``n_jobs``"
+msgstr ""
+
+msgid "The number of unprocessed jobs."
+msgstr "未処理のジョブ数です。"
+
+msgid "``0``"
+msgstr ""
+
 msgid "``features``"
 msgstr ""
 
@@ -198,14 +207,20 @@ msgstr ""
 msgid "The information about Apache Arrow that Groonga currently uses. It's only displayed when Apache Arrow is enabled."
 msgstr "Groongaの使用しているApache Arrowの情報です。Apache Arrowが有効な場合のみ表示されます。"
 
+msgid "``memory_map_size``"
+msgstr ""
+
+msgid "The total memory map size in bytes of Groonga."
+msgstr "Groongaのメモリーマップサイズの合計です。"
+
+msgid "``2929``"
+msgstr ""
+
 msgid "``n_workers``"
 msgstr ""
 
 msgid "The value of ``n_workers`` set in this context."
 msgstr "このコンテキストで設定されている ``n_workers`` の値です。"
-
-msgid "``0``"
-msgstr ""
 
 msgid "``default_n_workers``"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/commands/status.po
@@ -210,8 +210,8 @@ msgstr "Groongaの使用しているApache Arrowの情報です。Apache Arrow�
 msgid "``memory_map_size``"
 msgstr ""
 
-msgid "The total memory map size in bytes of Groonga."
-msgstr "Groongaのメモリーマップサイズの合計です。"
+msgid "The total mapped memory size by this Groonga process in bytes."
+msgstr "このGroongaプロセスのメモリーマップサイズの合計です。"
 
 msgid "``2929``"
 msgstr ""

--- a/doc/source/reference/commands/status.rst
+++ b/doc/source/reference/commands/status.rst
@@ -71,8 +71,10 @@ The command returns the current status as an object::
       "starttime": STARTTIME,
       "uptime": UPTIME,
       "version": VERSION,
+      "n_jobs": N_JOBS,
       "features": FEATURES,
       "apache_arrow": APACHE_ARROW_INFORMATION,
+      "memory_map_size": MEMORY_MAP_SIZE,
       "n_workers": N_WORKERS,
       "default_n_workers": DEFAULT_N_WORKERS
     }
@@ -152,6 +154,10 @@ values:
      - The version of the Groonga process.
      - ``5.0.7``
 
+   * - ``n_jobs``
+     - The number of unprocessed jobs.
+     - ``0``
+
    * - ``features``
      - .. versionadded:: 10.0.1
 
@@ -190,6 +196,10 @@ values:
              "version_patch": 0,
              "version": "2.0.0"
           }
+
+   * - ``memory_map_size``
+     - The total memory map size in bytes of Groonga.
+     - ``2929``
 
    * - ``n_workers``
      - The value of ``n_workers`` set in this context.

--- a/doc/source/reference/commands/status.rst
+++ b/doc/source/reference/commands/status.rst
@@ -198,7 +198,7 @@ values:
           }
 
    * - ``memory_map_size``
-     - The total memory map size in bytes of Groonga.
+     - The total mapped memory size by this Groonga process in bytes.
      - ``2929``
 
    * - ``n_workers``


### PR DESCRIPTION
I found that it was not listed, so I added it.