### PR TITLE
docs api/grn_table_cursor: Move the grn_table_cursor_set_value() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table_cursor.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table_cursor.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_table_cursor``"
 msgstr ""
 
@@ -33,14 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "cursorのカレントレコードのvalueを引数の内容に置き換えます。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
-msgstr ""
-
-msgid "対象cursorを指定します。"
-msgstr ""
-
-msgid "新しいvalueの値を指定します。"
-msgstr ""
-
-msgid ":c:func:`grn_obj_set_value()` のflagsと同様の値を指定できます。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_table_cursor.rst
+++ b/doc/source/reference/api/grn_table_cursor.rst
@@ -16,14 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_table_cursor
-
-   TODO...
-
-.. c:function:: grn_rc grn_table_cursor_set_value(grn_ctx *ctx, grn_table_cursor *tc, const void *value, int flags)
-
-   cursorのカレントレコードのvalueを引数の内容に置き換えます。cursorのカレントレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。
-
-   :param tc: 対象cursorを指定します。
-   :param value: 新しいvalueの値を指定します。
-   :param flags: :c:func:`grn_obj_set_value()` のflagsと同様の値を指定できます。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -843,15 +843,15 @@ grn_obj_get_values(grn_ctx *ctx, grn_obj *obj, grn_id offset, void **values);
 
 #define GRN_OBJ_SET_MASK (0x07)
 /**
- * \brief Replace the value of the record with the specified value
+ * \brief Replace the value of the record/column with the specified value
  */
 #define GRN_OBJ_SET (0x01)
 /**
- * \brief Add the specified value to the record value
+ * \brief Add the specified value to the record/column value
  */
 #define GRN_OBJ_INCR (0x02)
 /**
- * \brief Subtract the specified value from the record value
+ * \brief Subtract the specified value from the record/column value
  */
 #define GRN_OBJ_DECR    (0x03)
 #define GRN_OBJ_APPEND  (0x04)

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -59,7 +59,7 @@ typedef __bf16 grn_bfloat16;
 #define GRN_FALSE  false
 
 typedef enum {
-  /// Success
+  /// Success (0)
   GRN_SUCCESS = 0,
   GRN_END_OF_DATA = 1,
   GRN_UNKNOWN_ERROR = -1,
@@ -83,6 +83,7 @@ typedef enum {
   GRN_NO_SUCH_DEVICE = -19,
   GRN_NOT_A_DIRECTORY = -20,
   GRN_IS_A_DIRECTORY = -21,
+  /// Invalid function argument (-22)
   GRN_INVALID_ARGUMENT = -22,
   GRN_TOO_MANY_OPEN_FILES_IN_SYSTEM = -23,
   GRN_TOO_MANY_OPEN_FILES = -24,

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -842,8 +842,17 @@ grn_obj_get_values(grn_ctx *ctx, grn_obj *obj, grn_id offset, void **values);
   } while (0)
 
 #define GRN_OBJ_SET_MASK (0x07)
+/**
+ * \brief Replace the value of the record with the specified value
+ */
 #define GRN_OBJ_SET      (0x01)
+/**
+ * \brief Add the specified value to the record value
+ */
 #define GRN_OBJ_INCR     (0x02)
+/**
+ * \brief Subtract the specified value from the record value
+ */
 #define GRN_OBJ_DECR     (0x03)
 #define GRN_OBJ_APPEND   (0x04)
 #define GRN_OBJ_PREPEND  (0x05)

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -845,21 +845,21 @@ grn_obj_get_values(grn_ctx *ctx, grn_obj *obj, grn_id offset, void **values);
 /**
  * \brief Replace the value of the record with the specified value
  */
-#define GRN_OBJ_SET      (0x01)
+#define GRN_OBJ_SET (0x01)
 /**
  * \brief Add the specified value to the record value
  */
-#define GRN_OBJ_INCR     (0x02)
+#define GRN_OBJ_INCR (0x02)
 /**
  * \brief Subtract the specified value from the record value
  */
-#define GRN_OBJ_DECR     (0x03)
-#define GRN_OBJ_APPEND   (0x04)
-#define GRN_OBJ_PREPEND  (0x05)
-#define GRN_OBJ_GET      (0x01 << 4)
-#define GRN_OBJ_COMPARE  (0x01 << 5)
-#define GRN_OBJ_LOCK     (0x01 << 6)
-#define GRN_OBJ_UNLOCK   (0x01 << 7)
+#define GRN_OBJ_DECR    (0x03)
+#define GRN_OBJ_APPEND  (0x04)
+#define GRN_OBJ_PREPEND (0x05)
+#define GRN_OBJ_GET     (0x01 << 4)
+#define GRN_OBJ_COMPARE (0x01 << 5)
+#define GRN_OBJ_LOCK    (0x01 << 6)
+#define GRN_OBJ_UNLOCK  (0x01 << 7)
 
 GRN_API grn_rc
 grn_obj_set_value(

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -350,9 +350,9 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
  *      * \ref GRN_OBJ_INCR
  *      * \ref GRN_OBJ_DECR
  *
- * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record
- *         for cursor does not exist, and the appropriate `grn_rc` for any other
- *         errors
+ * \return \ref GRN_SUCCESS on success, \ref GRN_INVALID_ARGUMENT if the current
+ *         record for cursor does not exist, and the appropriate `grn_rc` for
+ *         any other errors
  */
 GRN_API grn_rc
 grn_table_cursor_set_value(grn_ctx *ctx,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -345,13 +345,10 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
  * \param ctx The context object
  * \param tc Table cursor
  * \param value Value to set
- * \param flags
- *      * `GRN_OBJ_SET`
- *        * Replace the value of the record with `value`
- *      * `GRN_OBJ_INCR`
- *        * Add `value` to the record value
- *      * `GRN_OBJ_DECR`
- *        * Subtract `value` from the record value
+ * \param flags Available value:
+ *      * \ref GRN_OBJ_SET
+ *      * \ref GRN_OBJ_INCR
+ *      * \ref GRN_OBJ_DECR
  *
  * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record
  *         for cursor does not exist, and the appropriate `grn_rc` for any other

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -345,7 +345,7 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
  * \param ctx The context object
  * \param tc Table cursor
  * \param value Value to set
- * \param flags Available value:
+ * \param flags Available values:
  *      * \ref GRN_OBJ_SET
  *      * \ref GRN_OBJ_INCR
  *      * \ref GRN_OBJ_DECR

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -339,6 +339,24 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
                                void **key,
                                uint32_t *key_size,
                                void **value);
+/**
+ * \brief Set `value` to the current record according to `flags`
+ *
+ * \param ctx The context object
+ * \param tc Target cursor
+ * \param value Value to set
+ * \param flags
+ *      * GRN_OBJ_SET
+ *        * Replace the value of the record with `value`
+ *      * GRN_OBJ_INCR
+ *        * Add `value` to the record value
+ *      * GRN_OBJ_DECR
+ *        * Subtracts `value` from the record value
+ *
+ * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record
+ *         for cursor does not exist, and the appropriate `grn_rc` for any other
+ *         errors
+ */
 GRN_API grn_rc
 grn_table_cursor_set_value(grn_ctx *ctx,
                            grn_table_cursor *tc,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -351,7 +351,7 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
  *      * GRN_OBJ_INCR
  *        * Add `value` to the record value
  *      * GRN_OBJ_DECR
- *        * Subtracts `value` from the record value
+ *        * Subtract `value` from the record value
  *
  * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record
  *         for cursor does not exist, and the appropriate `grn_rc` for any other

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -343,14 +343,14 @@ grn_table_cursor_get_key_value(grn_ctx *ctx,
  * \brief Set `value` to the current record according to `flags`
  *
  * \param ctx The context object
- * \param tc Target cursor
+ * \param tc Table cursor
  * \param value Value to set
  * \param flags
- *      * GRN_OBJ_SET
+ *      * `GRN_OBJ_SET`
  *        * Replace the value of the record with `value`
- *      * GRN_OBJ_INCR
+ *      * `GRN_OBJ_INCR`
  *        * Add `value` to the record value
- *      * GRN_OBJ_DECR
+ *      * `GRN_OBJ_DECR`
  *        * Subtract `value` from the record value
  *
  * \return GRN_SUCCESS on success, GRN_INVALID_ARGUMENT if the current record


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.