### PR TITLE
test: skip a test that uses an empty key in Apache Arrow input mode

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -251,7 +251,6 @@ jobs:
         run: |
           grntest \
             --base-dir test/command \
-            --exclude-test load/vector/reference/missing_add/object/empty \
             --n-retries=2 \
             --read-timeout=30 \
             --reporter=mark \
@@ -802,7 +801,6 @@ jobs:
           $Env:GRN_ENABLE_REFERENCE_COUNT = "yes"
           grntest `
             --base-directory test\command `
-            --exclude-test load\vector\reference\missing_add\object\empty
             --groonga "${Env:FULL_INSTALL_FOLDER}\bin\groonga.exe" `
             --input-type apache-arrow `
             --interface http `

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -251,6 +251,7 @@ jobs:
         run: |
           grntest \
             --base-dir test/command \
+            --exclude-test load/vector/reference/missing_add/object/empty \
             --n-retries=2 \
             --read-timeout=30 \
             --reporter=mark \
@@ -801,6 +802,7 @@ jobs:
           $Env:GRN_ENABLE_REFERENCE_COUNT = "yes"
           grntest `
             --base-directory test\command `
+            --exclude-test load\vector\reference\missing_add\object\empty
             --groonga "${Env:FULL_INSTALL_FOLDER}\bin\groonga.exe" `
             --input-type apache-arrow `
             --interface http `

--- a/test/command/suite/load/vector/reference/missing_add/object/empty.test
+++ b/test/command/suite/load/vector/reference/missing_add/object/empty.test
@@ -1,3 +1,5 @@
+#@require-input-type json
+
 table_create Tags TABLE_HASH_KEY ShortText --normalizer NormalizerAuto
 
 table_create Data TABLE_NO_KEY


### PR DESCRIPTION
Because Apache Arrow format can't send an empty key.