### PR TITLE
package test: Apache Arrow is available now

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -32,7 +32,7 @@ apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${component}/*/*/*_{${architecture},all}.deb
 
 groonga --version
-if [ "${architecture}" != "i386" ] && [ "${distribution}" != "ubuntu" ]; then
+if [ "${distribution}" != "ubuntu" ]; then
   if ! groonga --version | grep -q apache-arrow; then
     echo "Apache Arrow isn't enabled"
     exit 1


### PR DESCRIPTION
GitHub: ref GH-1865
ref: https://github.com/groonga/groonga/pull/1861#discussion_r1722686568

Remove unnecessary architecture check for Apache Arrow support on arm64. It has been already supported on arm64.

ref: https://arrow.apache.org/install/#c-and-python-conda-packages