### PR TITLE
packages almalinux: add `--platform linux/arm64` when building arm64's image

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -327,14 +327,17 @@ jobs:
       # Test
       - name: Test
         run: |
-          if [[ "${{ matrix.test-docker-image }}" == arm64* ]]; then
-            echo "TEST_DOCKER_PLATFORM=linux/arm64" >> $GITHUB_ENV
-          else
-            echo "TEST_DOCKER_PLATFORM=linux/amd64" >> $GITHUB_ENV
-          fi
+          case "${{ matrix.test-docker-image }}" in
+            arm64v8/*)
+              platform=linux/arm64
+              ;;
+            *)
+              platform=linux/amd64
+              ;;
+          esac
           docker run \
+            --platform ${platform} \
             --rm \
             --volume ${PWD}:/groonga:ro \
-            --platform ${{ env.TEST_DOCKER_PLATFORM }} \
             ${{ matrix.test-docker-image }} \
             /groonga/packages/${{ matrix.task-namespace }}/test.sh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -196,56 +196,67 @@ jobs:
             task-namespace: apt
             target: debian-bullseye
             test-docker-image: debian:bullseye
+            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux bullseye arm64
             id: debian-bullseye-arm64
             task-namespace: apt
             target: debian-bullseye-arm64
             test-docker-image: arm64v8/debian:bullseye
+            test-docker-platform: linux/arm64
           - label: Debian GNU/Linux bookworm amd64
             id: debian-bookworm-amd64
             task-namespace: apt
             target: debian-bookworm
             test-docker-image: debian:bookworm
+            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux bookworm arm64
             id: debian-bookworm-arm64
             task-namespace: apt
             target: debian-bookworm-arm64
             test-docker-image: arm64v8/debian:bookworm
+            test-docker-platform: linux/arm64
           - label: Debian GNU/Linux trixie amd64
             id: debian-trixie-amd64
             task-namespace: apt
             target: debian-trixie
             test-docker-image: debian:trixie
+            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux trixie arm64
             id: debian-trixie-arm64
             task-namespace: apt
             target: debian-trixie-arm64
             test-docker-image: arm64v8/debian:trixie
+            test-docker-platform: linux/arm64
           - label: CentOS 7 x86_64
             id: centos-7-x86_64
             task-namespace: yum
             target: centos-7
             test-docker-image: centos:7
+            test-docker-platform: linux/amd64
           - label: AlmaLinux 8 x86_64
             id: almalinux-8-x86_64
             task-namespace: yum
             target: almalinux-8
             test-docker-image: almalinux:8
+            test-docker-platform: linux/amd64
           - label: AlmaLinux 8 aarch64
             id: almalinux-8-aarch64
             task-namespace: yum
             target: almalinux-8-aarch64
             test-docker-image: arm64v8/almalinux:8
+            test-docker-platform: linux/arm64
           - label: AlmaLinux 9 x86_64
             id: almalinux-9-x86_64
             task-namespace: yum
             target: almalinux-9
             test-docker-image: almalinux:9
+            test-docker-platform: linux/amd64
           - label: AlmaLinux 9 aarch64
             id: almalinux-9-aarch64
             task-namespace: yum
             target: almalinux-9-aarch64
             test-docker-image: arm64v8/almalinux:9
+            test-docker-platform: linux/arm64
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
@@ -330,5 +341,6 @@ jobs:
           docker run \
             --rm \
             --volume ${PWD}:/groonga:ro \
+            --platform ${{ matrix.test-docker-platform }} \
             ${{ matrix.test-docker-image }} \
             /groonga/packages/${{ matrix.task-namespace }}/test.sh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -196,67 +196,56 @@ jobs:
             task-namespace: apt
             target: debian-bullseye
             test-docker-image: debian:bullseye
-            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux bullseye arm64
             id: debian-bullseye-arm64
             task-namespace: apt
             target: debian-bullseye-arm64
             test-docker-image: arm64v8/debian:bullseye
-            test-docker-platform: linux/arm64
           - label: Debian GNU/Linux bookworm amd64
             id: debian-bookworm-amd64
             task-namespace: apt
             target: debian-bookworm
             test-docker-image: debian:bookworm
-            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux bookworm arm64
             id: debian-bookworm-arm64
             task-namespace: apt
             target: debian-bookworm-arm64
             test-docker-image: arm64v8/debian:bookworm
-            test-docker-platform: linux/arm64
           - label: Debian GNU/Linux trixie amd64
             id: debian-trixie-amd64
             task-namespace: apt
             target: debian-trixie
             test-docker-image: debian:trixie
-            test-docker-platform: linux/amd64
           - label: Debian GNU/Linux trixie arm64
             id: debian-trixie-arm64
             task-namespace: apt
             target: debian-trixie-arm64
             test-docker-image: arm64v8/debian:trixie
-            test-docker-platform: linux/arm64
           - label: CentOS 7 x86_64
             id: centos-7-x86_64
             task-namespace: yum
             target: centos-7
             test-docker-image: centos:7
-            test-docker-platform: linux/amd64
           - label: AlmaLinux 8 x86_64
             id: almalinux-8-x86_64
             task-namespace: yum
             target: almalinux-8
             test-docker-image: almalinux:8
-            test-docker-platform: linux/amd64
           - label: AlmaLinux 8 aarch64
             id: almalinux-8-aarch64
             task-namespace: yum
             target: almalinux-8-aarch64
             test-docker-image: arm64v8/almalinux:8
-            test-docker-platform: linux/arm64
           - label: AlmaLinux 9 x86_64
             id: almalinux-9-x86_64
             task-namespace: yum
             target: almalinux-9
             test-docker-image: almalinux:9
-            test-docker-platform: linux/amd64
           - label: AlmaLinux 9 aarch64
             id: almalinux-9-aarch64
             task-namespace: yum
             target: almalinux-9-aarch64
             test-docker-image: arm64v8/almalinux:9
-            test-docker-platform: linux/arm64
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
@@ -338,9 +327,14 @@ jobs:
       # Test
       - name: Test
         run: |
+          if [[ "${{ matrix.test-docker-image }}" == arm64* ]]; then
+            echo "TEST_DOCKER_PLATFORM=linux/arm64" >> $GITHUB_ENV
+          else
+            echo "TEST_DOCKER_PLATFORM=linux/amd64" >> $GITHUB_ENV
+          fi
           docker run \
             --rm \
             --volume ${PWD}:/groonga:ro \
-            --platform ${{ matrix.test-docker-platform }} \
+            --platform ${{ env.TEST_DOCKER_PLATFORM }} \
             ${{ matrix.test-docker-image }} \
             /groonga/packages/${{ matrix.task-namespace }}/test.sh

--- a/packages/yum/almalinux-8-aarch64/from
+++ b/packages/yum/almalinux-8-aarch64/from
@@ -1,1 +1,1 @@
-arm64v8/almalinux:8
+arm64v8/almalinux:8 --platform linux/arm64

--- a/packages/yum/almalinux-8-aarch64/from
+++ b/packages/yum/almalinux-8-aarch64/from
@@ -1,1 +1,1 @@
-arm64v8/almalinux:8 --platform linux/arm64
+--platform=linux/arm64 arm64v8/almalinux:8

--- a/packages/yum/almalinux-9-aarch64/from
+++ b/packages/yum/almalinux-9-aarch64/from
@@ -1,1 +1,1 @@
-arm64v8/almalinux:9
+arm64v8/almalinux:9 --platform linux/arm64

--- a/packages/yum/almalinux-9-aarch64/from
+++ b/packages/yum/almalinux-9-aarch64/from
@@ -1,1 +1,1 @@
-arm64v8/almalinux:9 --platform linux/arm64
+--platform=linux/arm64 arm64v8/almalinux:9


### PR DESCRIPTION
ref: https://github.com/groonga/groonga/issues/1806

This change solves the following error on CI.
Because Docker build process does not automatically detect the correct platform for the image. As a result, the platform information defaults to the host platform. So in this case, platform infromation wasn't as a arm64.

To resolve this issue, we need to specify the platform explicitly in the Docker build command.
ref: https://docs.docker.com/build/building/multi-platform/

Here is the error log:

https://github.com/groonga/groonga/actions/runs/9705591558/job/26788067581#step:9:42

```
------
#3 [internal] load metadata for docker.io/arm64v8/almalinux:8
#3 ERROR: no match for platform in manifest: not found
------
Dockerfile:2
--------------------
   1 |     ARG FROM=almalinux:8
   2 | >>> FROM ${FROM}
   3 |
   4 |     ARG DEBUG
--------------------
ERROR: failed to solve: arm64v8/almalinux:8: failed to resolve source metadata for docker.io/arm64v8/almalinux:8: no match for platform in manifest: not found
rake aborted!#1 [internal] load build definition from Dockerfile
```
