### PR TITLE
docs: api/grn_encoding: Move the to_string() and parse() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_encoding.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_encoding.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_encoding``"
 msgstr ""
 
@@ -33,20 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Returns string representation for the encoding. For example, 'grn_encoding_to_string(``GRN_ENC_UTF8``)' returns '\"utf8\"'."
-msgstr "エンコーディングの形式を文字列で返します。たとえば'grn_encoding_to_string(``GRN_ENC_UTF8``)' は\"utf8\"を返します。"
-
-msgid "\"unknown\" is returned for invalid encoding."
-msgstr "無効なエンコーディングの場合は\"unknown\"を返します。"
-
-msgid "The encoding."
-msgstr "その時点のエンコーディング。"
-
-msgid "Parses encoding name and returns grn_encoding. For example, 'grn_encoding_parse(\"UTF8\")' returns '``GRN_ENC_UTF8``'."
-msgstr "エンコーディング名をパースし、grn_encodingを返します。たとえば、'grn_encoding_parse(\"UTF8\")' は'``GRN_ENC_UTF8``'を返します。"
-
-msgid "``GRN_ENC_UTF8`` is returned for invalid encoding name."
-msgstr "``GRN_ENC_UTF8`` は無効なエンコーディング名が与えた時に返されます。"
-
-msgid "The encoding name."
-msgstr "エンコーディング名。"
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_encoding.rst
+++ b/doc/source/reference/api/grn_encoding.rst
@@ -16,22 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_encoding
-
-   TODO...
-
-.. c:function:: const char *grn_encoding_to_string(grn_encoding encoding)
-
-   Returns string representation for the encoding. For example, 'grn_encoding_to_string(``GRN_ENC_UTF8``)' returns '"utf8"'.
- 
-   "unknown" is returned for invalid encoding.
-
-   :param encoding: The encoding.
-
-.. c:function:: grn_encoding grn_encoding_parse(const char *name)
- 
-   Parses encoding name and returns grn_encoding. For example, 'grn_encoding_parse("UTF8")' returns '``GRN_ENC_UTF8``'.
- 
-   ``GRN_ENC_UTF8`` is returned for invalid encoding name.
-
-   :param name: The encoding name.
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -161,7 +161,7 @@ typedef enum {
   /// The default encoding specified at build time (0).
   /// The default at build time is "UTF-8".
   GRN_ENC_DEFAULT = 0,
-  /// "none" (1).
+  /// "none" (1)
   /// Used for binary or as an internal initial value.
   GRN_ENC_NONE,
   /// EUC-JP (2)
@@ -400,23 +400,23 @@ grn_get_memory_map_size(void);
 /* grn_encoding */
 /**
  * \brief Return string representation for the encoding. For example,
- *        `grn_encoding_to_string(GRN_ENC_UTF8)` returns `"utf8"`
+ *        `grn_encoding_to_string(GRN_ENC_UTF8)` return `"utf8"`.
  *
  * \param encoding The encoding
  *
  * \return String representation for the encoding on success, "unknown"
- *         on invalid encoding
+ *         on invalid encoding.
  */
 GRN_API const char *
 grn_encoding_to_string(grn_encoding encoding);
 /**
- * \brief Parse encoding name and returns \ref grn_encoding. For example,
- *        `grn_encoding_parse("UTF8")` returns \ref GRN_ENC_UTF8
+ * \brief Parse encoding name and return \ref grn_encoding. For example,
+ *        `grn_encoding_parse("UTF8")` return \ref GRN_ENC_UTF8.
  *
  * \param name The encoding name
  *
  * \return \ref grn_encoding matching `name` on success, \ref GRN_ENC_UTF8 on
- *         invalid encoding name
+ *         invalid encoding name.
  */
 GRN_API grn_encoding
 grn_encoding_parse(const char *name);

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -161,8 +161,7 @@ typedef enum {
   /// The default encoding specified at build time (0).
   /// The default at build time is "UTF-8".
   GRN_ENC_DEFAULT = 0,
-  /// "none" (1)
-  /// Used for binary or as an internal initial value.
+  /// Process strings as binary data (1)
   GRN_ENC_NONE,
   /// EUC-JP (2)
   GRN_ENC_EUC_JP,
@@ -400,7 +399,7 @@ grn_get_memory_map_size(void);
 /* grn_encoding */
 /**
  * \brief Return string representation for the encoding. For example,
- *        `grn_encoding_to_string(GRN_ENC_UTF8)` return `"utf8"`.
+ *        `grn_encoding_to_string(GRN_ENC_UTF8)` returns `"utf8"`.
  *
  * \param encoding The encoding
  *
@@ -411,7 +410,7 @@ GRN_API const char *
 grn_encoding_to_string(grn_encoding encoding);
 /**
  * \brief Parse encoding name and return \ref grn_encoding. For example,
- *        `grn_encoding_parse("UTF8")` return \ref GRN_ENC_UTF8.
+ *        `grn_encoding_parse("UTF8")` returns \ref GRN_ENC_UTF8.
  *
  * \param name The encoding name
  *

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -158,12 +158,21 @@ GRN_API const char *
 grn_get_global_error_message(void);
 
 typedef enum {
+  /// The default encoding specified at build time (0).
+  /// The default at build time is "UTF-8".
   GRN_ENC_DEFAULT = 0,
+  /// "none" (1).
+  /// Used for binary or as an internal initial value.
   GRN_ENC_NONE,
+  /// EUC-JP (2)
   GRN_ENC_EUC_JP,
+  /// UTF-8 (3)
   GRN_ENC_UTF8,
+  /// Shift_JIS (4)
   GRN_ENC_SJIS,
+  /// Latin-1 (5)
   GRN_ENC_LATIN1,
+  /// KOI8-R (6)
   GRN_ENC_KOI8R
 } grn_encoding;
 
@@ -389,9 +398,26 @@ GRN_API size_t
 grn_get_memory_map_size(void);
 
 /* grn_encoding */
-
+/**
+ * \brief Return string representation for the encoding. For example,
+ *        `grn_encoding_to_string(GRN_ENC_UTF8)` returns `"utf8"`
+ *
+ * \param encoding The encoding
+ *
+ * \return String representation for the encoding on success, "unknown"
+ *         on invalid encoding
+ */
 GRN_API const char *
 grn_encoding_to_string(grn_encoding encoding);
+/**
+ * \brief Parse encoding name and returns \ref grn_encoding. For example,
+ *        `grn_encoding_parse("UTF8")` returns \ref GRN_ENC_UTF8
+ *
+ * \param name The encoding name
+ *
+ * \return \ref grn_encoding matching `name` on success, \ref GRN_ENC_UTF8 on
+ *         invalid encoding name
+ */
 GRN_API grn_encoding
 grn_encoding_parse(const char *name);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.