### PR TITLE
docs: api/grn_table_cursor: Move the close() and next() reference to the header file

### DIFF
--- a/doc/source/reference/api/grn_table_cursor.rst
+++ b/doc/source/reference/api/grn_table_cursor.rst
@@ -20,18 +20,6 @@ Reference
 
    TODO...
 
-.. c:function:: grn_rc grn_table_cursor_close(grn_ctx *ctx, grn_table_cursor *tc)
-
-   :c:func:`grn_table_cursor_open` で生成したcursorを解放します。
-
-   :param tc: 対象cursorを指定します。
-
-.. c:function:: grn_id grn_table_cursor_next(grn_ctx *ctx, grn_table_cursor *tc)
-
-   cursorのカレントレコードを一件進めてそのIDを返します。cursorの対象範囲の末尾に達すると ``GRN_ID_NIL`` を返します。
-
-   :param tc: 対象cursorを指定します。
-
 .. c:function:: int grn_table_cursor_get_key(grn_ctx *ctx, grn_table_cursor *tc, void **key)
 
    cursorのカレントレコードのkeyをkeyパラメータにセットし、その長さを返します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -227,8 +227,26 @@ grn_table_cursor_open(grn_ctx *ctx,
                       int offset,
                       int limit,
                       int flags);
+/**
+ * \brief Free the cursor created by grn_table_cursor_open()
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ *
+ * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if `tc` is invalid
+ */
 GRN_API grn_rc
 grn_table_cursor_close(grn_ctx *ctx, grn_table_cursor *tc);
+
+/**
+ * \brief Move the cursur forward to the next and return its record ID.
+ *        Return GRN_ID_NIL when the end is reached
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ *
+ * \return Record ID on there is a next, GRN_ID_NIL on no next or on error
+ */
 GRN_API grn_id
 grn_table_cursor_next(grn_ctx *ctx, grn_table_cursor *tc);
 GRN_API int


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.