### PR TITLE
docs: api/grn_user_data: Copy the contents of the reference to a header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_user_data.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_user_data.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_user_data``"
 msgstr ""
 
@@ -33,8 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "objectに登録できるユーザデータへのポインタを返します。table, column, proc, exprのみ使用可能です。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_user_data.rst
+++ b/doc/source/reference/api/grn_user_data.rst
@@ -16,12 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_user_data
-
-   TODO...
-
-.. c:function:: grn_user_data *grn_obj_user_data(grn_ctx *ctx, grn_obj *obj)
-
-   objectに登録できるユーザデータへのポインタを返します。table, column, proc, exprのみ使用可能です。
-
-   :param obj: 対象objectを指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -903,6 +903,13 @@ grn_obj_unref_recursive(grn_ctx *ctx, grn_obj *obj);
 GRN_API void
 grn_obj_unref_recursive_dependent(grn_ctx *ctx, grn_obj *obj);
 
+/**
+ * \brief Returns a pointer to user data that can be registered in the object
+ *
+ * \param ctx The context object
+ * \param obj Only table, column, proc, and expr can be specified
+ * \return Pointer to user data
+ */
 GRN_API grn_user_data *
 grn_obj_user_data(grn_ctx *ctx, grn_obj *obj);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.
Target: doc/source/reference/api/grn_user_data.rst
