### PR TITLE
doc contribution/documentation: improve steps about send patch

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -101,7 +101,7 @@ msgid "Send patch"
 msgstr "パッチを送る"
 
 msgid "You can submit your patch to the Groonga repository on GitHub via a pull request. Feel free to send a pull request by following two steps."
-msgstr "GitHub上のGroongaリポジトリに対してプルリクエストを通じてパッチを送ることができます。次の手順で、気軽にプルリクエストを作ってみましょう"
+msgstr "GitHub上のGroongaリポジトリに対してプルリクエストを通じてパッチを送ることができます。次の手順で、気軽にプルリクエストを作ってみましょう。"
 
 msgid "Prepare your pull request"
 msgstr "プルリクエストの準備をする"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -97,6 +97,36 @@ msgstr "次のコマンドで、変更を反映したHTMLファイルを生成�
 msgid "Open the generated file in your Web browser to preview your changes. For example, if you have edited this {doc}`introduction` page, you can preview it by the following command:"
 msgstr "生成されたファイルをWebブラウザで開き、変更を確認できます。例えば、この {doc}`introduction` ページを編集した場合、次のコマンドで変更を確認できます。"
 
+msgid "Send patch"
+msgstr "パッチを送る"
+
+msgid "You can submit your patch to the Groonga repository on GitHub via a pull request. Feel free to send a pull request by following two steps."
+msgstr "GitHub上のGroongaリポジトリに対してプルリクエストを通じてパッチを送ることができます。次の手順で、気軽にプルリクエストを作ってみましょう"
+
+msgid "Prepare your pull request"
+msgstr "プルリクエストの準備をする"
+
+msgid "Submit your pull request"
+msgstr "プルリクエストを送る"
+
+msgid "Ensure your changes are committed and then push your changes to your fork repository on GitHub. Follow these commands:"
+msgstr "次のコマンドで、変更をコミットし、その変更をGitHubにある自分のフォークリポジトリにプッシュします。"
+
+msgid "Now you're ready to submit a pull request to the upstream Groonga repository. Follow these steps:"
+msgstr "これで、アップストリームのGroongaリポジトリにプルリクエストを送る準備ができました。次のステップに従い実際にプルリクエストを送ってみましょう。"
+
+msgid "Go to your fork repository on GitHub"
+msgstr "GitHubで自分のフォークリポジトリにアクセスします"
+
+msgid "Click the `Compare & pull request` button"
+msgstr "`Compare & pull request`ボタンをクリックします"
+
+msgid "Make sure your changes are reflected"
+msgstr "変更がすべて反映されているかを確認します"
+
+msgid "Click the `Create Pull Request` button and send your pull request"
+msgstr "`Create Pull Request`ボタンをクリックして、プルリクエストを送ります"
+
 msgid "Optional: Translate documentation"
 msgstr "任意: ドキュメントを翻訳する"
 
@@ -142,32 +172,5 @@ msgstr "翻訳が反映されたHTML形式のドキュメントをWebブラウ�
 msgid "For example, to preview the Japanese translation of the {doc}`introduction` page, use the following command:"
 msgstr "例えば、{doc}`introduction` ページに日本語訳を追加した場合、次のコマンドで確認できます"
 
-msgid "Send patch"
-msgstr "パッチを送る"
-
-msgid "You can submit your patch to the Groonga repository on GitHub via a pull request. Feel free to send a pull request by following two steps."
-msgstr "GitHub上のGroongaリポジトリに対してプルリクエストを通じてパッチを送ることができます。次の手順で、気軽にプルリクエストを作ってみましょう"
-
-msgid "Prepare your pull request"
-msgstr "プルリクエストの準備をする"
-
-msgid "Submit your pull request"
-msgstr "プルリクエストを送る"
-
-msgid "Ensure your changes are committed and then push your changes to your fork repository on GitHub. Follow these commands:"
-msgstr "次のコマンドで、変更をコミットし、その変更をGitHubにある自分のフォークリポジトリにプッシュします。"
-
-msgid "Now you're ready to submit a pull request to the upstream Groonga repository. Follow these steps:"
-msgstr "これで、アップストリームのGroongaリポジトリにプルリクエストを送る準備ができました。次のステップに従い実際にプルリクエストを送ってみましょう。"
-
-msgid "Go to your fork repository on GitHub"
-msgstr "GitHubで自分のフォークリポジトリにアクセスします"
-
-msgid "Click the `Compare & pull request` button"
-msgstr "`Compare & pull request`ボタンをクリックします"
-
-msgid "Make sure your changes are reflected"
-msgstr "変更がすべて反映されているかを確認します"
-
-msgid "Click the `Create Pull Request` button and send your pull request"
-msgstr "`Create Pull Request`ボタンをクリックして、プルリクエストを送ります"
+msgid "If the translations seem correct after preview, please send a patch. For more information on this process, see the [Send patch](#send-patch)"
+msgstr "翻訳を確認して正しく反映されていましたら、パッチを送りましょう。送り方については、[パッチを送る](#send-patch)を参照してください。"

--- a/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/documentation/introduction.po
@@ -173,4 +173,4 @@ msgid "For example, to preview the Japanese translation of the {doc}`introductio
 msgstr "例えば、{doc}`introduction` ページに日本語訳を追加した場合、次のコマンドで確認できます"
 
 msgid "If the translations seem correct after preview, please send a patch. For more information on this process, see the [Send patch](#send-patch)"
-msgstr "翻訳を確認して正しく反映されていましたら、パッチを送りましょう。送り方については、[パッチを送る](#send-patch)を参照してください。"
+msgstr "翻訳を確認して正しく反映されていたらパッチを送りましょう。送り方については、[パッチを送る](#send-patch)を参照してください。"

--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -101,6 +101,36 @@ For example, if you have edited this {doc}`introduction` page, you can preview i
 % open ../groonga.doc/doc/en/html/contribution/documentation/introduction.html
 ```
 
+## Send patch
+
+You can submit your patch to the Groonga repository on GitHub via a pull request.
+Feel free to send a pull request by following two steps.
+
+- Prepare your pull request
+- Submit your pull request
+
+### Prepare your pull request
+
+Ensure your changes are committed and then push your changes to your fork repository on GitHub.
+Follow these commands:
+
+```console
+% git switch -c your-working-branch
+% git add doc
+% git commit -m 'Describe your works here'
+% git push origin your-working-branch
+```
+
+### Submit your pull request
+
+Now you're ready to submit a pull request to the upstream Groonga repository.
+Follow these steps:
+
+1. Go to your fork repository on GitHub
+2. Click the `Compare & pull request` button
+3. Make sure your changes are reflected
+4. Click the `Create Pull Request` button and send your pull request
+
 ## Optional: Translate documentation
 
 This is an optional step.
@@ -155,32 +185,4 @@ For example, to preview the Japanese translation of the {doc}`introduction` page
 % open ../groonga.doc/doc/ja/html/contribution/documentation/introduction.html
 ```
 
-## Send patch
-
-You can submit your patch to the Groonga repository on GitHub via a pull request.
-Feel free to send a pull request by following two steps.
-
-- Prepare your pull request
-- Submit your pull request
-
-### Prepare your pull request
-
-Ensure your changes are committed and then push your changes to your fork repository on GitHub.
-Follow these commands:
-
-```console
-% git switch -c your-working-branch
-% git add doc
-% git commit -m 'Describe your works here'
-% git push origin your-working-branch
-```
-
-### Submit your pull request
-
-Now you're ready to submit a pull request to the upstream Groonga repository.
-Follow these steps:
-
-1. Go to your fork repository on GitHub
-2. Click the `Compare & pull request` button
-3. Make sure your changes are reflected
-4. Click the `Create Pull Request` button and send your pull request
+If the translations seem correct after preview, please send a patch. For more information on this process, see the [Send patch](#send-patch)


### PR DESCRIPTION
Related Issue: https://github.com/groonga/groonga/issues/1733

- [x] Add the Sending patch section after Preview Your Modifications on HTML

Consider sending a PR before the `Optional: Translate documentation`.
This approach allows non-Japanese speakers to update only the English sections without needing to skip any parts.

ref: https://github.com/groonga/groonga/pull/1746#discussion_r1542432771