### PR TITLE
ci cmake windows: remove unnecessary step for installing red-arrow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -790,8 +790,6 @@ jobs:
             grntest `
             pkg-config `
             red-arrow
-      - name: Install Red Arrow
-        run: |
       - name: "Test: command line"
         run: |
           ruby test\command_line\run-test.rb `


### PR DESCRIPTION
Because it has already been installed at the previous step.