### PR TITLE
ci package ubuntu: add steps for building and testing Ubuntu focal amd64's package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -183,6 +183,7 @@ jobs:
           - Debian GNU/Linux bookworm arm64
           - Debian GNU/Linux trixie amd64
           - Debian GNU/Linux trixie arm64
+          - Ubuntu focal amd64
           - AlmaLinux 8 x86_64
           - AlmaLinux 8 aarch64
           - AlmaLinux 9 x86_64
@@ -208,6 +209,11 @@ jobs:
             task-namespace: apt
             target: debian-trixie-arm64
             test-docker-image: arm64v8/debian:trixie
+          - label: Ubuntu focal amd64
+            id: ubuntu-focal-amd64
+            task-namespace: apt
+            target: ubuntu-focal
+            test-docker-image: ubuntu:focal
           - label: AlmaLinux 8 x86_64
             id: almalinux-8-x86_64
             task-namespace: yum

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -56,7 +56,6 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
       "debian-bookworm-arm64",
       "debian-trixie",
       "debian-trixie-arm64",
-      "ubuntu-focal",
     ]
   end
 

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -56,6 +56,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
       "debian-bookworm-arm64",
       "debian-trixie",
       "debian-trixie-arm64",
+      "ubuntu-focal",
     ]
   end
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -2,6 +2,8 @@
 
 set -exu
 
+echo "debconf debconf/frontend select Noninteractive" | debconf-set-selections
+
 apt update
 apt install -V -y lsb-release wget
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -32,7 +32,7 @@ apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${component}/*/*/*_{${architecture},all}.deb
 
 groonga --version
-if [ "${architecture}" != "i386" ]; then
+if [ "${architecture}" != "i386" ] && [ "${distribution}" != "ubuntu" ]; then
   if ! groonga --version | grep -q apache-arrow; then
     echo "Apache Arrow isn't enabled"
     exit 1
@@ -72,11 +72,6 @@ if groonga --version | grep -q apache-arrow; then
   apt install -V -y \
     g++ \
     libre2-dev
-  # Remove -std=c++11 from RE2 pkg-config to ensure C++17 compatibility for Apache Arrow in Ubuntu focal.
-  # ref: https://github.com/apache/arrow/issues/41396#issuecomment-2081996268
-  if [ "${code_name}" = "focal" ]; then
-    sed -i -e 's/-std=c++11//g' /usr/lib/x86_64-linux-gnu/pkgconfig/re2.pc
-  fi
   MAKEFLAGS=-j$(nproc) gem install red-arrow
 fi
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -7,6 +7,14 @@ apt install -V -y lsb-release wget
 
 distribution=$(lsb_release --id --short | tr 'A-Z' 'a-z')
 code_name=$(lsb_release --codename --short)
+case "${distribution}" in
+  debian)
+    component=main
+    ;;
+  ubuntu)
+    component=universe
+    ;;
+esac
 architecture=$(dpkg --print-architecture)
 
 wget https://apache.jfrog.io/artifactory/arrow/${distribution}/apache-arrow-apt-source-latest-${code_name}.deb
@@ -19,7 +27,7 @@ apt update
 
 repositories_dir=/groonga/packages/apt/repositories
 apt install -V -y \
-  ${repositories_dir}/${distribution}/pool/${code_name}/main/*/*/*_{${architecture},all}.deb
+  ${repositories_dir}/${distribution}/pool/${code_name}/${component}/*/*/*_{${architecture},all}.deb
 
 groonga --version
 if [ "${architecture}" != "i386" ]; then

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -72,6 +72,11 @@ if groonga --version | grep -q apache-arrow; then
   apt install -V -y \
     g++ \
     libre2-dev
+  # Remove -std=c++11 from RE2 pkg-config to ensure C++17 compatibility for Apache Arrow in Ubuntu focal.
+  # ref: https://github.com/apache/arrow/issues/41396#issuecomment-2081996268
+  if [ "${code_name}" = "focal" ]; then
+    sed -i -e 's/-std=c++11//g' /usr/lib/x86_64-linux-gnu/pkgconfig/re2.pc
+  fi
   MAKEFLAGS=-j$(nproc) gem install red-arrow
 fi
 

--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -19,7 +19,7 @@ apt update
 
 repositories_dir=/groonga/packages/apt/repositories
 apt install -V -y \
-  ${repositories_dir}/debian/pool/${code_name}/main/*/*/*_{${architecture},all}.deb
+  ${repositories_dir}/${distribution}/pool/${code_name}/main/*/*/*_{${architecture},all}.deb
 
 groonga --version
 if [ "${architecture}" != "i386" ]; then

--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -10,15 +10,6 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V --no-install-recommends ${quiet} \
-    ca-certificates \
-    gpg-agent \
-    lsb-release \
-    software-properties-common \
-    wget && \
-  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
-  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
-  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
   add-apt-repository -y ppa:groonga/ppa && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
@@ -29,7 +20,6 @@ RUN \
     debhelper \
     devscripts \
     dh-apparmor \
-    libarrow-dev \
     libedit-dev \
     libevent-dev \
     liblz4-dev \

--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -10,8 +10,6 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  add-apt-repository -y ppa:groonga/ppa && \
-  apt update ${quiet} && \
   apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \

--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -37,7 +37,6 @@ RUN \
     libmsgpack-dev \
     libjemalloc-dev \
     libpcre3-dev \
-    libsimdjson-dev \
     libssl-dev \
     libstemmer-dev \
     libthrift-dev \

--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -1,0 +1,52 @@
+ARG FROM=ubuntu:focal
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V --no-install-recommends ${quiet} \
+    ca-certificates \
+    gpg-agent \
+    lsb-release \
+    software-properties-common \
+    wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  add-apt-repository -y ppa:groonga/ppa && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    autoconf-archive \
+    build-essential \
+    ccache \
+    cmake \
+    debhelper \
+    devscripts \
+    dh-apparmor \
+    libarrow-dev \
+    libedit-dev \
+    libevent-dev \
+    liblz4-dev \
+    libmecab-dev \
+    libmsgpack-dev \
+    libjemalloc-dev \
+    libpcre3-dev \
+    libsimdjson-dev \
+    libssl-dev \
+    libstemmer-dev \
+    libthrift-dev \
+    libxxhash-dev \
+    libzmq3-dev \
+    libzstd-dev \
+    lsb-release \
+    ninja-build \
+    pkg-config \
+    rapidjson-dev \
+    zlib1g-dev && \
+  apt clean

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -20,6 +20,11 @@ override_dh_auto_configure:
 	else							\
 	  GRN_WITH_APACHE_ARROW=OFF;				\
 	fi;							\
+	if [ "$$(lsb_release -cs)" = "focal" ]; then		\
+	  GRN_WITH_SIMDJSON=no;                                 \
+	else                                                    \
+	  GRN_WITH_SIMDJSON=auto;                               \
+	fi;                                                     \
 	dh_auto_configure					\
 	  --buildsystem=cmake+ninja				\
 	  --							\
@@ -30,7 +35,8 @@ override_dh_auto_configure:
 	  -DGRN_WITH_DOC=ON					\
 	  -DGRN_WITH_EXAMPLES=ON				\
 	  -DGRN_WITH_MRUBY=ON					\
-	  -DGRN_WITH_MUNIN_PLUGINS=ON
+	  -DGRN_WITH_MUNIN_PLUGINS=ON                           \
+	  -DGRN_WITH_SIMDJSON=$${GRN_WITH_SIMDJSON}
 
 # disable 'make check'.
 override_dh_auto_test:

--- a/test/command/suite/select/drilldowns/keys/multiple_large.test
+++ b/test/command/suite/select/drilldowns/keys/multiple_large.test
@@ -1,4 +1,4 @@
-# Need xxHash
+#@require-feature xxhash
 
 table_create Data TABLE_NO_KEY
 column_create Data text COLUMN_SCALAR ShortText


### PR DESCRIPTION
GitHub: ref GH-1865

In this PR, we add steps for building and testing Ubuntu focal packages as part of our regular development workflow on CI.
The reason for adding this is to prevent potential build failures on Launchpad during the release process, which can result in late discovery of issues and delays.

## Note about test using `xxHash`

Ubuntu focal provides `xxHash` version 0.7.3, which does not meet the required version 0.8.0. We have updated the tests to skip xxHash-dependent functionality on Ubuntu focal by adding `@require-feature xxhash` which is the grntest's function. This change ensures that the test about features requiring `xxHash` are executed only when `xxHash` is available.

```
-- Checking for module 'libxxhash>=0.8.0'
--   Requested 'libxxhash >= 0.8.0' but version of xxhash is 0.7.3
You may find new versions of xxhash at https://www.xxhash.com/
-- Could NOT find GroongaxxHash (missing: GroongaxxHash_FOUND) (Required is at least version "0.8.0")
-- No xxHash
```