### PR TITLE
ja: Skip object clear in grn_obj_clear_value(), if object is empty

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -2539,7 +2539,7 @@ grn_obj_clear_value(grn_ctx *ctx, grn_obj *obj, grn_id id)
     grn_id range = DB_OBJ(obj)->range;
     switch (obj->header.type) {
     case GRN_COLUMN_VAR_SIZE:
-      {
+      if (!grn_obj_is_empty(ctx, obj, id)) {
         grn_obj buf;
         GRN_VOID_INIT(&buf);
         rc = grn_obj_set_value(ctx, obj, id, &buf, GRN_OBJ_SET);


### PR DESCRIPTION
This is an optimization. This doesn't change the current behavior.

In `grn_obj_set_value()`, it checks if the value is the same, and if it is, it does not update.
This check fetches value but it's heavy when we need to remove many records.
For example, `RESULT_SET1 && RESULT_SET2` is heavy is `RESULT_SET1` and `RESULT_SET2` have many different records.

We can check it with more lighter way. We don't need entire value. We just need to know whether the existing value is empty or not.