### PR TITLE
Add a `libarrow-dev` package to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ if [ -f /etc/debian_version ]; then
 
   wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   ${SUDO} apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  rm "apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
   ${SUDO} apt update
 fi
 
@@ -68,7 +69,3 @@ case "${distribution}-${code_name}" in
     ${SUDO} apt install -y -V "${package_names[@]}"
     ;;
 esac
-
-if [ -f "apache-arrow-apt-source-latest-${code_name}.deb" ]; then
-  rm "apache-arrow-apt-source-latest-${code_name}.deb"
-fi

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,10 @@ fi
 if [ -f /etc/debian_version ]; then
   ${SUDO} apt update
   ${SUDO} apt install -y -V lsb-release wget
+
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')-rc/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  ${SUDO} apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  ${SUDO} apt update
 fi
 
 if type lsb_release  > /dev/null 2>&1; then
@@ -44,6 +48,7 @@ case "${distribution}-${code_name}" in
       cmake
       g++
       gcc
+      libarrow-dev
       liblz4-dev
       libmecab-dev
       libmsgpack-dev
@@ -64,3 +69,6 @@ case "${distribution}-${code_name}" in
     ;;
 esac
 
+if [ -f "apache-arrow-apt-source-latest-${code_name}.deb" ]; then
+  rm "apache-arrow-apt-source-latest-${code_name}.deb"
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ if [ -f /etc/debian_version ]; then
   ${SUDO} apt update
   ${SUDO} apt install -y -V lsb-release wget
 
-  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')-rc/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   ${SUDO} apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   ${SUDO} apt update
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ if [ -f /etc/debian_version ]; then
 
   wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   ${SUDO} apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-  rm "apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb"
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
   ${SUDO} apt update
 fi
 


### PR DESCRIPTION
## What I did
- Add `libarrow-dev` package to setup script

## The Error I faced
- I faced the following CMake Error when I build groonga with `--preset=doc`

```console
% cmake -S . -B ../groonga.doc --preset=doc
CMake Error at CMakeLists.txt:531 (find_package):
  By not providing "FindArrow.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Arrow", but
  CMake did not find one.

  Could not find a package configuration file provided by "Arrow" with any of
  the following names:

    ArrowConfig.cmake
    arrow-config.cmake

  Add the installation prefix of "Arrow" to CMAKE_PREFIX_PATH or set
  "Arrow_DIR" to a directory containing one of the above files.  If "Arrow"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
See also "/home/otegami/dev/groonga.doc/CMakeFiles/CMakeOutput.log".
See also "/home/otegami/dev/groonga.doc/CMakeFiles/CMakeError.log".
cmake -S . -B ../groonga.doc --preset=doc  2.91s user 1.14s system 99% cpu 4.066 total
```

### The cause of this error
- There is no step to install Apache Arrow although we need to use it for generating documentation.

### How to reproduce
```console
% cd groonga
% ./setup.sh
% cmake -S . -B ../groonga.doc --preset=doc
-- AVX2 flags: -mavx2
CMake Error at CMakeLists.txt:531 (find_package):
  By not providing "FindArrow.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Arrow", but
  CMake did not find one.

  Could not find a package configuration file provided by "Arrow" with any of
  the following names:

    ArrowConfig.cmake
    arrow-config.cmake

  Add the installation prefix of "Arrow" to CMAKE_PREFIX_PATH or set
  "Arrow_DIR" to a directory containing one of the above files.  If "Arrow"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
See also "/home/otegami/dev/groonga.doc/CMakeFiles/CMakeOutput.log".
See also "/home/otegami/dev/groonga.doc/CMakeFiles/CMakeError.log".
```