### PR TITLE
docs: api/grn_table: Move the grn_table_create() reference to the header file

### DIFF
--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -16,35 +16,6 @@ TODO...
 Reference
 ---------
 
-.. c:function:: grn_obj *grn_table_create(grn_ctx *ctx, const char *name, unsigned int name_size, const char *path, grn_obj_flags flags, grn_obj *key_type, grn_obj *value_type)
-
-   nameパラメータに対応する新たなtableをctxが使用するdbに定義します。
-
-   :param name:
-      作成するtableの名前を指定します。NULLなら無名tableとなります。
-
-      persistent dbに対して名前をありのtableを作成するときには、flagsに ``GRN_OBJ_PERSISTENT`` が指定されていなけれなりません。
-   :param path:
-      作成するtableのファイルパスを指定します。
-      flagsに ``GRN_OBJ_PERSISTENT`` が指定されている場合のみ有効です。
-      NULLなら自動的にファイルパスが付与されます。
-   :param flags:
-      ``GRN_OBJ_PERSISTENT`` を指定すると永続tableとなります。
-
-      ``GRN_OBJ_TABLE_PAT_KEY``, ``GRN_OBJ_TABLE_HASH_KEY``, ``GRN_OBJ_TABLE_NO_KEY`` のいずれかを指定します。
-
-      ``GRN_OBJ_KEY_NORMALIZE`` を指定すると正規化された文字列がkeyとなります。
-
-      ``GRN_OBJ_KEY_WITH_SIS`` を指定するとkey文字列の全suffixが自動的に登録されます。
-   :param key_type:
-      keyの型を指定します。``GRN_OBJ_TABLE_NO_KEY`` が指定された場合は無効です。
-      既存のtypeあるいはtableを指定できます。
-
-      key_typeにtable Aを指定してtable Bを作成した場合、Bは必ずAのサブセットとなります。
-   :param value_type:
-      keyに対応する値を格納する領域の型を指定します。
-      tableはcolumnとは別に、keyに対応する値を格納する領域を一つだけ持つことができます。
-
 .. c:function:: grn_id grn_table_add(grn_ctx *ctx, grn_obj *table, const void *key, unsigned int key_size, int *added)
 
    keyに対応する新しいrecordをtableに追加し、そのIDを返します。keyに対応するrecordがすでにtableに存在するならば、そのrecordのIDを返します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -47,7 +47,6 @@ extern "C" {
  * \param key_type Built-in type or table. If table B is created with table A
  *                 as key_type, B will always be a subset of A.
  *                 Disabled if GRN_OBJ_TABLE_NO_KEY is specified.
- *                 Invalid if GRN_OBJ_TABLE_NO_KEY is specified.
  * \param value_type Type of the value for key.
  *                   A table can have only one value for key, in addition to
  *                   column

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -25,6 +25,35 @@ extern "C" {
 
 #define GRN_TABLE_MAX_KEY_SIZE (0x1000)
 
+/**
+ * \brief Define a new table in the DB used by ctx
+ *
+ * \param ctx The context object
+ * \param name Name of the table to create. If `NULL`, it is an unnamed table.
+ *             When creating a named table for a persistent db,
+ *             GRN_OBJ_PERSISTENT must be specified in `flags`
+ * \param name_size Length of `name`
+ * \param path File path of the table to create.
+ *             Enabled only if GRN_OBJ_PERSISTENT is specified in `flags`.
+ *             If `NULL`, the file path is automatically assigned.
+ * \param flags
+ *    * GRN_OBJ_TABLE_NO_KEY: Array table
+ *    * GRN_OBJ_TABLE_HASH_KEY: Hash table
+ *    * GRN_OBJ_TABLE_PAT_KEY: Patricia trie
+ *    * GRN_OBJ_KEY_WITH_SIS: All suffixes in the key string are automatically
+ *      registered
+ *    * GRN_OBJ_PERSISTENT: Persistent table
+ *    * GRN_OBJ_KEY_NORMALIZE: Normalized string is the key
+ * \param key_type Built-in type or table. If table B is created with table A
+ *                 as key_type, B will always be a subset of A.
+ *                 Disabled if GRN_OBJ_TABLE_NO_KEY is specified.
+ *                 Invalid if GRN_OBJ_TABLE_NO_KEY is specified.
+ * \param value_type Type of the value for key.
+ *                   A table can have only one value for key, in addition to
+ *                   column
+ *
+ * \return A newly created table on success, `NULL` on error
+ */
 GRN_API grn_obj *
 grn_table_create(grn_ctx *ctx,
                  const char *name,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.