### PR TITLE
ja: Add grn_ja_is_empty()

### DIFF
--- a/lib/grn_store.h
+++ b/lib/grn_store.h
@@ -165,6 +165,8 @@ GRN_API grn_rc
 grn_ja_putv(grn_ctx *ctx, grn_ja *ja, grn_id id, grn_obj *vector, int flags);
 GRN_API uint32_t
 grn_ja_size(grn_ctx *ctx, grn_ja *ja, grn_id id);
+GRN_API bool
+grn_ja_is_empty(grn_ctx *ctx, grn_ja *ja, grn_id id);
 
 void
 grn_ja_check(grn_ctx *ctx, grn_ja *ja);


### PR DESCRIPTION
We will add `grn_obj_is_empty` after this.
We will use it there.
`grn_obj_is_empty` is used to improve checking for empty values.