### PR TITLE
package almalinux-8 test: use Ruby 3.1 instead of 2.5 for grntest

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -72,6 +72,11 @@ if [ "${run_test}" = "yes" ]; then
       . /opt/rh/rh-ruby30/enable
       set -u
       ;;
+    8)
+      ${DNF} module disable -y ruby
+      ${DNF} module enable -y ruby:3.1
+      ${DNF} install -y ruby-devel
+      ;;
     *)
       ${DNF} install -y ruby-devel
       ;;


### PR DESCRIPTION
## Problem

CI failed with the following error log.

```
ERROR:  Error installing grntest:
	timeout requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```

- ref: https://github.com/groonga/groonga/actions/runs/8677683712/job/23793718468

## Expected

Successfully install gem `grntest`.

## Explanation

The gem `timeout` requires Ruby version >= 2.6.0.
On AlmaLinux8, the default Ruby version is 2.5.0 as shown below.

```console
$ dnf module list ruby
Name                          Stream                           Profiles                            Summary                                                                     
ruby                          2.5 [d]                          common [d]                          An interpreter of object-oriented scripting language                        
ruby                          2.6                              common [d]                          An interpreter of object-oriented scripting language                        
ruby                          2.7                              common [d]                          An interpreter of object-oriented scripting language                        
ruby                          3.0                              common [d]                          An interpreter of object-oriented scripting language                        
ruby                          3.1                              common [d]                          An interpreter of object-oriented scripting language                        

Hint: [d]efault, [e]nabled, [x]disabled, [i]nstalled 
```

## Solution

Use Ruby 3.1 not 2.5 for grntest.

grntest is used only for test. So newer Ruby doesn't affect anything to users.