### PR TITLE
docs: api/grn_table: Move grn_table_sort() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -105,27 +105,6 @@ msgstr ""
 msgid "注意: multithread環境では他のthreadのアクセスによって、存在しないアドレスへアクセスし、SIGSEGVが発生する可能性があります。"
 msgstr ""
 
-msgid "table内のレコードをソートし、上位limit個の要素をresultに格納します。"
-msgstr ""
-
-msgid "keys.keyには、tableのcolumn,accessor,procのいずれかが指定できます。keys.flagsには、``GRN_TABLE_SORT_ASC`` / ``GRN_TABLE_SORT_DESC`` のいずれかを指定できます。``GRN_TABLE_SORT_ASC`` では昇順、``GRN_TABLE_SORT_DESC`` では降順でソートされます。keys.offsetは、内部利用のためのメンバです。"
-msgstr ""
-
-msgid "sortされたレコードのうち、(0ベースで)offset番目から順にresにレコードを格納します。"
-msgstr ""
-
-msgid "resに格納するレコードの上限を指定します。"
-msgstr ""
-
-msgid "結果を格納するtableを指定します。"
-msgstr ""
-
-msgid "ソートキー配列へのポインタを指定します。"
-msgstr ""
-
-msgid "ソートキー配列のサイズを指定します。"
-msgstr ""
-
 msgid "tableのレコードを特定の条件でグループ化します。"
 msgstr ""
 
@@ -151,6 +130,9 @@ msgid "対象table1を指定します。"
 msgstr ""
 
 msgid "対象table2を指定します。"
+msgstr ""
+
+msgid "結果を格納するtableを指定します。"
 msgstr ""
 
 msgid "実行する演算の種類を指定します。"

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -92,19 +92,6 @@ Reference
 
    TODO...
 
-.. c:function:: int grn_table_sort(grn_ctx *ctx, grn_obj *table, int offset, int limit, grn_obj *result, grn_table_sort_key *keys, int n_keys)
-
-   table内のレコードをソートし、上位limit個の要素をresultに格納します。
-
-   keys.keyには、tableのcolumn,accessor,procのいずれかが指定できます。keys.flagsには、``GRN_TABLE_SORT_ASC`` / ``GRN_TABLE_SORT_DESC`` のいずれかを指定できます。``GRN_TABLE_SORT_ASC`` では昇順、``GRN_TABLE_SORT_DESC`` では降順でソートされます。keys.offsetは、内部利用のためのメンバです。
-
-   :param table: 対象tableを指定します。
-   :param offset: sortされたレコードのうち、(0ベースで)offset番目から順にresにレコードを格納します。
-   :param limit: resに格納するレコードの上限を指定します。
-   :param result: 結果を格納するtableを指定します。
-   :param keys: ソートキー配列へのポインタを指定します。
-   :param n_keys: ソートキー配列のサイズを指定します。
- 
 .. c:type:: grn_table_group_result
 
    TODO...

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -496,7 +496,13 @@ grn_table_cursor_foreach(grn_ctx *ctx,
 typedef struct _grn_table_sort_key grn_table_sort_key;
 typedef unsigned char grn_table_sort_flags;
 
-#define GRN_TABLE_SORT_ASC  (0x00 << 0)
+/**
+ * \brief Sort in ascending order
+ */
+#define GRN_TABLE_SORT_ASC (0x00 << 0)
+/**
+ * \brief Sort in descending order
+ */
 #define GRN_TABLE_SORT_DESC (0x01 << 0)
 
 struct _grn_table_sort_key {
@@ -518,8 +524,8 @@ struct _grn_table_sort_key {
  *             * keys.key: You can specify either column, accessor, or proc of
  *               table
  *             * keys.flags: You can specify the next
- *               * GRN_TABLE_SORT_ASC: Sort in ascending order
- *               * GRN_TABLE_SORT_DESC: Sort in descending order
+ *               * \ref GRN_TABLE_SORT_ASC
+ *               * \ref GRN_TABLE_SORT_DESC
  *             * keys.offset: Member for internal use
  * \param n_keys Number of elements in `keys` array
  *

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -505,6 +505,26 @@ struct _grn_table_sort_key {
   int offset;
 };
 
+/**
+ * \brief Sorts the records in table and stores the results in `result`
+ *
+ * \param ctx The context object
+ * \param table Target table
+ * \param offset Starting offset of the sorted record.
+ *               The records are stored in order from the offset (zero-based).
+ * \param limit Maximum number of records to be stored in `result`
+ * \param result Table to store results
+ * \param keys Array of sort keys
+ *             * keys.key: You can specify either column, accessor, or proc of
+ *               table
+ *             * keys.flags: You can specify the next
+ *               * GRN_TABLE_SORT_ASC: Sort in ascending order
+ *               * GRN_TABLE_SORT_DESC: Sort in descending order
+ *             * keys.offset: Member for internal use
+ * \param n_keys Number of elements in `keys` array
+ *
+ * \return Number of sorted records
+ */
 GRN_API int
 grn_table_sort(grn_ctx *ctx,
                grn_obj *table,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -506,7 +506,7 @@ struct _grn_table_sort_key {
 };
 
 /**
- * \brief Sorts the records in table and stores the results in `result`
+ * \brief Sort the records in table and store the results in `result`
  *
  * \param ctx The context object
  * \param table Target table

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -521,8 +521,8 @@ struct _grn_table_sort_key {
  * \param limit Maximum number of records to be stored in `result`
  * \param result Table to store results
  * \param keys Array of sort keys
- *             * keys.key: You can specify either column, accessor, or proc of
- *               table
+ *             * keys.key: You can specify either column of table, accessor of
+ *               table, or proc
  *             * keys.flags: You can specify the next
  *               * \ref GRN_TABLE_SORT_ASC
  *               * \ref GRN_TABLE_SORT_DESC


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.