### PR TITLE
test debian bullseye: workaround for build error of red-arrow

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -69,7 +69,7 @@ if groonga --version | grep -q apache-arrow; then
     g++ \
     libre2-dev
   if [ "${code_name}" == "bullseye" ]; then
-    sed -i -e 's/-std=c++11//g' /usr/lib/x86_64-linux-gnu/pkgconfig/re2.pc
+    sed -i -e 's/-std=c++11//g' /usr/lib/*/pkgconfig/re2.pc
   fi
   MAKEFLAGS=-j$(nproc) gem install red-arrow
 fi

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -67,6 +67,9 @@ MAKEFLAGS=-j$(nproc) gem install grntest
 if groonga --version | grep -q apache-arrow; then
   apt install -V -y \
     g++
+  if [ "${code_name}" == "bullseye" ]; then
+    sed -i -e 's/-std=c++11//g' /usr/lib/x86_64-linux-gnu/pkgconfig/re2.pc
+  fi
   MAKEFLAGS=-j$(nproc) gem install red-arrow
 fi
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -66,7 +66,8 @@ MAKEFLAGS=-j$(nproc) gem install grntest
 
 if groonga --version | grep -q apache-arrow; then
   apt install -V -y \
-    g++
+    g++ \
+    libre2-dev
   if [ "${code_name}" == "bullseye" ]; then
     sed -i -e 's/-std=c++11//g' /usr/lib/x86_64-linux-gnu/pkgconfig/re2.pc
   fi


### PR DESCRIPTION
Apache Arrow C++ requires C++17 or later.
However re2.pc on Debian bullseye have "-std=c++11". If "-std=c++11" was added, we can't build Apache Arrow C++.

TODO: This is testing now on CI.