### PR TITLE
packages windows: add redirect to old version

### DIFF
--- a/packages/packages-groonga-org-package-task.rb
+++ b/packages/packages-groonga-org-package-task.rb
@@ -273,7 +273,7 @@ class PackagesGroongaOrgPackageTask < PackageTask
     end
 
     case target_namespace
-    when :source
+    when :source, :windows
       return unless use_packages_groonga_org?(target_namespace)
       rsync_dir =
         "#{repository_rsync_base_path}/#{target_namespace}/#{@package}/"


### PR DESCRIPTION
Currently, we don't download `.htaccess` for Windows from packages.groonga.org before download packages from GitHub release page.

So,  `.htaccess` for Windows is wrote only the latest version of Windows packages as below.

```
Redirect /windows/groonga/groonga-14.0.6-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022.zip
Redirect /windows/groonga/groonga-latest-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019-with-vcruntime.zip
```

Because we already create empty  `.htaccess` for Windows at https://github.com/groonga/groonga/blob/v14.0.6/packages/packages-groonga-org-package-task.rb#L301.


In this modification, we download `.htaccess` from packages.groonga.org before download packages from GitHub release page.
So, we can get previous version information from `.htaccess` at https://github.com/groonga/groonga/blob/v14.0.6/packages/packages-groonga-org-package-task.rb#L299.

Finally,  `.htaccess` for Windows is wrote the latest version and previous version as below.

```
Redirect /windows/groonga/groonga-14.0.6-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019.zip
Redirect /windows/groonga/groonga-14.0.6-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.6/groonga-14.0.6-x64-vs2019-with-vcruntime.zip

Redirect /windows/groonga/groonga-14.0.7-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2022.zip
Redirect /windows/groonga/groonga-latest-x64-vs2022.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2022.zip
Redirect /windows/groonga/groonga-14.0.7-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x64-vs2022-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2022-with-vcruntime.zip
Redirect /windows/groonga/groonga-14.0.7-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2019.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2019.zip
Redirect /windows/groonga/groonga-14.0.7-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2019-with-vcruntime.zip
Redirect /windows/groonga/groonga-latest-x64-vs2019-with-vcruntime.zip https://github.com/groonga/groonga/releases/download/v14.0.7/groonga-14.0.7-x64-vs2019-with-vcruntime.zip
```