### PR TITLE
ci: set timeout for package build jobs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -237,6 +237,7 @@ jobs:
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ (matrix.id == 'debian-trixie-arm64' && 270) || 90 }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -199,6 +199,7 @@ jobs:
             task-namespace: apt
             target: debian-bookworm-arm64
             test-docker-image: arm64v8/debian:bookworm
+            timeout-minutes: 90
           - label: Debian GNU/Linux trixie amd64
             id: debian-trixie-amd64
             task-namespace: apt
@@ -209,6 +210,7 @@ jobs:
             task-namespace: apt
             target: debian-trixie-arm64
             test-docker-image: arm64v8/debian:trixie
+            timeout-minutes: 270
           - label: Ubuntu focal amd64
             id: ubuntu-focal-amd64
             task-namespace: apt
@@ -237,7 +239,7 @@ jobs:
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ (matrix.id == 'debian-trixie-arm64' && 270) || 90 }}
+    timeout-minutes: ${{ matrix.timeout-minutes || 60 }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -226,6 +226,7 @@ jobs:
             task-namespace: yum
             target: almalinux-8-aarch64
             test-docker-image: arm64v8/almalinux:8
+            timeout-minutes: 60
           - label: AlmaLinux 9 x86_64
             id: almalinux-9-x86_64
             task-namespace: yum
@@ -236,10 +237,11 @@ jobs:
             task-namespace: yum
             target: almalinux-9-aarch64
             test-docker-image: arm64v8/almalinux:9
+            timeout-minutes: 60
     env:
       APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ matrix.timeout-minutes || 60 }}
+    timeout-minutes: ${{ matrix.timeout-minutes || 30 }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GitHub: fix GH-1885

To prevent CI jobs from running for a long time (max: 6 hours) and to ensure efficient usage of CI resources, this commit adds a timeout configuration for package build jobs.

Set timeouts as follows
- 90 minutes for Debian bookworm arm64
- 270 minutes for Debian trixie arm64
- 60 minutes for AlmaLinux 8/9 aarch64
- 30 minutes for all the other platforms

This ensures that long-running jobs do not block other developers from accessing CI resources and helps maintain faster turnaround times for all jobs.

## For reviewers

I decided the timeout time using the following information.
I have set the timeout to approximately double the time taken by jobs, or added an extra 10 minutes if the duration is short.

https://github.com/groonga/groonga/actions/runs/10465513740/usage

| Job | Run time |
| --- | --- |
| Build (Debian GNU/Linux bookworm amd64) | 18m 57s |
| Build (Debian GNU/Linux bookworm arm64) | 43m 36s |
| Build (Debian GNU/Linux trixie amd64) | 14m 1s |
| Build (Debian GNU/Linux trixie arm64) | 3h 33m 19s |
| Build (Ubuntu focal amd64) | 13m 56s |
| Build (AlmaLinux 8 x86_64) | 12m 55s |
| Build (AlmaLinux 8 aarch64) | 18m 49s |
| Build (AlmaLinux 9 x86_64) | 15m 14s |
| Build (AlmaLinux 9 aarch64) | 35m 27s |


