### PR TITLE
doc contribution/documentation: add how to preview translations on HTML files to the translate doc section

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -112,6 +112,9 @@ msgstr "`.edit.po` ファイル内のドキュメントを翻訳する"
 msgid "Reflect translations to `.po` files"
 msgstr "翻訳を `.po` ファイルに反映する"
 
+msgid "Preview translations on HTML files"
+msgstr ""
+
 msgid "Use the following command to generate `.edit.po` files, which are translation files, corresponding to your changes. The generated files will be located in `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES`. Each file corresponds to a `.rst` or `.md` file. Please add your translations to `.edit.po` files:"
 msgstr "次のコマンドで、翻訳用である `.edit.po` ファイルを生成します。生成されたファイルは `../groonga.doc/doc/locale/${LANGUAGE}/LC_MESSAGES` 配下にあります。各 `.rst` または `.md` ファイルに対応するファイルが生成されています。対応する `.edit.po` ファイルに翻訳を追加します。"
 
@@ -130,8 +133,14 @@ msgstr "次のコマンドで、翻訳内容を `.edit.po` ファイルから `.
 msgid "For example, if you have added Japanese translations about the {doc}`introduction` page and then execute the command above, your translations will be reflected to `/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` file."
 msgstr "例えば、この {doc}`introduction` ページの日本語訳を行い、上記のコマンドを実行した場合、翻訳内容は、`/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po` ファイルに反映されます。"
 
-msgid "Actually, the command to generate translation `.edit.po` files is the same as the one used for reflecting translations.  Therefore, there's no need to memorize different commands for generating translation files and reflecting the translations."
+msgid "Actually, the command to generate translation `.edit.po` files is the same as the one used for reflecting translations. Therefore, there's no need to memorize different commands for generating translation files and reflecting the translations."
 msgstr "実は、翻訳を反映するコマンドは、翻訳用の `.edit.po` ファイルを生成するコマンドと同じコマンドです。なので、翻訳用のファイル生成と翻訳の反映で違うコマンドを覚える必要はありません。"
+
+msgid "You can preview your translations in your browser in HTML format. The step for reflecting translations into `.po` files also generates the corresponding HTML files. These files are located in `../groonga.doc/doc/${LANGUAGE}/html/`. Each file corresponds to a `.rst` or `.md` file. Open the generated HTML file in your web browser to review your translations."
+msgstr ""
+
+msgid "For example, to preview the Japanese translation of the {doc}`introduction` page, use the following command:"
+msgstr ""
 
 msgid "Update"
 msgstr "更新"

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -147,7 +147,7 @@ Therefore, there's no need to memorize different commands for generating transla
 
 ### Preview translations on HTML files
 
-You can preview your translations in your browser in HTML format. The step for reflecting translations into `.po` files also generates the corresponding HTML files. These files are located in `../groonga.doc/doc/${LANGUAGE}/html/`. Each file corresponds to a `.rst` or `.md` file. Open the generated HTML file in your web browser to review your translations.
+You can preview your translations in your Web browser in HTML format. The step for reflecting translations into `.po` files also generates the corresponding HTML files. These files are located in `../groonga.doc/doc/${LANGUAGE}/html/`. Each file corresponds to a `.rst` or `.md` file. Open the generated HTML file in your Web browser to review your translations.
 
 For example, to preview the Japanese translation of the {doc}`introduction` page, use the following command:
 

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -109,6 +109,7 @@ After editing and previewing the Groonga documentation, the next step is to tran
 
 1. Translate the documentation in `.edit.po` files
 2. Reflect translations to `.po` files
+3. Preview translations on HTML files
 
 ### Translate the documentation in `.edit.po` files
 
@@ -142,6 +143,16 @@ For example, if you have added Japanese translations about the {doc}`introductio
 ```{note}
 Actually, the command to generate translation `.edit.po` files is the same as the one used for reflecting translations.
 Therefore, there's no need to memorize different commands for generating translation files and reflecting the translations.
+```
+
+### Preview translations on HTML files
+
+You can preview your translations in your browser in HTML format. The step for reflecting translations into `.po` files also generates the corresponding HTML files. These files are located in `../groonga.doc/doc/${LANGUAGE}/html/`. Each file corresponds to a `.rst` or `.md` file. Open the generated HTML file in your web browser to review your translations.
+
+For example, to preview the Japanese translation of the {doc}`introduction` page, use the following command:
+
+```console
+% open ../groonga.doc/doc/ja/html/contribution/documentation/introduction.html
 ```
 
 ## Update


### PR DESCRIPTION
Related Issue: https://github.com/groonga/groonga/issues/1733

I will add a new sections to the `introduction.md` about translating documentation.
- [x] Preview Your Translations on HTML without Japanese translations

I will do the below tasks at the following PRs.
- [ ] Add Japanese translations to Preview Your Translations on HTML
- [ ] Send Pull Request to Groonga Repository