### PR TITLE
docs: api/grn_command_version: Move the grn_command_version reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_command_version.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_command_version.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_command_version``"
 msgstr ""
 
@@ -33,11 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "デフォルトのcommand_versionを返します。"
-msgstr ""
-
-msgid "デフォルトのcommand_versionを変更します。"
-msgstr ""
-
-msgid "変更後のデフォルトのcommand_versionを指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_command_version.rst
+++ b/doc/source/reference/api/grn_command_version.rst
@@ -16,20 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_command_version
-
-.. c:macro:: GRN_COMMAND_VERSION_MIN
-
-.. c:macro:: GRN_COMMAND_VERSION_STABLE
-
-.. c:macro:: GRN_COMMAND_VERSION_MAX
-
-.. c:function:: grn_command_version grn_get_default_command_version(void)
-
-   デフォルトのcommand_versionを返します。
-
-.. c:function:: grn_rc grn_set_default_command_version(grn_command_version version)
-
-   デフォルトのcommand_versionを変更します。
-
-   :param version: 変更後のデフォルトのcommand_versionを指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -133,6 +133,7 @@ typedef enum {
   GRN_TOO_LARGE_OFFSET = -68,
   GRN_TOO_SMALL_LIMIT = -69,
   GRN_CAS_ERROR = -70,
+  /// When a version not supported by the default version set is specified (-71)
   GRN_UNSUPPORTED_COMMAND_VERSION = -71,
   GRN_NORMALIZER_ERROR = -72,
   GRN_TOKEN_FILTER_ERROR = -73,
@@ -307,8 +308,19 @@ grn_get_package(void);
 GRN_API const char *
 grn_get_package_label(void);
 
+/**
+ * \return Default command version
+ */
 GRN_API grn_command_version
 grn_get_default_command_version(void);
+/**
+ * \brief Set default command version
+ *
+ * \param version New command version
+ *
+ * \return \ref GRN_SUCCESS on success, \ref GRN_UNSUPPORTED_COMMAND_VERSION on
+ *         error
+ */
 GRN_API grn_rc
 grn_set_default_command_version(grn_command_version version);
 GRN_API grn_command_version


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.