### PR TITLE
doc: add `Checkout Groonga from the repository` step to the document contribution guide

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -25,8 +25,8 @@ msgstr "この文書では、Groongaドキュメントの執筆・生成・管�
 msgid "How to clone Groonga repository"
 msgstr "Groongaリポジトリのcloneの仕方"
 
-msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press `Fork` button. Now you can clone your Groonga repository."
-msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして `Fork` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます。"
+msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press ``Fork`` button. Now you can clone your Groonga repository."
+msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして ``Fork`` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます。"
 
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -23,13 +23,13 @@ msgid "This documentation describes about how to write, generate and manage Groo
 msgstr "この文書では、Groongaドキュメントの執筆・生成・管理の方法について説明します。"
 
 msgid "Checkout Groonga from the repository"
-msgstr ""
+msgstr "リポジトリーからGroongaをチェックアウト"
 
 msgid "You should build Groonga documentation from source code at the repository. Because source code in the repository is the latest."
-msgstr ""
+msgstr "リポジトリーのソースコードからGroongaドキュメントをビルドする必要があります。なぜなら、リポジトリーにあるソースコードが最新の状態だからです。"
 
 msgid "The Groonga repository is hosted on `GitHub <https://github.com/groonga/groonga>`_. Checkout the latest source code from the repository::"
-msgstr ""
+msgstr "Groongaのリポジトリーは `GitHub <https://github.com/groonga/groonga>`_ にあります。リポジトリーから最新のソースコードをチェックアウトします::"
 
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -37,13 +37,13 @@ msgstr "Groongaはドキュメントツールとして Sphinx_ を使います�
 msgid "Here are command lines to install Sphinx."
 msgstr "以下はSphinxをインストールするコマンドラインです。"
 
-msgid "Debian GNU/Linux, Ubuntu::"
+msgid "Debian GNU/Linux, Ubuntu:"
 msgstr ""
 
-msgid "CentOS, Fedora::"
+msgid "CentOS, Fedora:"
 msgstr ""
 
-msgid "OS X::"
+msgid "OS X:"
 msgstr ""
 
 msgid "Run ``cmake`` with ``--preset=doc``"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -22,14 +22,11 @@ msgstr "導入"
 msgid "This documentation describes about how to write, generate and manage Groonga documentation."
 msgstr "この文書では、Groongaドキュメントの執筆・生成・管理の方法について説明します。"
 
-msgid "Checkout Groonga from the repository"
-msgstr "リポジトリーからGroongaをチェックアウト"
+msgid "How to clone Groonga repository"
+msgstr "Groongaリポジトリのcloneの仕方"
 
-msgid "You should build Groonga documentation from source code at the repository. Because source code in the repository is the latest."
-msgstr "リポジトリーのソースコードからGroongaドキュメントをビルドする必要があります。なぜなら、リポジトリーにあるソースコードが最新の状態だからです。"
-
-msgid "The Groonga repository is hosted on `GitHub <https://github.com/groonga/groonga>`_. Checkout the latest source code from the repository::"
-msgstr "Groongaのリポジトリーは `GitHub <https://github.com/groonga/groonga>`_ にあります。リポジトリーから最新のソースコードをチェックアウトします::"
+msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press `Fork` button. Now you can clone your Groonga repository."
+msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして `Fork` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます。"
 
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -25,8 +25,8 @@ msgstr "この文書では、Groongaドキュメントの執筆・生成・管�
 msgid "How to clone Groonga repository"
 msgstr "Groongaリポジトリのcloneの仕方"
 
-msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press ``Fork`` button. Now you can clone your Groonga repository:"
-msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして ``Fork`` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます:"
+msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You need to access https://github.com/groonga/groonga and press ``Fork`` button. Now you can clone your Groonga repository:"
+msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして ``Fork`` ボタンを押す必要があります。これで自分のGroongaリポジトリをcloneすることができます:"
 
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -22,6 +22,15 @@ msgstr "導入"
 msgid "This documentation describes about how to write, generate and manage Groonga documentation."
 msgstr "この文書では、Groongaドキュメントの執筆・生成・管理の方法について説明します。"
 
+msgid "Checkout Groonga from the repository"
+msgstr ""
+
+msgid "You should build Groonga documentation from source code at the repository. Because source code in the repository is the latest."
+msgstr ""
+
+msgid "The Groonga repository is hosted on `GitHub <https://github.com/groonga/groonga>`_. Checkout the latest source code from the repository::"
+msgstr ""
+
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"
 

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -25,8 +25,8 @@ msgstr "この文書では、Groongaドキュメントの執筆・生成・管�
 msgid "How to clone Groonga repository"
 msgstr "Groongaリポジトリのcloneの仕方"
 
-msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press ``Fork`` button. Now you can clone your Groonga repository."
-msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして ``Fork`` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます。"
+msgid "First, please fork Groonga repository on GitHub because you need to build Groonga documentation from the latest source code. You just access https://github.com/groonga/groonga and press ``Fork`` button. Now you can clone your Groonga repository:"
+msgstr "はじめに、GitHub上のGroongaリポジトリをforkしてください。 なぜなら、最新のソースコードからGroongaドキュメントをビルドする必要があるからです。https://github.com/groonga/groonga にアクセスして ``Fork`` ボタンを押すだけです。これで自分のGroongaリポジトリをcloneすることができます:"
 
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -12,7 +12,7 @@ How to clone Groonga repository
 First, please fork Groonga repository on GitHub because
 you need to build Groonga documentation from the latest source code.
 You just access https://github.com/groonga/groonga and press
-`Fork` button. Now you can clone your Groonga repository.
+``Fork`` button. Now you can clone your Groonga repository.
 
 .. code-block:: console
 

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -12,7 +12,7 @@ How to clone Groonga repository
 First, please fork Groonga repository on GitHub because
 you need to build Groonga documentation from the latest source code.
 You just access https://github.com/groonga/groonga and press
-``Fork`` button. Now you can clone your Groonga repository.
+``Fork`` button. Now you can clone your Groonga repository:
 
 .. code-block:: console
 

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -16,8 +16,8 @@ You just access https://github.com/groonga/groonga and press
 
 .. code-block:: console
 
-  % git clone --recursive https://github.com/${YOUR_GITHUB_ACCOUNT}/groonga.git
-  % cd groonga
+   % git clone --recursive https://github.com/${YOUR_GITHUB_ACCOUNT}/groonga.git
+   % cd groonga
 
 Install depended software
 -------------------------
@@ -32,27 +32,27 @@ Debian GNU/Linux, Ubuntu:
 
 .. code-block:: console
 
-  % sudo apt-get install -V -y python3-pip gettext
-  % sudo pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+   % sudo apt-get install -V -y python3-pip gettext
+   % sudo pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
 
 CentOS, Fedora:
 
 .. code-block:: console
 
-  % sudo yum install -y python-pip gettext
-  % sudo pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+   % sudo yum install -y python-pip gettext
+   % sudo pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
 
 OS X:
 
 .. code-block:: console
 
-  % brew install python
-  % brew install gettext
-  % export PATH=`brew --prefix gettext`/bin:$PATH
-  % pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+   % brew install python
+   % brew install gettext
+   % export PATH=`brew --prefix gettext`/bin:$PATH
+   % pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
 
 Run ``cmake`` with ``--preset=doc``
 -----------------------------------
@@ -63,7 +63,7 @@ enable it explicitly by adding ``--preset=doc`` option to
 
 .. code-block:: console
 
-  % cmake -S . -B ../groonga.doc --preset=doc
+   % cmake -S . -B ../groonga.doc --preset=doc
 
 Now, your Groonga build is documentation ready.
 
@@ -74,7 +74,7 @@ You can generate HTML by the following command:
 
 .. code-block:: console
 
-  % cmake --build ../groonga.doc
+   % cmake --build ../groonga.doc
 
 You can find generated HTML documentation at ``../groonga.doc/doc/en/html/``.
 

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -16,7 +16,7 @@ You just access https://github.com/groonga/groonga and press
 
 .. code-block:: console
 
-  % git clone https://github.com/${YOUR_GITHUB_ACCOUNT}/groonga.git
+  % git clone --recursive https://github.com/${YOUR_GITHUB_ACCOUNT}/groonga.git
   % cd groonga
 
 Install depended software

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -28,19 +28,25 @@ Groonga uses Sphinx_ as documentation tool.
 
 Here are command lines to install Sphinx.
 
-Debian GNU/Linux, Ubuntu::
+Debian GNU/Linux, Ubuntu:
+
+.. code-block:: console
 
   % sudo apt-get install -V -y python3-pip gettext
   % sudo pip install -r doc/requirements.txt
   % (cd doc && bundle install)
 
-CentOS, Fedora::
+CentOS, Fedora:
+
+.. code-block:: console
 
   % sudo yum install -y python-pip gettext
   % sudo pip install -r doc/requirements.txt
   % (cd doc && bundle install)
 
-OS X::
+OS X:
+
+.. code-block:: console
 
   % brew install python
   % brew install gettext
@@ -53,7 +59,9 @@ Run ``cmake`` with ``--preset=doc``
 
 Groonga disables documentation generation by default. You need to
 enable it explicitly by adding ``--preset=doc`` option to
-``cmake``::
+``cmake``:
+
+.. code-block:: console
 
   % cmake -S . -B ../groonga.doc --preset=doc
 
@@ -62,7 +70,9 @@ Now, your Groonga build is documentation ready.
 Generate HTML
 -------------
 
-You can generate HTML by the following command::
+You can generate HTML by the following command:
+
+.. code-block:: console
 
   % cmake --build ../groonga.doc
 

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -11,7 +11,7 @@ How to clone Groonga repository
 
 First, please fork Groonga repository on GitHub because
 you need to build Groonga documentation from the latest source code.
-You just access https://github.com/groonga/groonga and press
+You need to access https://github.com/groonga/groonga and press
 ``Fork`` button. Now you can clone your Groonga repository:
 
 .. code-block:: console

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -6,17 +6,17 @@ Introduction
 This documentation describes about how to write, generate and manage
 Groonga documentation.
 
-Checkout Groonga from the repository
-------------------------------------
+How to clone Groonga repository
+-------------------------------
 
-You should build Groonga documentation from source code at the repository.
-Because source code in the repository is the latest.
+First, please fork Groonga repository on GitHub because
+you need to build Groonga documentation from the latest source code.
+You just access https://github.com/groonga/groonga and press
+`Fork` button. Now you can clone your Groonga repository.
 
-The Groonga repository is hosted on `GitHub
-<https://github.com/groonga/groonga>`_. Checkout the latest source
-code from the repository::
+.. code-block:: console
 
-  % git clone --recursive git@github.com:groonga/groonga.git
+  % git clone https://github.com/${YOUR_GITHUB_ACCOUNT}/groonga.git
   % cd groonga
 
 Install depended software

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -6,6 +6,19 @@ Introduction
 This documentation describes about how to write, generate and manage
 Groonga documentation.
 
+Checkout Groonga from the repository
+------------------------------------
+
+You should build Groonga documentation from source code at the repository.
+Because source code in the repository is the latest.
+
+The Groonga repository is hosted on `GitHub
+<https://github.com/groonga/groonga>`_. Checkout the latest source
+code from the repository::
+
+  % git clone --recursive git@github.com:groonga/groonga.git
+  % cd groonga
+
 Install depended software
 -------------------------
 


### PR DESCRIPTION
## Why we need this change
It will help them to contribute the documentation because contributors don't have the source code at the first time.
