### PR TITLE
doc install/mac_os_x: remove unnecessary configuration for mecabrc

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/mac_os_x.po
+++ b/doc/locale/ja/LC_MESSAGES/install/mac_os_x.po
@@ -37,9 +37,6 @@ msgstr "`MeCab <https://taku910.github.io/mecab/>`_ をトークナイザーと�
 msgid "Then install and configure MeCab dictionary."
 msgstr "それからMeCabの辞書をインストール・設定します。"
 
-msgid "Configure::"
-msgstr "設定::"
-
 msgid "Build from source"
 msgstr "ソースからビルド"
 

--- a/doc/source/install/mac_os_x.rst
+++ b/doc/source/install/mac_os_x.rst
@@ -36,10 +36,6 @@ Install::
 
   % brew install mecab-ipadic
 
-Configure::
-
-  % sed -i '' -e 's,dicrc.*=.*,dicrc = /usr/local/lib/mecab/dic/ipadic,g' /usr/local/etc/mecabrc
-
 Build from source
 -----------------
 


### PR DESCRIPTION
GitHub: fix GH-1846

Recent Homebrew installs the packages in /opt/homebrew.
Therefore, sed command does not work as expected when I follow the document.

And, the following settings are made by Homebrew default in mecabrc.
Seems that it necessary additional configuration.

```
;
; Configuration file of MeCab
;
; $Id: mecabrc.in,v 1.3 2006/05/29 15:36:08 taku-ku Exp $;
;
dicdir =  /opt/homebrew/lib/mecab/dic/ipadic

; userdic = /home/foo/bar/user.dic

; output-format-type = wakati
; input-buffer-size = 8192

; node-format = %m\n
; bos-format = %S\n
; eos-format = EOS\n
```

So this patch remove unnecessary configuration for mecabrc.
