### PR TITLE
docs: api/grn_table_cursor: Move the delete() and table() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table_cursor.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table_cursor.po
@@ -33,32 +33,14 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "cursorのカレントレコードのkeyをkeyパラメータにセットし、その長さを返します。"
+msgid "cursorのカレントレコードのvalueを引数の内容に置き換えます。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
 msgstr ""
 
 msgid "対象cursorを指定します。"
-msgstr ""
-
-msgid "カレントレコードのkeyへのポインタがセットされます。"
-msgstr ""
-
-msgid "cursorパラメータのカレントレコードのvalueをvalueパラメータにセットし、その長さを返します。"
-msgstr ""
-
-msgid "カレントレコードのvalueへのポインタがセットされます。"
-msgstr ""
-
-msgid "cursorのカレントレコードのvalueを引数の内容に置き換えます。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
 msgstr ""
 
 msgid "新しいvalueの値を指定します。"
 msgstr ""
 
 msgid ":c:func:`grn_obj_set_value()` のflagsと同様の値を指定できます。"
-msgstr ""
-
-msgid "cursorのカレントレコードを削除します。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
-msgstr ""
-
-msgid "cursorが属するtableを返します。"
 msgstr ""

--- a/doc/source/reference/api/grn_table_cursor.rst
+++ b/doc/source/reference/api/grn_table_cursor.rst
@@ -27,15 +27,3 @@ Reference
    :param tc: 対象cursorを指定します。
    :param value: 新しいvalueの値を指定します。
    :param flags: :c:func:`grn_obj_set_value()` のflagsと同様の値を指定できます。
-
-.. c:function:: grn_rc grn_table_cursor_delete(grn_ctx *ctx, grn_table_cursor *tc)
-
-   cursorのカレントレコードを削除します。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。
-
-   :param tc: 対象cursorを指定します。
-
-.. c:function:: grn_obj *grn_table_cursor_table(grn_ctx *ctx, grn_table_cursor *tc)
-
-   cursorが属するtableを返します。
-
-   :param tc: 対象cursorを指定します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -323,7 +323,7 @@ grn_table_cursor_set_value(grn_ctx *ctx,
  * \param ctx The context object
  * \param tc Target cursor
  *
- * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT If the current record
+ * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record
  *         for cursor does not exist, and the appropriate `grn_rc` for any other
  *         errors
  */

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -317,10 +317,28 @@ grn_table_cursor_set_value(grn_ctx *ctx,
                            grn_table_cursor *tc,
                            const void *value,
                            int flags);
+/**
+ * \brief Delete the current record for cursor
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ *
+ * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT If the current record
+ *         for cursor does not exist, and the appropriate `grn_rc` for any other
+ *         errors
+ */
 GRN_API grn_rc
 grn_table_cursor_delete(grn_ctx *ctx, grn_table_cursor *tc);
 GRN_API size_t
 grn_table_cursor_get_max_n_records(grn_ctx *ctx, grn_table_cursor *cursor);
+/**
+ * \brief Returns the table of cursor.
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ *
+ * \return The table of cursor on success, `NULL` on error
+ */
 GRN_API grn_obj *
 grn_table_cursor_table(grn_ctx *ctx, grn_table_cursor *tc);
 

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -332,7 +332,7 @@ grn_table_cursor_delete(grn_ctx *ctx, grn_table_cursor *tc);
 GRN_API size_t
 grn_table_cursor_get_max_n_records(grn_ctx *ctx, grn_table_cursor *cursor);
 /**
- * \brief Returns the table of cursor.
+ * \brief Return the table of cursor
  *
  * \param ctx The context object
  * \param tc Target cursor


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.