### PR TITLE
doc install: Fix typo in Japanese Debian/Ubuntu install guide

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/debian.po
+++ b/doc/locale/ja/LC_MESSAGES/install/debian.po
@@ -41,7 +41,7 @@ msgid "Install groonga-tokenizer-mecab package::"
 msgstr "groonga-tokenizer-mecabパッケージのインストール::"
 
 msgid "If you want to use ``TokenFilterStem`` as a token filter, install groonga-token-filter-stem package."
-msgstr "``TokenFilterStem`` をトークンフィルターとして使いたいときはgroonga-tokenizer-filter-stemパッケージをインストールしてください。"
+msgstr "``TokenFilterStem`` をトークンフィルターとして使いたいときはgroonga-token-filter-stemパッケージをインストールしてください。"
 
 msgid "Install groonga-token-filter-stem package::"
 msgstr "groonga-token-filter-stemパッケージのインストール::"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -74,7 +74,7 @@ msgid "Install `groonga-tokenizer-mecab` package:"
 msgstr "`groonga-tokenizer-mecab`パッケージをインストールします。"
 
 msgid "If you want to use `TokenFilterStem` as a token filter, install `groonga-token-filter-stem` package."
-msgstr "`TokenFilterStem`をトークンフィルターとして使いたいときは`groonga-tokenizer-filter-stem`パッケージをインストールします。"
+msgstr "`TokenFilterStem`をトークンフィルターとして使いたいときは`groonga-token-filter-stem`パッケージをインストールします。"
 
 msgid "Install groonga-token-filter-stem package:"
 msgstr "`groonga-token-filter-stem`パッケージをインストールします。"


### PR DESCRIPTION
This patch will change to correct package name in Japanese Debian/Ubuntu install guide

Fix GH-1847