### PR TITLE
grn_scan_info_build: Add missing RC check of grn_scan_scan_info_build_simple()

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -3986,6 +3986,9 @@ grn_scan_info_build(
   scan_info **sis;
 
   sis = grn_scan_info_build_simple(ctx, expr, n, op, record_exist);
+  if (ctx->rc != GRN_SUCCESS) {
+    return NULL;
+  }
 #ifdef GRN_WITH_MRUBY
   if (!sis) {
     grn_ctx_impl_mrb_ensure_init(ctx);


### PR DESCRIPTION
Add rc check because the error message changes depending on whether mruby is enabled or disabled when rc is not `GRN_SUCCESS`.

When mruby is enabled and rc is not `GRN_SUCCESS`, NULL is retuned because rc is checked.
(The next process will not continue.)

If mruby is disabled and rc is not checked, the next process will be executed and the error message may be overwritten.