### PR TITLE
ci: don't remove "{...}"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -143,7 +143,6 @@ jobs:
              -e 'print("## Groonga "); \
                  puts(ARGF.read.split(/^## Release /)[1]. \
                         gsub(/^\(.+\)=$/, ""). \
-                        gsub(/ {.+?}/, ""). \
                         gsub(/{doc}`(.+?)`/) { \
                           id = $1; \
                           title = id.split("\/").last; \


### PR DESCRIPTION
Because if "{...}" may exist in example of release note.