### PR TITLE
logger: Fix crash bug when log rotate is enabled

### DIFF
--- a/lib/logger.c
+++ b/lib/logger.c
@@ -313,6 +313,9 @@ grn_logger_output_end(grn_ctx *ctx,
         output->file != stderr &&
         (output->rotate_threshold_size > 0 &&
          output->size >= output->rotate_threshold_size)) {
+      if (output->need_flock) {
+        flock(fileno(output->file), LOCK_UN);
+      }
       fclose(output->file);
       output->file = NULL;
       grn_logger_output_rotate(ctx, output);
@@ -321,7 +324,7 @@ grn_logger_output_end(grn_ctx *ctx,
     }
   }
 #ifndef _WIN32
-  if (output->need_flock) {
+  if (output->need_flock && output->file) {
     flock(fileno(output->file), LOCK_UN);
   }
 #endif

--- a/lib/logger.c
+++ b/lib/logger.c
@@ -313,9 +313,11 @@ grn_logger_output_end(grn_ctx *ctx,
         output->file != stderr &&
         (output->rotate_threshold_size > 0 &&
          output->size >= output->rotate_threshold_size)) {
+#ifndef _WIN32
       if (output->need_flock) {
         flock(fileno(output->file), LOCK_UN);
       }
+#endif
       fclose(output->file);
       output->file = NULL;
       grn_logger_output_rotate(ctx, output);


### PR DESCRIPTION
This bug occurred in the following conditions.

* When logging to a file
  *  `--log-path <path>`
  * `--query-log-path <path>`
* Log rotate is enabled
  * `--log-rotate-threshold-size <threshold>`
  * `--query-log-rotate-threshold-size <threshold>`
* Process ID log output is enabled
  * `--log-flags process_id`

When the log is rotated, `output->file` is closed and set to `NULL`.
The crash occurs because of `flock(fileno(output->file), LOCK_UN);` in that state.
This unlocking was only executed when outputting process ID to the log, so it occurred only when outputting process ID.