### PR TITLE
arrow: Support `Int64` in `output_type=apache-arrow` for columns that reference other table

### DIFF
--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -2392,6 +2392,9 @@ namespace grnarrow {
       case GRN_DB_INT32:
         add_column_int32(*reinterpret_cast<int32_t *>(key));
         return;
+      case GRN_DB_INT64:
+        add_column_int64(*reinterpret_cast<int64_t *>(key));
+        return;
       default:
         break;
       }

--- a/test/command/suite/select/output/apache_arrow/reference_int64.expected
+++ b/test/command/suite/select/output/apache_arrow/reference_int64.expected
@@ -1,0 +1,33 @@
+table_create Referred TABLE_HASH_KEY Int64
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data value COLUMN_SCALAR Referred
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"value": 29}
+]
+[[0,0.0,0.0],1]
+select Data   --command_version 3   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+value: int64
+-- metadata --
+GROONGA:n_hits: 1
+	_id	value
+0	  1	   29

--- a/test/command/suite/select/output/apache_arrow/reference_int64.test
+++ b/test/command/suite/select/output/apache_arrow/reference_int64.test
@@ -1,0 +1,17 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+table_create Referred TABLE_HASH_KEY Int64
+
+table_create Data TABLE_NO_KEY
+column_create Data value COLUMN_SCALAR Referred
+
+load --table Data
+[
+{"value": 29}
+]
+
+select Data \
+  --command_version 3 \
+  --output_type apache-arrow


### PR DESCRIPTION
fixes #1704