### PR TITLE
packages: add libedit package as dependency

### DIFF
--- a/packages/apt/debian-bookworm/Dockerfile
+++ b/packages/apt/debian-bookworm/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     devscripts \
     lsb-release \
     libarrow-dev \
+    libedit-dev \
     libevent-dev \
     liblz4-dev \
     libmecab-dev \

--- a/packages/apt/debian-trixie/Dockerfile
+++ b/packages/apt/debian-trixie/Dockerfile
@@ -29,6 +29,7 @@ RUN \
     devscripts \
     lsb-release \
     libarrow-dev \
+    libedit-dev \
     libevent-dev \
     liblz4-dev \
     libmecab-dev \

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -6,6 +6,7 @@ Uploaders: HAYASHI Kentaro <hayashi@clear-code.com>
 Build-Depends:
   cmake,
   debhelper (>= 9),
+  libedit-dev,
   libevent-dev,
   libjemalloc-dev,
   liblz4-dev,

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -24,6 +24,7 @@ Source0:	http://packages.groonga.org/source/groonga/groonga-%{version}.tar.gz
 
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-%(%{__id_u} -n)
 BuildRequires:	arrow-devel >= @APACHE_ARROW_VERSION@
+BuildRequires:	libedit-devel
 BuildRequires:	libstemmer-devel
 BuildRequires:	libzstd-devel
 BuildRequires:	lz4-devel
@@ -56,6 +57,7 @@ Summary:	Runtime libraries for Groonga
 Group:		System Environment/Libraries
 License:	LGPLv2 and (MIT or GPLv2)
 Requires:	arrow@APACHE_ARROW_MAJOR_VERSION@-libs
+Requires:	libedit
 Requires:	libzstd
 Requires:	lz4
 Requires:	msgpack

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -44,6 +44,7 @@ BuildRequires:	zlib-devel
 #BuildRequires:	libevent-devel
 Requires:	%{name}-libs = %{version}-%{release}
 Requires:	%{name}-plugin-suggest = %{version}-%{release}
+Requires:	libedit
 Obsoletes:	%{name} < 1.2.2-0
 
 %description
@@ -57,7 +58,6 @@ Summary:	Runtime libraries for Groonga
 Group:		System Environment/Libraries
 License:	LGPLv2 and (MIT or GPLv2)
 Requires:	arrow@APACHE_ARROW_MAJOR_VERSION@-libs
-Requires:	libedit
 Requires:	libzstd
 Requires:	lz4
 Requires:	msgpack


### PR DESCRIPTION
GitHub: fix GH-1844

This patch will install libedit when it builds the groonga package due to build a package with libedit enabled.
