### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `b`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -845,15 +845,9 @@ grn_nfkc_normalize_expand(grn_ctx *ctx,
                                     "");
 }
 
-/*
- * This function assumes that the input utf8_char is a valid UTF-8 character.
- * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
- * before calling this function. This is a precondition in terms of contract
- * programming.
- */
-grn_inline static const unsigned char *
-grn_nfkc_normalize_unify_alphabet_diacritical_mark(
-  const unsigned char *utf8_char, unsigned char *unified)
+grn_inline static unsigned char *
+grn_nfkc_normalize_unify_a_diacritical_mark(const unsigned char *utf8_char,
+                                            unsigned char *unified)
 {
   /*
    * Latin-1 Supplement
@@ -917,6 +911,44 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
       (utf8_char[0] == 0xE1 && utf8_char[1] == 0xBA &&
        (0xA1 <= utf8_char[2] && utf8_char[2] <= 0xB7))) {
     *unified = 'a';
+    return unified;
+  }
+  return NULL;
+}
+
+grn_inline static unsigned char *
+grn_nfkc_normalize_unify_b_diacritical_mark(const unsigned char *utf8_char,
+                                            unsigned char *unified)
+{
+  /*
+   * Latin Extended Additional
+   * U+1E03 LATIN SMALL LETTER B WITH DOT ABOVE
+   * U+1E05 LATIN SMALL LETTER B WITH DOT BELOW
+   * U+1E07 LATIN SMALL LETTER B WITH LINE BELOW
+   * Uppercase counterparts(U+1E04, U+1E06) are covered by the
+   * following condition but they are never appeared here. Because NFKC
+   * normalization converts them to their lowercase equivalents.
+   */
+  if (utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
+      (0x83 <= utf8_char[2] && utf8_char[2] <= 0x87)) {
+    *unified = 'b';
+    return unified;
+  }
+  return NULL;
+}
+
+/*
+ * This function assumes that the input utf8_char is a valid UTF-8 character.
+ * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
+ * before calling this function. This is a precondition in terms of contract
+ * programming.
+ */
+grn_inline static const unsigned char *
+grn_nfkc_normalize_unify_alphabet_diacritical_mark(
+  const unsigned char *utf8_char, unsigned char *unified)
+{
+  if (grn_nfkc_normalize_unify_a_diacritical_mark(utf8_char, unified) ||
+      grn_nfkc_normalize_unify_b_diacritical_mark(utf8_char, unified)) {
     return unified;
   }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -853,65 +853,65 @@ grn_nfkc_normalize_unify_diacritical_mark_is_a(const unsigned char *utf8_char)
    * U+00E0 LATIN SMALL LETTER A WITH GRAVE ..
    * U+00E5 LATIN SMALL LETTER A WITH RING ABOVE
    */
-  if ((utf8_char[0] == 0xC3 && 0xA0 <= utf8_char[1] && utf8_char[1] <= 0xA5) ||
-      /*
-       * Latin Extended-A
-       * U+0101 LATIN SMALL LETTER A WITH MACRON
-       * U+0103 LATIN SMALL LETTER A WITH BREVE
-       * U+0105 LATIN SMALL LETTER A WITH OGONEK
-       * Uppercase counterparts (U+0102 and U+0104) are covered by the following
-       * condition but they are never appeared here. Because NFKC normalization
-       * converts them to their lowercase equivalents.
-       */
-      (utf8_char[0] == 0xC4 &&
-       (0x81 <= utf8_char[1] && utf8_char[1] <= 0x85)) ||
-      /*
-       * Latin Extended-B
-       * U+01CE LATIN SMALL LETTER A WITH CARON
-       * U+01DF LATIN SMALL LETTER A WITH DIAERESIS AND MACRON
-       * U+01E1 LATIN SMALL LETTER A WITH DOT ABOVE AND MACRON
-       * U+01FB LATIN SMALL LETTER A WITH RING ABOVE AND ACUTE
-       */
-      (utf8_char[0] == 0xC7 &&
-       (utf8_char[1] == 0x8E || utf8_char[1] == 0x9F || utf8_char[1] == 0xA1 ||
-        utf8_char[1] == 0xBB)) ||
-      /*
-       * Latin Extended-B
-       * U+0201 LATIN SMALL LETTER A WITH DOUBLE GRAVE
-       * U+0203 LATIN SMALL LETTER A WITH INVERTED BREVE
-       * U+0227 LATIN SMALL LETTER A WITH DOT ABOVE
-       */
-      (utf8_char[0] == 0xC8 && (utf8_char[1] == 0x81 || utf8_char[1] == 0x83 ||
-                                utf8_char[1] == 0xA7)) ||
-      /*
-       * Latin Extended Additional
-       * U+1E01 LATIN SMALL LETTER A WITH RING BELOW
-       */
-      (utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 && utf8_char[2] == 0x81) ||
-      /*
-       * Latin Extended Additional
-       * U+1EA1 LATIN SMALL LETTER A WITH DOT BELOW
-       * U+1EA3 LATIN SMALL LETTER A WITH HOOK ABOVE
-       * U+1EA5 LATIN SMALL LETTER A WITH CIRCUMFLEX
-       * U+1EA7 LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
-       * U+1EA9 LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
-       * U+1EAB LATIN SMALL LETTER A WITH CIRCUMFLEX AND TILDE
-       * U+1EAD LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
-       * U+1EAF LATIN SMALL LETTER A WITH BREVE AND ACUTE
-       * U+1EB1 LATIN SMALL LETTER A WITH BREVE AND GRAVE
-       * U+1EB3 LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
-       * U+1EB5 LATIN SMALL LETTER A WITH BREVE AND TILDE
-       * U+1EB7 LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
-       * Uppercase counterparts (U+1EA2, U+1EA4, U+1EA6, U+1EA8, U+1EAA,
-       * U+1EAC, U+1EAE, U+1EB0, U+1EB2, U+1EB4, and U+1EB6) are covered by the
-       * following condition but they are never appeared here. Because NFKC
-       * normalization converts them to their lowercase equivalents.
-       */
-      (utf8_char[0] == 0xE1 && utf8_char[1] == 0xBA &&
-       (0xA1 <= utf8_char[2] && utf8_char[2] <= 0xB7))) {
-    return true;
-  }
-  return false;
+  return (utf8_char[0] == 0xC3 && 0xA0 <= utf8_char[1] &&
+          utf8_char[1] <= 0xA5) ||
+         /*
+          * Latin Extended-A
+          * U+0101 LATIN SMALL LETTER A WITH MACRON
+          * U+0103 LATIN SMALL LETTER A WITH BREVE
+          * U+0105 LATIN SMALL LETTER A WITH OGONEK
+          * Uppercase counterparts (U+0102 and U+0104) are covered by the
+          * following condition but they are never appeared here. Because NFKC
+          * normalization converts them to their lowercase equivalents.
+          */
+         (utf8_char[0] == 0xC4 &&
+          (0x81 <= utf8_char[1] && utf8_char[1] <= 0x85)) ||
+         /*
+          * Latin Extended-B
+          * U+01CE LATIN SMALL LETTER A WITH CARON
+          * U+01DF LATIN SMALL LETTER A WITH DIAERESIS AND MACRON
+          * U+01E1 LATIN SMALL LETTER A WITH DOT ABOVE AND MACRON
+          * U+01FB LATIN SMALL LETTER A WITH RING ABOVE AND ACUTE
+          */
+         (utf8_char[0] == 0xC7 &&
+          (utf8_char[1] == 0x8E || utf8_char[1] == 0x9F ||
+           utf8_char[1] == 0xA1 || utf8_char[1] == 0xBB)) ||
+         /*
+          * Latin Extended-B
+          * U+0201 LATIN SMALL LETTER A WITH DOUBLE GRAVE
+          * U+0203 LATIN SMALL LETTER A WITH INVERTED BREVE
+          * U+0227 LATIN SMALL LETTER A WITH DOT ABOVE
+          */
+         (utf8_char[0] == 0xC8 &&
+          (utf8_char[1] == 0x81 || utf8_char[1] == 0x83 ||
+           utf8_char[1] == 0xA7)) ||
+         /*
+          * Latin Extended Additional
+          * U+1E01 LATIN SMALL LETTER A WITH RING BELOW
+          */
+         (utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
+          utf8_char[2] == 0x81) ||
+         /*
+          * Latin Extended Additional
+          * U+1EA1 LATIN SMALL LETTER A WITH DOT BELOW
+          * U+1EA3 LATIN SMALL LETTER A WITH HOOK ABOVE
+          * U+1EA5 LATIN SMALL LETTER A WITH CIRCUMFLEX
+          * U+1EA7 LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
+          * U+1EA9 LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
+          * U+1EAB LATIN SMALL LETTER A WITH CIRCUMFLEX AND TILDE
+          * U+1EAD LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
+          * U+1EAF LATIN SMALL LETTER A WITH BREVE AND ACUTE
+          * U+1EB1 LATIN SMALL LETTER A WITH BREVE AND GRAVE
+          * U+1EB3 LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
+          * U+1EB5 LATIN SMALL LETTER A WITH BREVE AND TILDE
+          * U+1EB7 LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
+          * Uppercase counterparts (U+1EA2, U+1EA4, U+1EA6, U+1EA8, U+1EAA,
+          * U+1EAC, U+1EAE, U+1EB0, U+1EB2, U+1EB4, and U+1EB6) are covered by
+          * the following condition but they are never appeared here. Because
+          * NFKC normalization converts them to their lowercase equivalents.
+          */
+         (utf8_char[0] == 0xE1 && utf8_char[1] == 0xBA &&
+          (0xA1 <= utf8_char[2] && utf8_char[2] <= 0xB7));
 }
 
 grn_inline static bool
@@ -926,11 +926,8 @@ grn_nfkc_normalize_unify_diacritical_mark_is_b(const unsigned char *utf8_char)
    * following condition but they are never appeared here. Because NFKC
    * normalization converts them to their lowercase equivalents.
    */
-  if (utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
-      (0x83 <= utf8_char[2] && utf8_char[2] <= 0x87)) {
-    return true;
-  }
-  return false;
+  return utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
+         (0x83 <= utf8_char[2] && utf8_char[2] <= 0x87);
 }
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -932,7 +932,6 @@ grn_nfkc_normalize_unify_diacritical_mark_is_b(const unsigned char *utf8_char)
   }
   return false;
 }
-
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -846,7 +846,7 @@ grn_nfkc_normalize_expand(grn_ctx *ctx,
 }
 
 grn_inline static unsigned char *
-grn_nfkc_normalize_unify_a_diacritical_mark(const unsigned char *utf8_char,
+grn_nfkc_normalize_unify_diacritical_mark_a(const unsigned char *utf8_char,
                                             unsigned char *unified)
 {
   /*
@@ -917,7 +917,7 @@ grn_nfkc_normalize_unify_a_diacritical_mark(const unsigned char *utf8_char,
 }
 
 grn_inline static unsigned char *
-grn_nfkc_normalize_unify_b_diacritical_mark(const unsigned char *utf8_char,
+grn_nfkc_normalize_unify_diacritical_mark_b(const unsigned char *utf8_char,
                                             unsigned char *unified)
 {
   /*
@@ -947,8 +947,8 @@ grn_inline static const unsigned char *
 grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   const unsigned char *utf8_char, unsigned char *unified)
 {
-  if (grn_nfkc_normalize_unify_a_diacritical_mark(utf8_char, unified) ||
-      grn_nfkc_normalize_unify_b_diacritical_mark(utf8_char, unified)) {
+  if (grn_nfkc_normalize_unify_diacritical_mark_a(utf8_char, unified) ||
+      grn_nfkc_normalize_unify_diacritical_mark_b(utf8_char, unified)) {
     return unified;
   }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -845,9 +845,8 @@ grn_nfkc_normalize_expand(grn_ctx *ctx,
                                     "");
 }
 
-grn_inline static unsigned char *
-grn_nfkc_normalize_unify_diacritical_mark_a(const unsigned char *utf8_char,
-                                            unsigned char *unified)
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_a(const unsigned char *utf8_char)
 {
   /*
    * Latin-1 Supplement
@@ -910,15 +909,13 @@ grn_nfkc_normalize_unify_diacritical_mark_a(const unsigned char *utf8_char,
        */
       (utf8_char[0] == 0xE1 && utf8_char[1] == 0xBA &&
        (0xA1 <= utf8_char[2] && utf8_char[2] <= 0xB7))) {
-    *unified = 'a';
-    return unified;
+    return true;
   }
-  return NULL;
+  return false;
 }
 
-grn_inline static unsigned char *
-grn_nfkc_normalize_unify_diacritical_mark_b(const unsigned char *utf8_char,
-                                            unsigned char *unified)
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_b(const unsigned char *utf8_char)
 {
   /*
    * Latin Extended Additional
@@ -931,10 +928,9 @@ grn_nfkc_normalize_unify_diacritical_mark_b(const unsigned char *utf8_char,
    */
   if (utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
       (0x83 <= utf8_char[2] && utf8_char[2] <= 0x87)) {
-    *unified = 'b';
-    return unified;
+    return true;
   }
-  return NULL;
+  return false;
 }
 
 /*
@@ -947,8 +943,11 @@ grn_inline static const unsigned char *
 grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   const unsigned char *utf8_char, unsigned char *unified)
 {
-  if (grn_nfkc_normalize_unify_diacritical_mark_a(utf8_char, unified) ||
-      grn_nfkc_normalize_unify_diacritical_mark_b(utf8_char, unified)) {
+  if (grn_nfkc_normalize_unify_diacritical_mark_is_a(utf8_char)) {
+    *unified = 'a';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_b(utf8_char)) {
+    *unified = 'b';
     return unified;
   }
 

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -945,9 +945,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_b(utf8_char)) {
     *unified = 'b';
     return unified;
+  } else {
+    return utf8_char;
   }
-
-  return utf8_char;
 }
 
 grn_inline static const unsigned char *

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -903,7 +903,7 @@ grn_nfkc_normalize_unify_diacritical_mark_a(const unsigned char *utf8_char,
        * U+1EB3 LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
        * U+1EB5 LATIN SMALL LETTER A WITH BREVE AND TILDE
        * U+1EB7 LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
-       * Uppercase counterparts(U+1EA2, U+1EA4, U+1EA6, U+1EA8, U+1EAA,
+       * Uppercase counterparts (U+1EA2, U+1EA4, U+1EA6, U+1EA8, U+1EAA,
        * U+1EAC, U+1EAE, U+1EB0, U+1EB2, U+1EB4, and U+1EB6) are covered by the
        * following condition but they are never appeared here. Because NFKC
        * normalization converts them to their lowercase equivalents.
@@ -925,7 +925,7 @@ grn_nfkc_normalize_unify_diacritical_mark_b(const unsigned char *utf8_char,
    * U+1E03 LATIN SMALL LETTER B WITH DOT ABOVE
    * U+1E05 LATIN SMALL LETTER B WITH DOT BELOW
    * U+1E07 LATIN SMALL LETTER B WITH LINE BELOW
-   * Uppercase counterparts(U+1E04, U+1E06) are covered by the
+   * Uppercase counterparts (U+1E04, U+1E06) are covered by the
    * following condition but they are never appeared here. Because NFKC
    * normalization converts them to their lowercase equivalents.
    */

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/b/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/b/latin_extended_additional.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḂḃḄḅḆḇ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "bbbbbb",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/b/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/b/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḂḃḄḅḆḇ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: ref GH-1755

This PR enhances the NormalizerNFKC by introducing functionality to the `unify_alphabet_diacritical_mark` option.
This option is specifically aimed at stripping diacritical marks from characters related to the letter `b`.

It ensures that any character with diacritical marks falling under the Combining Diacritical Marks Unicode block is normalized to `b`.

## For reviewers
The following code can generate a mapping between Unicode and UTF-8.

```ruby
#!/usr/bin/env ruby

def have_diactritical_combining_character?(character)
  code_points = character.unicode_normalize(:nfd).codepoints
  code_points.any? do |code_point|
    (0x0300..0x036f).cover?(code_point)
  end
end

def base_character(character)
  character.unicode_normalize(:nfd).chars.first
end

def base_character_is_lower_alphabet?(character)
  base_code_point = base_character(character).codepoints.first
  (("a".codepoints.first)..("z".codepoints.first)).cover?(base_code_point)
end

def base_character_is_capital_alphabet?(character)
  base_code_point = base_character(character).codepoints.first
  (("A".codepoints.first)..("Z".codepoints.first)).cover?(base_code_point)
end 

def base_character_is_alphabet?(character)
  base_character_is_lower_alphabet?(character) || base_character_is_capital_alphabet?(character)
end

puts '## Generate mapping about Unicode and UTF-8'
(0x0000..0xffff).each do |code_point|
  begin
    character = code_point.chr("UTF-8")
  rescue RangeError
    next
  end
  next unless have_diactritical_combining_character?(character)
  next unless base_character_is_lower_alphabet?(character)
  next unless base_character(character) == "b"
  pp ["U+%04x" % code_point, character, character.bytes.collect {|b| "%#02x" % b}]
end

puts "-" * 50

puts '## Generate target characters'
(0x0000..0xffff).each do |code_point|
  begin
    character = code_point.chr("UTF-8")
  rescue RangeError
    next
  end
  next unless have_diactritical_combining_character?(character)
  next unless base_character_is_alphabet?(character)
  next unless ["b", "B"].any?(base_character(character))
  print character
end
```
```console
$ ruby unicode.rb
## Generate mapping about Unicode and UTF-8
["U+1e03", "ḃ", ["0xe1", "0xb8", "0x83"]]
["U+1e05", "ḅ", ["0xe1", "0xb8", "0x85"]]
["U+1e07", "ḇ", ["0xe1", "0xb8", "0x87"]]
--------------------------------------------------
## Generate target characters
ḂḃḄḅḆḇ
```