### PR TITLE
docs: api/grn_encoding: Move the default encoding get and set reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_encoding.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_encoding.po
@@ -33,15 +33,6 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "デフォルトのencodingを返します。"
-msgstr ""
-
-msgid "デフォルトのencodingを変更します。"
-msgstr ""
-
-msgid "変更後のデフォルトのencodingを指定します。"
-msgstr ""
-
 msgid "Returns string representation for the encoding. For example, 'grn_encoding_to_string(``GRN_ENC_UTF8``)' returns '\"utf8\"'."
 msgstr "エンコーディングの形式を文字列で返します。たとえば'grn_encoding_to_string(``GRN_ENC_UTF8``)' は\"utf8\"を返します。"
 

--- a/doc/source/reference/api/grn_encoding.rst
+++ b/doc/source/reference/api/grn_encoding.rst
@@ -20,16 +20,6 @@ Reference
 
    TODO...
 
-.. c:function:: grn_encoding grn_get_default_encoding(void)
-
-   デフォルトのencodingを返します。
-
-.. c:function:: grn_rc grn_set_default_encoding(grn_encoding encoding)
-
-   デフォルトのencodingを変更します。
-
-   :param encoding: 変更後のデフォルトのencodingを指定します。
-
 .. c:function:: const char *grn_encoding_to_string(grn_encoding encoding)
 
    Returns string representation for the encoding. For example, 'grn_encoding_to_string(``GRN_ENC_UTF8``)' returns '"utf8"'.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -287,12 +287,12 @@ GRN_API grn_rc
 grn_ctx_merge_temporary_open_space(grn_ctx *ctx);
 
 /**
- * \return Default encoding
+ * \return The default encoding
  */
 GRN_API grn_encoding
 grn_get_default_encoding(void);
 /**
- * \brief Set default encoding
+ * \brief Set the default encoding
  *
  * \param encoding New encoding
  *

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -286,8 +286,19 @@ grn_ctx_pop_temporary_open_space(grn_ctx *ctx);
 GRN_API grn_rc
 grn_ctx_merge_temporary_open_space(grn_ctx *ctx);
 
+/**
+ * \return Default encoding
+ */
 GRN_API grn_encoding
 grn_get_default_encoding(void);
+/**
+ * \brief Set default encoding
+ *
+ * \param encoding New encoding
+ *
+ * \return \ref GRN_SUCCESS on success, \ref GRN_INVALID_ARGUMENT on
+ *         error
+ */
 GRN_API grn_rc
 grn_set_default_encoding(grn_encoding encoding);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.