### PR TITLE
dist: download all related products when we execute "make dist"

### DIFF
--- a/vendor/Makefile.am
+++ b/vendor/Makefile.am
@@ -45,5 +45,4 @@ dist-hook:
 	GIT_DIR=$(srcdir)/groonga-log-source/.git git archive --format=tar HEAD | \
 	  tar xf - -C $(distdir)/groonga-log-source
 	cd $(distdir) && $(RUBY) download_rapidjson.rb
-	cd $(distdir) && $(RUBY) download.rb blosc
-	cd $(distdir) && $(RUBY) download.rb xsimd
+	cd $(distdir) && $(RUBY) download.rb


### PR DESCRIPTION
Because prevent we forget include related products into Groonga source archive.

If we execute "download.rb" with no arguments, "download.rb" download all related products.

Here is diff under the "vendor/" between before this modification and after this modification.

```diff
--- old.list	2024-03-01 14:55:16.310975363 +0900
+++ new.list	2024-03-01 15:00:04.172958257 +0900
@@ -13788,6 +13788,7 @@
 ./tools/ucd-symbol-list.rb
 ./vendor
 ./vendor/CMakeLists.txt
+./vendor/CRoaring-1.1.2.tar.gz
 ./vendor/Makefile.am
 ./vendor/Makefile.in
 ./vendor/c-blosc2-2.13.2.tar.gz
@@ -13827,6 +13828,7 @@
 ./vendor/groonga-log/Makefile.in
 ./vendor/groonga-log/ruby_scripts_groonga_log_sources.am
 ./vendor/groonga-log/ruby_scripts_sources.am
+./vendor/h3-4.1.0.tar.gz
 ./vendor/lz4
 ./vendor/lz4/CMakeLists.txt
 ./vendor/lz4/Makefile.am
@@ -15297,7 +15299,9 @@
 ./vendor/rapidjson-1.1.0/thirdparty
 ./vendor/rapidjson-1.1.0/thirdparty/gtest
 ./vendor/rapidjson-1.1.0/travis-doxygen.sh
+./vendor/simsimd-3.8.0.tar.gz
 ./vendor/xsimd-12.1.1.tar.gz
+./vendor/zstd-1.5.5.tar.gz
 ./version
 ./version-gen.sh
 ./version.sh
```