### PR TITLE
package ubuntu: drop support for Ubuntu 23.10 (Mantic Minotaur)

### DIFF
--- a/packages/launchpad-helper.rb
+++ b/packages/launchpad-helper.rb
@@ -35,7 +35,6 @@ module LaunchpadHelper
     [
       ["focal", "20.04"],
       ["jammy", "22.04"],
-      ["mantic", "23.10"],
       ["noble", "24.04"],
     ]
   end


### PR DESCRIPTION
Because Ubuntu 23.10 reached EOL at July 11, 2024. 
See: https://lists.ubuntu.com/archives/ubuntu-announce/2024-July/000303.html