### PR TITLE
packages debian: prevent attempt made to download or upload any content

### DIFF
--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -24,7 +24,6 @@ override_dh_auto_configure:
 	  --buildsystem=cmake+ninja				\
 	  --							\
 	  -DCMAKE_BUILD_TYPE=RelWithDebInfo			\
-	  -DFETCHCONTENT_FULLY_DISCONNECTED=OFF			\
 	  -DGRN_WITH_APACHE_ARROW=$${GRN_WITH_APACHE_ARROW}	\
 	  -DGRN_WITH_BLOSC=bundled				\
 	  -DGRN_WITH_DOC=ON					\


### PR DESCRIPTION
We want to prevent attempt made to download or upload any content on CI.

Currently, we build packages for Ubuntu on Lanchpad. However, we can't download or upload with external hosts on Lanchpad.

If We prevent attempt made to download or upload any content on CI by this PR, we detect missing dependency pacakges in advance.