### PR TITLE
docs: api/grn_table: Move the grn_table_update() reference to the header file

### DIFF
--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -76,18 +76,6 @@ Reference
    :param table: 対象tableを指定します。
    :param id: レコードIDを指定します。
 
-.. c:function:: grn_rc grn_table_update(grn_ctx *ctx, grn_obj *table, const void *src_key, unsigned int src_key_size, const void *dest_key, unsigned int dest_key_size)
- 
-   tableのsrc_keyに対応するレコードのkeyを変更します。新しいkeyとそのbyte長をdest_keyとdest_key_sizeに指定します。
-
-   この操作は、``GRN_TABLE_DAT_KEY`` 型のテーブルのみ使用できます。
-
-   :param table: 対象tableを指定します。
-   :param src_key: 対象レコードのkeyを指定します。
-   :param src_key_size: 対象レコードのkeyの長さ(byte)を指定します。
-   :param dest_key: 変更後のkeyを指定します。
-   :param dest_key_size: 変更後のkeyの長さ(byte)を指定します。
-
 .. c:function:: grn_rc grn_table_truncate(grn_ctx *ctx, grn_obj *table)
 
    tableの全レコードを一括して削除します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -148,7 +148,8 @@ grn_table_update_by_id(grn_ctx *ctx,
  * \param dest_key_size Length of `dest_key_size` (byte)
  *
  * \return GRN_SUCCESS on success, GRN_OPERATION_NOT_PERMITTED if not
- *         GRN_TABLE_DAT_KEY, `grn_rc` according to error on error
+ *         GRN_TABLE_DAT_KEY, and the appropriate `grn_rc` for any other
+ *         errors
  */
 GRN_API grn_rc
 grn_table_update(grn_ctx *ctx,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -134,6 +134,22 @@ grn_table_update_by_id(grn_ctx *ctx,
                        grn_id id,
                        const void *dest_key,
                        unsigned int dest_key_size);
+/**
+ * \brief Change the key of the record matching the `src_key` of the table.
+ *        Specify the new key and its byte length in `dest_key` and
+ *        `dest_key_size`. This operation is allowed only for table of
+ *        type GRN_TABLE_DAT_KEY
+ *
+ * \param ctx The context object
+ * \param table Target table
+ * \param src_key Key of record to be updated
+ * \param src_key_size Length of `src_key` (byte)
+ * \param dest_key New key
+ * \param dest_key_size Length of `dest_key_size` (byte)
+ *
+ * \return GRN_SUCCESS on success, GRN_OPERATION_NOT_PERMITTED if not
+ *         GRN_TABLE_DAT_KEY, `grn_rc` according to error on error
+ */
 GRN_API grn_rc
 grn_table_update(grn_ctx *ctx,
                  grn_obj *table,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.