### PR TITLE
db: add missing header for "grn_fopen()"

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -60,6 +60,10 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#ifdef WIN32
+# include <share.h>
+#endif
+
 static const uint32_t GRN_TABLE_PAT_KEY_CACHE_SIZE = 1 << 15;
 
 #define WITH_NORMALIZE(table, key, key_size, block)                            \

--- a/lib/db.c
+++ b/lib/db.c
@@ -61,7 +61,7 @@
 #include <sys/stat.h>
 
 #ifdef WIN32
-# include <share.h>
+#  include <share.h>
 #endif
 
 static const uint32_t GRN_TABLE_PAT_KEY_CACHE_SIZE = 1 << 15;


### PR DESCRIPTION
GitHub: fix GH-1810

"grn_fopen()" is defined as "_fsopen()" in Windows.

We can specify "shflag" in the third argument of "_fsopen()". We use "shflg" in "_fsopen()".

We need to include "share.h" to use "shflag".
See: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/fsopen-wfsopen?view=msvc-160

However, db.c does not include "share.h".
So, "error C2065: '_SH_DENYNO': undeclared identifier" occur.

This problem only occur in Groonga for Windows.
Because "fopen()" does not have "shflag".
("grn_fopen()" is defined "fopen()" in Linux.)