### PR TITLE
doc contribution/documentation: add how to reflect translations to `.po` files to the translate doc section

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -109,6 +109,9 @@ msgstr "Groongaドキュメントの編集とプレビューが完了したら�
 msgid "Translate the documentation in `.edit.po` files"
 msgstr "`.edit.po` ファイル内のドキュメントを翻訳する"
 
+msgid "Reflect translations to `.po` files"
+msgstr ""
+
 msgid "Use the following command to generate `.edit.po` files, which are translation files, corresponding to your changes. The generated files will be located in `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. Please add your translations to `.edit.po` files:"
 msgstr "次のコマンドで、翻訳用である `.edit.po` ファイルを生成します。生成されたファイルは `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応するファイルが生成されています。対応する `.edit.po` ファイルに翻訳を追加します。"
 
@@ -117,6 +120,15 @@ msgstr "例えば、この {doc}`introduction` ページを編集して、日本
 
 msgid "Please do not modify the `.rst` or `.md` files while adding translations to the `.edit.po` files. Editing `.rst` or `.md` files without first reflecting the translations in `.po` files will result in the loss of those translations. If you want to edit `.rst` or `.md` files, ensure you first reflect your translations in `.po` files. The method to reflect translations will be introduced in the next step."
 msgstr "`.edit.po` ファイルに翻訳を追加している最中に、翻訳元の `.rst` または `.md` ファイルを変更しないでください。翻訳した内容を `.po` ファイルに反映せずにを翻訳元を編集してしまうと、翻訳内容が消えてしまいます。翻訳元を編集したい場合は先に翻訳内容を `.po` ファイルに反映してください。反映方法は次のステップで紹介します。"
+
+msgid "After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files, which are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file."
+msgstr ""
+
+msgid "To reflect translations from the `.edit.po` files to the `.po` files, use the following command:"
+msgstr ""
+
+msgid "For example, if you have added translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/ja/LC_MESSAGES/contribution/documentation/introduction.po` file."
+msgstr ""
 
 msgid "Update"
 msgstr "更新"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -110,7 +110,7 @@ msgid "Translate the documentation in `.edit.po` files"
 msgstr "`.edit.po` ファイル内のドキュメントを翻訳する"
 
 msgid "Reflect translations to `.po` files"
-msgstr ""
+msgstr "翻訳を `.po` ファイルに反映する"
 
 msgid "Use the following command to generate `.edit.po` files, which are translation files, corresponding to your changes. The generated files will be located in `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. Please add your translations to `.edit.po` files:"
 msgstr "次のコマンドで、翻訳用である `.edit.po` ファイルを生成します。生成されたファイルは `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応するファイルが生成されています。対応する `.edit.po` ファイルに翻訳を追加します。"
@@ -122,13 +122,13 @@ msgid "Please do not modify the `.rst` or `.md` files while adding translations 
 msgstr "`.edit.po` ファイルに翻訳を追加している最中に、翻訳元の `.rst` または `.md` ファイルを変更しないでください。翻訳した内容を `.po` ファイルに反映せずにを翻訳元を編集してしまうと、翻訳内容が消えてしまいます。翻訳元を編集したい場合は先に翻訳内容を `.po` ファイルに反映してください。反映方法は次のステップで紹介します。"
 
 msgid "After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files, which are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file."
-msgstr ""
+msgstr "`.edit.po` ファイルに翻訳を追加した後、最終的な翻訳ファイルである `.po` ファイルへ翻訳を反映するのが、次のステップになります。`.po` ファイルは、`doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応しています。翻訳を編集したい場合は、対応する `.edit.po` ファイルを編集してから、変更内容を `.po` ファイルに反映し直す必要があります。"
 
 msgid "To reflect translations from the `.edit.po` files to the `.po` files, use the following command:"
-msgstr ""
+msgstr "次のコマンドで、翻訳内容を `.edit.po` ファイルから `.po` ファイルへ反映します。"
 
-msgid "For example, if you have added translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/ja/LC_MESSAGES/contribution/documentation/introduction.po` file."
-msgstr ""
+msgid "For example, if you have added Japanese translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` file."
+msgstr "例えば、この {doc}`introduction` ページの日本語訳を行い、上記のコマンドを実行した場合、翻訳内容は、`/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` ファイルに反映されます。"
 
 msgid "Update"
 msgstr "更新"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -130,6 +130,9 @@ msgstr "次のコマンドで、翻訳内容を `.edit.po` ファイルから `.
 msgid "For example, if you have added Japanese translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` file."
 msgstr "例えば、この {doc}`introduction` ページの日本語訳を行い、上記のコマンドを実行した場合、翻訳内容は、`/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` ファイルに反映されます。"
 
+msgid "Actually, the command to generate translation `.edit.po` files is the same as the one used for reflecting translations.  Therefore, there's no need to memorize different commands for generating translation files and reflecting the translations."
+msgstr "実は、翻訳を反映するコマンドは、翻訳用の `.edit.po` ファイルを生成するコマンドと同じコマンドです。なので、翻訳用のファイル生成と翻訳の反映で違うコマンドを覚える必要はありません。"
+
 msgid "Update"
 msgstr "更新"
 

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -121,8 +121,8 @@ msgstr "例えば、この {doc}`introduction` ページを編集して、日本
 msgid "Please do not modify the `.rst` or `.md` files while adding translations to the `.edit.po` files. Editing `.rst` or `.md` files without first reflecting the translations in `.po` files will result in the loss of those translations. If you want to edit `.rst` or `.md` files, ensure you first reflect your translations in `.po` files. The method to reflect translations will be introduced in the next step."
 msgstr "`.edit.po` ファイルに翻訳を追加している最中に、翻訳元の `.rst` または `.md` ファイルを変更しないでください。翻訳した内容を `.po` ファイルに反映せずにを翻訳元を編集してしまうと、翻訳内容が消えてしまいます。翻訳元を編集したい場合は先に翻訳内容を `.po` ファイルに反映してください。反映方法は次のステップで紹介します。"
 
-msgid "After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files, which are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file."
-msgstr "`.edit.po` ファイルに翻訳を追加した後、最終的な翻訳ファイルである `.po` ファイルへ翻訳を反映するのが、次のステップになります。`.po` ファイルは、`doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応しています。翻訳を編集したい場合は、対応する `.edit.po` ファイルを編集してから、変更内容を `.po` ファイルに反映し直す必要があります。"
+msgid "After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files. `.po` files are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file."
+msgstr "`.edit.po` ファイルに翻訳を追加した後、`.po` ファイルへ翻訳を反映するのが、次のステップになります。`.po` ファイルは、最終的な翻訳ファイルになります。ファイルは、`doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応しています。翻訳を編集したい場合は、対応する `.edit.po` ファイルを編集してから、変更内容を `.po` ファイルに反映し直す必要があります。"
 
 msgid "To reflect translations from the `.edit.po` files to the `.po` files, use the following command:"
 msgstr "次のコマンドで、翻訳内容を `.edit.po` ファイルから `.po` ファイルへ反映します。"

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -129,7 +129,7 @@ The method to reflect translations will be introduced in the next step.
 
 ### Reflect translations to `.po` files
 
-After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files, which are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file.
+After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files. `.po` files are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file.
 
 To reflect translations from the `.edit.po` files to the `.po` files, use the following command:
 

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -139,6 +139,11 @@ To reflect translations from the `.edit.po` files to the `.po` files, use the fo
 
 For example, if you have added Japanese translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` file.
 
+```{note}
+Actually, the command to generate translation `.edit.po` files is the same as the one used for reflecting translations.
+Therefore, there's no need to memorize different commands for generating translation files and reflecting the translations.
+```
+
 ## Update
 
 You can find sources of documentation at `doc/source/`. The sources

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -108,6 +108,7 @@ This is an optional step.
 After editing and previewing the Groonga documentation, the next step is to translate the documents to make them accessible to a wider range of Groonga community users. Translating into languages other than English ensures that non-English speakers can also understand the Groonga documentation. Follow these steps to translate Groonga documentation.
 
 1. Translate the documentation in `.edit.po` files
+2. Reflect translations to `.po` files
 
 ### Translate the documentation in `.edit.po` files
 
@@ -125,6 +126,18 @@ Editing `.rst` or `.md` files without first reflecting the translations in `.po`
 If you want to edit `.rst` or `.md` files, ensure you first reflect your translations in `.po` files.
 The method to reflect translations will be introduced in the next step.
 ```
+
+### Reflect translations to `.po` files
+
+After adding your translations to the `.edit.po` files, the next step is to reflect these translations to the `.po` files, which are the finalized translation files. These `.po` files are located in `doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. If you want to edit your translations, edit the corresponding `.edit.po` file and then reflect your changes to the `.po` file.
+
+To reflect translations from the `.edit.po` files to the `.po` files, use the following command:
+
+```console
+% cmake --build ../groonga.doc
+```
+
+For example, if you have added translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/ja/LC_MESSAGES/contribution/documentation/introduction.po` file.
 
 ## Update
 

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -137,7 +137,7 @@ To reflect translations from the `.edit.po` files to the `.po` files, use the fo
 % cmake --build ../groonga.doc
 ```
 
-For example, if you have added translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/ja/LC_MESSAGES/contribution/documentation/introduction.po` file.
+For example, if you have added Japanese translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` file.
 
 ## Update
 


### PR DESCRIPTION
Related Issue: https://github.com/groonga/groonga/issues/1733

I will add a new sections to the `introduction.md` about translating documentation.
- [x] Reflect Your Translations without Japanese translations
- [x] Add Japanese translations to Reflect Your Translations

I will do the below tasks at the following PRs.
- [ ] Preview Your Translations on HTML
- [ ] Send Pull Request to Groonga Repository