### PR TITLE
doc contribution/documentation: remove `Update` step in the doc contribution guide

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -171,12 +171,3 @@ msgstr "変更がすべて反映されているかを確認します"
 
 msgid "Click the `Create Pull Request` button and send your pull request"
 msgstr "`Create Pull Request`ボタンをクリックして、プルリクエストを送ります"
-
-msgid "Update"
-msgstr "更新"
-
-msgid "You can find sources of documentation at `doc/source/`. The sources should be written in English. See {doc}`i18n` about how to translate documentation."
-msgstr "ドキュメントのソースは `doc/source/` にあります。ソースは英語で書かれているはずです。ドキュメントの翻訳方法については、{doc}`i18n` をご覧ください。"
-
-msgid "You can update the target file when you update the existing documentation file."
-msgstr "既に存在するドキュメントのファイルを更新すると、翻訳対象のファイルを更新できます。"

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -184,12 +184,3 @@ Follow these steps:
 2. Click the `Compare & pull request` button
 3. Make sure your changes are reflected
 4. Click the `Create Pull Request` button and send your pull request
-
-## Update
-
-You can find sources of documentation at `doc/source/`. The sources
-should be written in English. See {doc}`i18n` about how to translate
-documentation.
-
-You can update the target file when you update the existing
-documentation file.


### PR DESCRIPTION
The Update step is a duplicated content from the introduction because the processes for editing and translating documentation are already covered at other steps in the introduction page.