### PR TITLE
docs: api/grn_table_cursor: Move the get_key() and get_value() reference to the header file

### DIFF
--- a/doc/source/reference/api/grn_table_cursor.rst
+++ b/doc/source/reference/api/grn_table_cursor.rst
@@ -20,20 +20,6 @@ Reference
 
    TODO...
 
-.. c:function:: int grn_table_cursor_get_key(grn_ctx *ctx, grn_table_cursor *tc, void **key)
-
-   cursorのカレントレコードのkeyをkeyパラメータにセットし、その長さを返します。
-
-   :param tc: 対象cursorを指定します。
-   :param key: カレントレコードのkeyへのポインタがセットされます。
-
-.. c:function:: int grn_table_cursor_get_value(grn_ctx *ctx, grn_table_cursor *tc, void **value)
-
-   cursorパラメータのカレントレコードのvalueをvalueパラメータにセットし、その長さを返します。
-
-   :param tc: 対象cursorを指定します。
-   :param value: カレントレコードのvalueへのポインタがセットされます。
-
 .. c:function:: grn_rc grn_table_cursor_set_value(grn_ctx *ctx, grn_table_cursor *tc, const void *value, int flags)
 
    cursorのカレントレコードのvalueを引数の内容に置き換えます。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -280,8 +280,30 @@ grn_table_cursor_close(grn_ctx *ctx, grn_table_cursor *tc);
  */
 GRN_API grn_id
 grn_table_cursor_next(grn_ctx *ctx, grn_table_cursor *tc);
+
+/**
+ * \brief Sets the key of the current record in cursor to `key` parameter and
+ *        returns its length
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ * \param key A pointer to the key of the current record is set
+ *
+ * \return Length of `key`
+ */
 GRN_API int
 grn_table_cursor_get_key(grn_ctx *ctx, grn_table_cursor *tc, void **key);
+
+/**
+ * \brief Sets the value of the current record in cursor to `value` parameter
+ *        and returns its length
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ * \param value A pointer to the value of the current record is set
+ *
+ * \return Length of `value`
+ */
 GRN_API int
 grn_table_cursor_get_value(grn_ctx *ctx, grn_table_cursor *tc, void **value);
 GRN_API uint32_t


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.