### PR TITLE
docs: api/grn_table: move size() and rename() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -137,12 +137,3 @@ msgstr ""
 
 msgid "格納したカラムIDの数を返します。"
 msgstr ""
-
-msgid "tableに登録されているレコードの件数を返します。"
-msgstr ""
-
-msgid "ctxが使用するdbにおいてtableに対応する名前をnameに更新します。tableの全てのcolumnも同時に名前が変更されます。tableは永続オブジェクトでなければいけません。"
-msgstr ""
-
-msgid "nameパラメータのsize(byte)を指定します。"
-msgstr ""

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -123,15 +123,3 @@ Reference
    :param name_size: nameパラメータの長さを指定します。
    :param res: 結果を格納する ``GRN_TABLE_HASH_KEY`` のtableを指定します。
    :return: 格納したカラムIDの数を返します。
-
-.. c:function:: unsigned int grn_table_size(grn_ctx *ctx, grn_obj *table)
-
-   tableに登録されているレコードの件数を返します。
-
-   :param table: 対象tableを指定します。
-
-.. c:function:: grn_rc grn_table_rename(grn_ctx *ctx, grn_obj *table, const char *name, unsigned int name_size)
-
-   ctxが使用するdbにおいてtableに対応する名前をnameに更新します。tableの全てのcolumnも同時に名前が変更されます。tableは永続オブジェクトでなければいけません。
-
-   :param name_size: nameパラメータのsize(byte)を指定します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -681,9 +681,29 @@ grn_table_columns(grn_ctx *ctx,
                   unsigned int name_size,
                   grn_obj *res);
 
+/**
+ * \brief Return the number of records registered in the table
+ *
+ * \param ctx The context object
+ * \param table The table or database
+ *
+ * \return Number of records
+ */
 GRN_API unsigned int
 grn_table_size(grn_ctx *ctx, grn_obj *table);
 
+/**
+ *
+ * \brief Rename table to `name`. All columns of the table are renamed at the
+ *        same time. The table must be a persistent object.
+ *
+ * \param ctx The context object
+ * \param table Target table
+ * \param name New name
+ * \param name_size Length of `name`
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error
+ */
 GRN_API grn_rc
 grn_table_rename(grn_ctx *ctx,
                  grn_obj *table,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -687,7 +687,7 @@ grn_table_columns(grn_ctx *ctx,
  * \param ctx The context object
  * \param table The table or database
  *
- * \return Number of records
+ * \return The number of records
  */
 GRN_API unsigned int
 grn_table_size(grn_ctx *ctx, grn_obj *table);
@@ -700,7 +700,7 @@ grn_table_size(grn_ctx *ctx, grn_obj *table);
  * \param ctx The context object
  * \param table Target table
  * \param name New name
- * \param name_size Length of `name`
+ * \param name_size Size of `name` in bytes
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error
  */


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.