### PR TITLE
ci: Run doxygen to check for correct markup

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -12,7 +12,6 @@ on:
       - 'include/**/*.h'
       - 'include/**/*.hpp'
       - '.github/workflows/document.yml'
-
   pull_request:
     paths:
       - 'Rakefile'
@@ -33,7 +32,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-      - name: Install doxygen
+      - name: Install Doxygen
         run: sudo apt install -y -V doxygen graphviz
-      - name: Run doxygen
+      - name: Run Doxygen
         run: rake document:api

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -1,0 +1,39 @@
+name: Build document
+on:
+  push:
+    branches:
+      - main
+      - 'maintenance/**'
+    tags:
+      - '*'
+    paths:
+      - 'Rakefile'
+      - 'doc/Doxyfile'
+      - 'include/**/*.h'
+      - 'include/**/*.hpp'
+      - '.github/workflows/document.yml'
+
+  pull_request:
+    paths:
+      - 'Rakefile'
+      - 'doc/Doxyfile'
+      - 'include/**/*.h'
+      - 'include/**/*.hpp'
+      - '.github/workflows/document.yml'
+concurrency:
+  group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  # todo: Build and publish the full document, including Sphinx.
+  doxygen:
+    name: Doxygen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+      - name: Install doxygen
+        run: sudo apt install -y -V doxygen graphviz
+      - name: Run doxygen
+        run: rake document:api

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,14 @@ jobs:
           set -o pipefail
           pre-commit run --show-diff-on-failure --color=always --all-files | \
             tools/filter-github-actions-workflow-command.rb
+  doxygen:
+    name: Doxygen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install doxygen
+        run: sudo apt install -y -V doxygen graphviz
+      - name: Run doxygen
+        run: doxygen doc/Doxyfile
+        env:
+          DOXYGEN_QUIET: YES

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,5 +40,3 @@ jobs:
         run: sudo apt install -y -V doxygen graphviz
       - name: Run doxygen
         run: rake document:api
-        env:
-          DOXYGEN_QUIET: YES

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,15 +28,3 @@ jobs:
           set -o pipefail
           pre-commit run --show-diff-on-failure --color=always --all-files | \
             tools/filter-github-actions-workflow-command.rb
-  doxygen:
-    name: Doxygen
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ruby
-      - name: Install doxygen
-        run: sudo apt install -y -V doxygen graphviz
-      - name: Run doxygen
-        run: rake document:api

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,9 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
       - name: Install doxygen
         run: sudo apt install -y -V doxygen graphviz
       - name: Run doxygen
-        run: doxygen doc/Doxyfile
+        run: rake document:api
         env:
           DOXYGEN_QUIET: YES

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -852,7 +852,7 @@ WARN_NO_PARAMDOC       = NO
 # Possible values are: NO, YES and FAIL_ON_WARNINGS.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -810,7 +810,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = $(DOXYGEN_QUIET)
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -810,7 +810,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = $(DOXYGEN_QUIET)
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
Updated settings for running doxygen with CI.

* QUIET = YES
  * The warning log is hard to find, so the generation log is not output
* WARN_AS_ERROR = FAIL_ON_WARNINGS
  * If there is a warning, it should be terminated abnormally