### PR TITLE
h3: add missing definition for using common math constants in VC++

### DIFF
--- a/plugins/tokenizers/h3_index.c
+++ b/plugins/tokenizers/h3_index.c
@@ -19,6 +19,19 @@
 #  define GRN_PLUGIN_FUNCTION_TAG tokenizers_h3_index
 #endif
 
+#ifdef WIN32
+#  define _USE_MATH_DEFINES
+/* We want use M_PI macro in math.h.
+   But we can't use M_PI in VC++ just because we include math.h.
+   We need to define _USE_MATH_DEFINES before including math.h in order to use M_PI.
+
+   See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants
+   
+   math.h is included in groonga.h.
+   So, we define _USE_MATH_DEFINES before including groonga.h
+*/
+#endif /* WIN32 */
+
 #include <groonga.h>
 #include <groonga/tokenizer.h>
 
@@ -29,8 +42,6 @@
 #else
 #  include <h3/h3api.h>
 #endif
-
-#include <math.h>
 
 static const char *grn_h3_index_tag = "[tokenizer][h3-index]";
 

--- a/plugins/tokenizers/h3_index.c
+++ b/plugins/tokenizers/h3_index.c
@@ -23,7 +23,8 @@
 #  define _USE_MATH_DEFINES
 /* We want use M_PI macro in math.h.
    But we can't use M_PI in VC++ just because we include math.h.
-   We need to define _USE_MATH_DEFINES before including math.h in order to use M_PI.
+   We need to define _USE_MATH_DEFINES before including math.h in order to use
+   M_PI.
 
    See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants
    

--- a/plugins/tokenizers/h3_index.c
+++ b/plugins/tokenizers/h3_index.c
@@ -27,7 +27,7 @@
    M_PI.
 
    See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants
-   
+
    math.h is included in groonga.h.
    So, we define _USE_MATH_DEFINES before including groonga.h
 */


### PR DESCRIPTION
We want use `M_PI` macro in math.h.
But we can't use `M_PI` in VC++ just because we include `math.h`. We need to define `_USE_MATH_DEFINES` before including `math.h` in order to use `M_PI`.

  See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants

`math.h` is included in `groonga.h`.
So, we define `_USE_MATH_DEFINES` before including `groonga.h`
