### PR TITLE
docs: api/grn_table_cursor: Move the grn_table_cursor_open reference to the header file

### DIFF
--- a/doc/source/reference/api/grn_table_cursor.rst
+++ b/doc/source/reference/api/grn_table_cursor.rst
@@ -20,46 +20,6 @@ Reference
 
    TODO...
 
-.. c:function:: grn_table_cursor *grn_table_cursor_open(grn_ctx *ctx, grn_obj *table, const void *min, unsigned int min_size, const void *max, unsigned int max_size, int offset, int limit, int flags)
-
-   tableに登録されているレコードを順番に取り出すためのカーソルを生成して返します。
-
-   :param table: 対象tableを指定します。
-   :param min: keyの下限を指定します。（NULLは下限なしと見なします。） ``GRN_CURSOR_PREFIX`` については後述。
-   :param min_size: minのsizeを指定します。``GRN_CURSOR_PREFIX`` については後述。
-   :param max: keyの上限を指定します。（NULLは上限なしと見なします。） ``GRN_CURSOR_PREFIX`` については後述。
-   :param max_size: maxのsizeを指定します。``GRN_CURSOR_PREFIX`` については無視される場合があります。
-   :param flags:
-      ``GRN_CURSOR_ASCENDING`` を指定すると昇順にレコードを取り出します。
-
-      ``GRN_CURSOR_DESCENDING`` を指定すると降順にレコードを取り出します。(下記 ``GRN_CURSOR_PREFIX`` を指定し、keyが近いレコードを取得する場合、もしくは、common prefix searchを行う場合には、``GRN_CURSOR_ASCENDING`` / ``GRN_CURSOR_DESCENDING`` は無視されます。)
-
-      ``GRN_CURSOR_GT`` を指定するとminに一致したkeyをcursorの範囲に含みません。(minがNULLの場合もしくは、下記 ``GRN_CURSOR_PREFIX`` を指定し、keyが近いレコードを取得する場合、もしくは、common prefix searchを行う場合には、``GRN_CURSOR_GT`` は無視されます。)
-
-      ``GRN_CURSOR_LT`` を指定するとmaxに一致したkeyをcursorの範囲に含みません。(maxがNULLの場合もしくは、下記 ``GRN_CURSOR_PREFIX`` を指定した場合には、``GRN_CURSOR_LT`` は無視されます。)
-
-      ``GRN_CURSOR_BY_ID`` を指定するとID順にレコードを取り出します。(下記 ``GRN_CURSOR_PREFIX`` を指定した場合には、``GRN_CURSOR_BY_ID`` は無視されます。) ``GRN_OBJ_TABLE_PAT_KEY`` を指定したtableについては、``GRN_CURSOR_BY_KEY`` を指定するとkey順にレコードを取り出します。( ``GRN_OBJ_TABLE_HASH_KEY`` , ``GRN_OBJ_TABLE_NO_KEY`` を指定したテーブルでは ``GRN_CURSOR_BY_KEY`` は無視されます。)
-
-      ``GRN_CURSOR_PREFIX`` を指定すると、 ``GRN_OBJ_TABLE_PAT_KEY`` を指定したテーブルに関する下記のレコードを取り出すカーソルが作成されます。maxがNULLの場合には、keyがminと前方一致するレコードを取り出します。max_sizeパラメータは無視されます。
-
-      maxとmax_sizeが指定され、かつ、テーブルのkeyがShortText型である場合、maxとcommon prefix searchを行い、common prefixがmin_sizeバイト以上のレコードを取り出します。minは無視されます。
-
-      maxとmax_sizeが指定され、かつ、テーブルのkeyが固定長型の場合、maxとPAT木上で近い位置にあるノードから順番にレコードを取り出します。ただし、keyのパトリシア木で、min_sizeバイト未満のビットに対するノードで、maxと異なった方向にあるノードに対応するレコードについては取り出しません。PAT木上で位置が近いこととkeyの値が近いことは同一ではありません。この場合、maxで与えられるポインタが指す値は、対象テーブルのkeyサイズと同じか超える幅である必要があります。minは無視されます。
-
-      ``GRN_CURSOR_BY_ID`` / ``GRN_CURSOR_BY_KEY`` / ``GRN_CURSOR_PREFIX`` の3フラグは、同時に指定することができません。
-
-      ``GRN_OBJ_TABLE_PAT_KEY`` を指定して作ったテーブルで、``GRN_CURSOR_PREFIX`` と ``GRN_CURSOR_RK`` を指定すると、半角小文字のアルファベット文字列から、それを旧JIS X 4063:2000規格に従って全角カタカナに変換した文字列に前方一致する値をkeyとするレコードを取り出します。``GRN_ENC_UTF8`` のみをサポートしています。``GRN_CURSOR_ASCENDING`` / ``GRN_CURSOR_DESCENDING`` は無効であり、レコードをkey値の昇降順で取り出すことはできません。
-  
-   :param offset:
-      該当する範囲のレコードのうち、(0ベースで)offset番目からレコードを取り出します。
-
-      ``GRN_CURSOR_PREFIX`` を指定したときは負の数を指定することはできません。
-
-   :param limit:
-      該当する範囲のレコードのうち、limit件のみを取り出します。-1が指定された場合は、全件が指定されたものとみなします。
-
-      ``GRN_CURSOR_PREFIX`` を指定したときは-1より小さい負の数を指定することはできません。
-
 .. c:function:: grn_rc grn_table_cursor_close(grn_ctx *ctx, grn_table_cursor *tc)
 
    :c:func:`grn_table_cursor_open` で生成したcursorを解放します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -137,7 +137,7 @@ grn_table_truncate(grn_ctx *ctx, grn_obj *table);
  * \param flags
  *     * GRN_CURSOR_ASCENDING: Retrieve records in ascending order
  *       * If GRN_CURSOR_PREFIX is specified and a record with a near key is
- *       retrieved, or a common prefix search is used, it will be ignored
+ *         retrieved, or a common prefix search is used, it will be ignored
  *     * GRN_CURSOR_DESCENDING: Retrieve records in descending order
  *       * If GRN_CURSOR_PREFIX is specified and a record with a near key is
  *         retrieved, or a common prefix search is used, it will be ignored

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -114,6 +114,81 @@ grn_table_truncate(grn_ctx *ctx, grn_obj *table);
 #define GRN_CURSOR_SIZE_BY_BIT (0x01 << 5)
 #define GRN_CURSOR_RK          (0x01 << 6)
 
+/**
+ * \brief Creates and returns a cursor to retrieve the records registered in
+ *        the table in order
+ *
+ * \param ctx The context object
+ * \param table Target table
+ * \param min Minimum limit of key (`NULL` means no minimum limit).
+ *            See below for GRN_CURSOR_PREFIX
+ * \param min_size Size of min. See below for GRN_CURSOR_PREFIX
+ * \param max Maximum limit of key (`NULL` means no minimum limit).
+ *            See below for GRN_CURSOR_PREFIX
+ * \param max_size Size of max. GRN_CURSOR_PREFIX may be ignored
+ * \param offset Extracts records from the range of records that meet the
+ *               condition, starting with the `offset`-th (offset is
+ *               zero-based). When GRN_CURSOR_PREFIX is specified, negative
+ *               numbers cannot be specified
+ * \param limit Only `limit` records in the range that meet the condition are
+ *              extracted. -1 means all.
+ *              When GRN_CURSOR_PREFIX is specified, negative numbers cannot
+ *              be specified
+ * \param flags
+ *     * GRN_CURSOR_ASCENDING: Retrieve records in ascending order
+ *       * If GRN_CURSOR_PREFIX is specified and a record with a near key is
+ *       retrieved, or a common prefix search is used, it will be ignored
+ *     * GRN_CURSOR_DESCENDING: Retrieve records in descending order
+ *       * If GRN_CURSOR_PREFIX is specified and a record with a near key is
+ *         retrieved, or a common prefix search is used, it will be ignored
+ *     * GRN_CURSOR_GT: a key that matches `min` is not included in the cursor
+ *       range
+ *       * If `min` is `NULL`, or if GRN_CURSOR_PREFIX is specified and a record
+ *         with a near key is retrieved, or a common prefix search is used,
+ *         it will be ignored
+ *     * GRN_CURSOR_LT: a key that matches `max` is not included in the cursor
+ *       range
+ *       * If `max` is `NULL`, or if GRN_CURSOR_PREFIX is specified, it will
+ *         be ignored
+ *     * GRN_CURSOR_BY_ID: Retrieves records in ID order
+ *       * If GRN_CURSOR_PREFIX is specified, it will be ignored
+ *     * GRN_CURSOR_BY_KEY: Retrieves records in key order
+ *       * It can be used with table that specify GRN_OBJ_TABLE_PAT_KEY
+ *       * For table with GRN_OBJ_TABLE_HASH_KEY or GRN_OBJ_TABLE_NO_KEY, it
+ *         will be ignored
+ *     * GRN_CURSOR_PREFIX: A cursor is created to retrieve the following
+ *       records for the table GRN_OBJ_TABLE_PAT_KEY
+ *       * If `max` is `NULL`, retrieve the record for which key is a prefix
+ *         match to `min`. `max_size` is ignored
+ *       * If `max` and `max_size` are specified and the table key is of type
+ *         `ShortText`, then a `max` and common prefix search is executed and
+ *         records with a common prefix
+ *         greater than or equal to min_size bytes are retrieved. `min` is
+ *         ignored
+ *       * If `max` and `max_size` are specified and the key of the table is a
+ *         fixed-length type, records are retrieved sequentially from nodes that
+ *         are near each other on the `max` and PAT tree.
+ *         * But, records are not retrieved for nodes in the PAT tree of key for
+ *           bits less than `min_size` bytes and corresponding to nodes on a
+ *           different branch than `max`.
+ *           Being near a position on the PAT tree is not the same as being near
+ *           a key value.
+ *           In this case, `max` must be as wide as or greater than the key size
+ *           of the target table. `min` is ignored
+ *     * GRN_CURSOR_BY_ID, GRN_CURSOR_BY_KEY and GRN_CURSOR_PREFIX cannot be
+ *       specified at the same time.
+ *     * In a table created with GRN_OBJ_TABLE_PAT_KEY, if GRN_CURSOR_PREFIX and
+ *       GRN_CURSOR_RK are specified, retrieves records where key is a prefix
+ *       matching a string of lower case alphabetic characters converted to
+ *       half-width kana characters according to JIS X 4063:2000 (this standard
+ *       is abolished).
+ *       * Supports only GRN_ENC_UTF8
+ *       * GRN_CURSOR_ASCENDING and GRN_CURSOR_DESCENDING are invalid.
+ *         Records cannot be retrieved in ascending or descending order of key
+ *         value
+ *
+ * \return  A newly opened table cursor on success, `NULL` on error
+ */
 GRN_API grn_table_cursor *
 grn_table_cursor_open(grn_ctx *ctx,
                       grn_obj *table,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -123,7 +123,7 @@ grn_table_truncate(grn_ctx *ctx, grn_obj *table);
  * \param min Minimum limit of key (`NULL` means no minimum limit).
  *            See below for GRN_CURSOR_PREFIX
  * \param min_size Size of min. See below for GRN_CURSOR_PREFIX
- * \param max Maximum limit of key (`NULL` means no minimum limit).
+ * \param max Maximum limit of key (`NULL` means no maximum limit).
  *            See below for GRN_CURSOR_PREFIX
  * \param max_size Size of max. GRN_CURSOR_PREFIX may be ignored
  * \param offset Extracts records from the range of records that meet the
@@ -157,7 +157,7 @@ grn_table_truncate(grn_ctx *ctx, grn_obj *table);
  *       * For table with GRN_OBJ_TABLE_HASH_KEY or GRN_OBJ_TABLE_NO_KEY, it
  *         will be ignored
  *     * GRN_CURSOR_PREFIX: A cursor is created to retrieve the following
- *       records for the table GRN_OBJ_TABLE_PAT_KEY
+ *       records for the table with GRN_OBJ_TABLE_PAT_KEY
  *       * If `max` is `NULL`, retrieve the record for which key is a prefix
  *         match to `min`. `max_size` is ignored
  *       * If `max` and `max_size` are specified and the table key is of type


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.