### PR TITLE
NormalizerNFKC: add `unify_alphabet_diacritical_mark` option

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -35,7 +35,7 @@ typedef struct {
   grn_nfkc_compose_func compose_func;
   grn_bool include_removed_source_location;
   grn_bool report_source_offset;
-  grn_bool unify_alphabet_diacritical_mark;
+  bool unify_alphabet_diacritical_mark;
   grn_bool unify_kana;
   grn_bool unify_kana_case;
   grn_bool unify_kana_voiced_sound_mark;

--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -35,6 +35,7 @@ typedef struct {
   grn_nfkc_compose_func compose_func;
   grn_bool include_removed_source_location;
   grn_bool report_source_offset;
+  grn_bool unify_alphabet_diacritical_mark;
   grn_bool unify_kana;
   grn_bool unify_kana_case;
   grn_bool unify_kana_voiced_sound_mark;

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -53,6 +53,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->compose_func = compose_func;
   options->include_removed_source_location = GRN_TRUE;
   options->report_source_offset = GRN_FALSE;
+  options->unify_alphabet_diacritical_mark = false;
   options->unify_kana = GRN_FALSE;
   options->unify_kana_case = GRN_FALSE;
   options->unify_kana_voiced_sound_mark = GRN_FALSE;
@@ -148,6 +149,13 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->report_source_offset);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw,
+                                            "unify_alphabet_diacritical_mark")) {
+      options->unify_alphabet_diacritical_mark =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_alphabet_diacritical_mark);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_kana")) {
       options->unify_kana = grn_vector_get_element_bool(ctx,
                                                         raw_options,

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1254,7 +1254,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
   i_byte = 0;
   i_character = 0;
   while (current < end) {
-    unsigned char unified_alpha[2];
+    unsigned char unified_alphabet[2];
     unsigned char unified_kana[3];
     unsigned char unified_kana_case[3];
     unsigned char unified_kana_voiced_sound_mark[3];
@@ -1283,7 +1283,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
         unified_char_length == 2) {
       unifying =
         grn_nfkc_normalize_unify_alphabet_diacritical_mark(unifying,
-                                                           unified_alpha);
+                                                           unified_alphabet);
     }
 
     if (before && data->options->unify_kana &&

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -849,6 +849,7 @@ grn_inline static const unsigned char *
 grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   const unsigned char *utf8_char, unsigned char *unified)
 {
+  // TODO: Implement function to return `unified` instead of `utf8_char`.
   return utf8_char;
 }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1254,7 +1254,7 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
   i_byte = 0;
   i_character = 0;
   while (current < end) {
-    unsigned char unified_alphabet[2];
+    unsigned char unified_alphabet[1];
     unsigned char unified_kana[3];
     unsigned char unified_kana_case[3];
     unsigned char unified_kana_voiced_sound_mark[3];
@@ -1284,6 +1284,9 @@ grn_nfkc_normalize_unify_stateless(grn_ctx *ctx,
       unifying =
         grn_nfkc_normalize_unify_alphabet_diacritical_mark(unifying,
                                                            unified_alphabet);
+      if (unifying == unified_alphabet) {
+        unified_char_length = sizeof(unified_alphabet);
+      }
     }
 
     if (before && data->options->unify_kana &&

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark.expected
@@ -1,0 +1,20 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ÀÁÂ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "àáâ",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ÀÁÂ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: ref GH-1755

This PR adds the `unify_alphabet_diacritical_mark` option to NormalizerNFKC.
This option will allow the removal of diacritical marks to normalize them to alphabets in the following PRs.

In this PR, we are not implementing the actual logic, but just introducing the option interface.