### PR TITLE
doc: improve `Install depended software` step in the document contribution guide

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -25,11 +25,14 @@ msgstr "この文書では、Groongaドキュメントの執筆・生成・管�
 msgid "Install depended software"
 msgstr "必要なソフトウェアのインストール"
 
+msgid "How to Install Sphinx"
+msgstr "Shpinxのインストール方法"
+
 msgid "Groonga uses Sphinx_ as documentation tool."
 msgstr "Groongaはドキュメントツールとして Sphinx_ を使います。"
 
-msgid "Here are command lines to install Sphinx and the other dependencies."
-msgstr "以下はSphinxと他の必要なソフトウェアをインストールするコマンドラインです。"
+msgid "Here are command lines to install Sphinx."
+msgstr "以下はSphinxをインストールするコマンドラインです。"
 
 msgid "Debian GNU/Linux, Ubuntu:"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -28,8 +28,8 @@ msgstr "必要なソフトウェアのインストール"
 msgid "Groonga uses Sphinx_ as documentation tool."
 msgstr "Groongaはドキュメントツールとして Sphinx_ を使います。"
 
-msgid "Here are command lines to install Sphinx."
-msgstr "以下はSphinxをインストールするコマンドラインです。"
+msgid "Here are command lines to install Sphinx and the other dependencies."
+msgstr "以下はSphinxと他の必要なソフトウェアをインストールするコマンドラインです。"
 
 msgid "Debian GNU/Linux, Ubuntu::"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -31,13 +31,13 @@ msgstr "Groongaはドキュメントツールとして Sphinx_ を使います�
 msgid "Here are command lines to install Sphinx and the other dependencies."
 msgstr "以下はSphinxと他の必要なソフトウェアをインストールするコマンドラインです。"
 
-msgid "Debian GNU/Linux, Ubuntu::"
+msgid "Debian GNU/Linux, Ubuntu:"
 msgstr ""
 
-msgid "CentOS, Fedora::"
+msgid "CentOS, Fedora:"
 msgstr ""
 
-msgid "OS X::"
+msgid "OS X:"
 msgstr ""
 
 msgid "Run ``cmake`` with ``--preset=doc``"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -22,9 +22,6 @@ msgstr "導入"
 msgid "This documentation describes about how to write, generate and manage Groonga documentation."
 msgstr "この文書では、Groongaドキュメントの執筆・生成・管理の方法について説明します。"
 
-msgid "Install depended software"
-msgstr "必要なソフトウェアのインストール"
-
 msgid "How to Install Sphinx"
 msgstr "Shpinxのインストール方法"
 
@@ -42,6 +39,12 @@ msgstr ""
 
 msgid "OS X:"
 msgstr ""
+
+msgid "How to Install required packages for generating documents"
+msgstr "ドキュメント生成に必要なパッケージのインストール方法"
+
+msgid "You can install required packages for generating Groonga documentation by the following command."
+msgstr "以下のコマンドでGroongaドキュメントを生成するのに必要なパッケージをインストールできます。"
 
 msgid "Run ``cmake`` with ``--preset=doc``"
 msgstr "``cmake`` を ``--preset=doc`` 付きで実行"

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -6,9 +6,6 @@ Introduction
 This documentation describes about how to write, generate and manage
 Groonga documentation.
 
-Install depended software
--------------------------
-
 How to Install Sphinx
 -------------------------
 
@@ -43,6 +40,17 @@ OS X:
    % export PATH=`brew --prefix gettext`/bin:$PATH
    % pip install -r doc/requirements.txt
    % (cd doc && bundle install)
+
+How to Install required packages for generating documents
+---------------------------------------------------------
+
+You can install required packages for generating Groonga documentation by the following command.
+
+Debian GNU/Linux, Ubuntu:
+
+.. code-block:: console
+
+   % ./setup.sh
 
 Run ``cmake`` with ``--preset=doc``
 -----------------------------------

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -13,10 +13,11 @@ Groonga uses Sphinx_ as documentation tool.
 
 .. _Sphinx: https://www.sphinx-doc.org/
 
-Here are command lines to install Sphinx.
+Here are command lines to install Sphinx and the other dependencies.
 
 Debian GNU/Linux, Ubuntu::
 
+  % ./setup.sh
   % sudo apt-get install -V -y python3-pip gettext
   % sudo pip install -r doc/requirements.txt
   % (cd doc && bundle install)

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -15,26 +15,31 @@ Groonga uses Sphinx_ as documentation tool.
 
 Here are command lines to install Sphinx and the other dependencies.
 
-Debian GNU/Linux, Ubuntu::
+Debian GNU/Linux, Ubuntu:
 
-  % ./setup.sh
-  % sudo apt-get install -V -y python3-pip gettext
-  % sudo pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+.. code-block:: console
 
-CentOS, Fedora::
+   % sudo apt-get install -V -y python3-pip gettext
+   % sudo pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
 
-  % sudo yum install -y python-pip gettext
-  % sudo pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+CentOS, Fedora:
 
-OS X::
+.. code-block:: console
 
-  % brew install python
-  % brew install gettext
-  % export PATH=`brew --prefix gettext`/bin:$PATH
-  % pip install -r doc/requirements.txt
-  % (cd doc && bundle install)
+   % sudo yum install -y python-pip gettext
+   % sudo pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
+
+OS X:
+
+.. code-block:: console
+
+   % brew install python
+   % brew install gettext
+   % export PATH=`brew --prefix gettext`/bin:$PATH
+   % pip install -r doc/requirements.txt
+   % (cd doc && bundle install)
 
 Run ``cmake`` with ``--preset=doc``
 -----------------------------------

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -50,6 +50,7 @@ Debian GNU/Linux, Ubuntu:
 
 .. code-block:: console
 
+   % cd groonga
    % ./setup.sh
 
 Run ``cmake`` with ``--preset=doc``

--- a/doc/source/contribution/documentation/introduction.rst
+++ b/doc/source/contribution/documentation/introduction.rst
@@ -9,11 +9,14 @@ Groonga documentation.
 Install depended software
 -------------------------
 
+How to Install Sphinx
+-------------------------
+
 Groonga uses Sphinx_ as documentation tool.
 
 .. _Sphinx: https://www.sphinx-doc.org/
 
-Here are command lines to install Sphinx and the other dependencies.
+Here are command lines to install Sphinx.
 
 Debian GNU/Linux, Ubuntu:
 


### PR DESCRIPTION
## What I did
- Add a step for installing depended packages for building documentation on Ubuntu

## What I didn't
- Improve steps for other Linux distributions