### PR TITLE
packages/windows: Use Octokit's artifact_download_url

### DIFF
--- a/packages/windows/download_github_actions_artifact.rb
+++ b/packages/windows/download_github_actions_artifact.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "fileutils"
+require "open-uri"
 
 require "octokit"
 
@@ -33,7 +34,8 @@ workflow_runs_response.workflow_runs.each do |workflow_run|
     FileUtils.mkdir_p(output_directory)
     puts("Downloading #{name}...")
     File.open("#{output_directory}/#{name}.zip", "wb") do |output|
-      output.print(client.get("/repos/groonga/groonga/actions/artifacts/#{id}/zip"))
+      uri = URI.parse(client.artifact_download_url('groonga/groonga', id))
+      output.print(uri.open.read)
     end
     downloaded = true
     break unless target_type == "all"

--- a/packages/windows/download_github_actions_artifact.rb
+++ b/packages/windows/download_github_actions_artifact.rb
@@ -35,7 +35,9 @@ workflow_runs_response.workflow_runs.each do |workflow_run|
     puts("Downloading #{name}...")
     File.open("#{output_directory}/#{name}.zip", "wb") do |output|
       uri = URI.parse(client.artifact_download_url('groonga/groonga', id))
-      output.print(uri.open.read)
+      uri.open do |input|
+        IO.copy_stream(input, output)
+      end
     end
     downloaded = true
     break unless target_type == "all"


### PR DESCRIPTION
Fixed the error:

```
<?xml version="1.0" encoding="utf-8"?> (Octokit::BadRequest)
<Error><Code>InvalidAuthenticationInfo</Code><Message>Authentication information is not given in the correct format. Check the value of Authorization header.
RequestId:xxx
Time:2024-07-05T06:20:29.6447183Z</Message></Error>
```