### PR TITLE
scan_info_build_match_expr_codes: Improve error message

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -2730,7 +2730,7 @@ scan_info_build_match_expr_codes(
       grn_inspect(ctx, &inspected, ec->value);
 
       ERR(GRN_INVALID_ARGUMENT,
-          "invalid match target: <%.*s>",
+          "invalid match target: %.*s",
           (int)GRN_TEXT_LEN(&inspected),
           GRN_TEXT_VALUE(&inspected));
 

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -2725,13 +2725,16 @@ scan_info_build_match_expr_codes(
     break;
   default:
     {
-      char name[GRN_TABLE_MAX_KEY_SIZE];
-      int name_size;
-      name_size = grn_obj_name(ctx, ec->value, name, GRN_TABLE_MAX_KEY_SIZE);
+      grn_obj inspected;
+      GRN_TEXT_INIT(&inspected, 0);
+      grn_inspect(ctx, &inspected, ec->value);
+
       ERR(GRN_INVALID_ARGUMENT,
           "invalid match target: <%.*s>",
-          name_size,
-          name);
+          (int)GRN_TEXT_LEN(&inspected),
+          GRN_TEXT_VALUE(&inspected));
+
+      GRN_OBJ_FIN(ctx, &inspected);
       return expr->codes_curr;
     }
     break;

--- a/test/command/suite/select/match_columns/invalid/table.expected
+++ b/test/command/suite/select/match_columns/invalid/table.expected
@@ -20,8 +20,7 @@ select Memos   --match_columns Memos   --query Groonga
       0.0,
       0.0
     ],
-    "invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>"
+    "invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[1] subrec:none>"
   ]
 ]
 #|e| invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[1] subrec:none>
-#|e| invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>

--- a/test/command/suite/select/match_columns/invalid/table.expected
+++ b/test/command/suite/select/match_columns/invalid/table.expected
@@ -13,5 +13,15 @@ load --table Memos
 ]
 [[0,0.0,0.0],1]
 select Memos   --match_columns Memos   --query Groonga
-[[[-22,0.0,0.0],"invalid match target: <Memos>"]]
-#|e| invalid match target: <Memos>
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>>"
+  ]
+]
+#|e| invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[1] subrec:none>>
+#|e| invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>>

--- a/test/command/suite/select/match_columns/invalid/table.expected
+++ b/test/command/suite/select/match_columns/invalid/table.expected
@@ -20,8 +20,8 @@ select Memos   --match_columns Memos   --query Groonga
       0.0,
       0.0
     ],
-    "invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>>"
+    "invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>"
   ]
 ]
-#|e| invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[1] subrec:none>>
-#|e| invalid match target: <#<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>>
+#|e| invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[1] subrec:none>
+#|e| invalid match target: #<table:no_key Memos value:(nil) size:1 columns:[title] ids:[] subrec:none>

--- a/test/command/suite/select/match_columns/invalid/table.test
+++ b/test/command/suite/select/match_columns/invalid/table.test
@@ -1,3 +1,5 @@
+#@require-feature mruby
+
 table_create Memos TABLE_NO_KEY
 column_create Memos title COLUMN_SCALAR ShortText
 

--- a/test/command/suite/select/match_columns/invalid/table.test
+++ b/test/command/suite/select/match_columns/invalid/table.test
@@ -1,5 +1,3 @@
-#@require-feature mruby
-
 table_create Memos TABLE_NO_KEY
 column_create Memos title COLUMN_SCALAR ShortText
 


### PR DESCRIPTION
Include the result of grn_inspect() in the message because there may be logs with no information, such as `invalid match target: <>`.