### PR TITLE
Add grn_expr_get_n_codes()

### DIFF
--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -158,6 +158,8 @@ grn_expr_parse(grn_ctx *ctx,
                grn_operator default_mode,
                grn_operator default_op,
                grn_expr_flags flags);
+uint32_t
+grn_expr_get_n_codes(grn_ctx *ctx, grn_obj *expr);
 
 GRN_API grn_obj *
 grn_expr_snip(grn_ctx *ctx,

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -6237,6 +6237,12 @@ grn_expr_parse(grn_ctx *ctx,
   GRN_API_RETURN(ctx->rc);
 }
 
+uint32_t
+grn_expr_get_n_codes(grn_ctx *ctx, grn_obj *expr)
+{
+  return ((grn_expr *)expr)->codes_curr;
+}
+
 grn_rc
 grn_expr_parser_close(grn_ctx *ctx)
 {


### PR DESCRIPTION
Currently there is no way to know if `grn_expr_parse()` has added to `expr->codes`.
By using `grn_expr_get_n_codes()`, we can get the number of `expr->codes` so that we can check the increment.