### PR TITLE
docs: api/grn_table: move grn_table_delete() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -63,12 +63,6 @@ msgstr ""
 msgid "keybufのサイズ(byte長)を指定します。"
 msgstr ""
 
-msgid "tableのkeyに対応するレコードを削除します。対応するレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
-msgstr ""
-
-msgid "検索keyのサイズを指定します。"
-msgstr ""
-
 msgid "tableのidに対応するレコードを削除します。対応するレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。"
 msgstr ""
 

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -36,14 +36,6 @@ Reference
    :param keybuf: keyを格納するバッファ(呼出側で準備する)を指定します。
    :param buf_size: keybufのサイズ(byte長)を指定します。
  
-.. c:function:: grn_rc grn_table_delete(grn_ctx *ctx, grn_obj *table, const void *key, unsigned int key_size)
-
-   tableのkeyに対応するレコードを削除します。対応するレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。
- 
-   :param table: 対象tableを指定します。
-   :param key: 検索keyを指定します。
-   :param key_size: 検索keyのサイズを指定します。
-
 .. c:function:: grn_rc grn_table_delete_by_id(grn_ctx *ctx, grn_obj *table, grn_id id)
 
    tableのidに対応するレコードを削除します。対応するレコードが存在しない場合は ``GRN_INVALID_ARGUMENT`` を返します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -149,10 +149,10 @@ GRN_API int
 grn_table_get_key(
   grn_ctx *ctx, grn_obj *table, grn_id id, void *keybuf, int buf_size);
 /**
- * \brief Delete the record matching the key in the table or database.
+ * \brief Delete the record matching the key in the table.
  *
  * \param ctx The context object
- * \param table The table or database
+ * \param table The table
  * \param key Key of record to be deleted
  * \param key_size Size of `key` in bytes
  *

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -148,6 +148,18 @@ grn_table_lcp_search(grn_ctx *ctx,
 GRN_API int
 grn_table_get_key(
   grn_ctx *ctx, grn_obj *table, grn_id id, void *keybuf, int buf_size);
+/**
+ * \brief Delete the record matching the key in the table or database.
+ *
+ * \param ctx The context object
+ * \param table The table or database
+ * \param key Key of record to be deleted
+ * \param key_size Size of `key` in bytes
+ *
+ * \return \ref GRN_SUCCESS on success, \ref GRN_INVALID_ARGUMENT if the
+ *         record does not exist, and the appropriate `grn_rc` for any other
+ *         errors.
+ */
 GRN_API grn_rc
 grn_table_delete(grn_ctx *ctx,
                  grn_obj *table,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.