### PR TITLE
Add rc check after scan_info_build_match()

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -3905,6 +3905,9 @@ grn_scan_info_build_simple_and_operations(grn_ctx *ctx,
     {
       float weight = grn_weight_bulk_get(ctx, operator->value);
       scan_info_build_match(ctx, si, -1, weight);
+      if (ctx->rc != GRN_SUCCESS) {
+        goto exit;
+      }
     }
 
     if (nth_sis > 0) {


### PR DESCRIPTION
In `invalid match target: <>` error, stop processing.
This error occurs in scan_info_build_match(), so check rc.

The other calls to scan_info_build_match() have already been checked.
* https://github.com/groonga/groonga/blob/c4a58af6373b283f76eb6b4c49276f020752d7da/lib/expr.c#L3349-L3361
* https://github.com/groonga/groonga/blob/c4a58af6373b283f76eb6b4c49276f020752d7da/lib/expr.c#L3749-L3757