### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `c`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -929,6 +929,34 @@ grn_nfkc_normalize_unify_diacritical_mark_is_b(const unsigned char *utf8_char)
   return utf8_char[0] == 0xE1 && utf8_char[1] == 0xB8 &&
          (0x83 <= utf8_char[2] && utf8_char[2] <= 0x87);
 }
+
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_c(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00E7 LATIN SMALL LETTER C WITH CEDILLA
+     */
+    (utf8_char[0] == 0xc3 && utf8_char[1] == 0xa7) ||
+    /*
+     * Latin Extended-A
+     * U+0107 LATIN SMALL LETTER C WITH ACUTE
+     * U+0109 LATIN SMALL LETTER C WITH CIRCUMFLEX
+     * U+010B LATIN SMALL LETTER C WITH DOT ABOVE
+     * U+010D LATIN SMALL LETTER C WITH CARON
+     * Uppercase counterparts (U+0108, U+010A, U+010C) are covered by the
+     * following condition but they are never appeared here. Because NFKC
+     * normalization converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc4 && 0x87 <= utf8_char[1] && utf8_char[1] <= 0x8d) ||
+    /*
+     * Latin Extended Additional
+     * U+1E09 LATIN SMALL LETTER C WITH CEDILLA AND ACUTE
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 && utf8_char[2] == 0x89));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -944,6 +972,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_b(utf8_char)) {
     *unified = 'b';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_c(utf8_char)) {
+    *unified = 'c';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_1_supplement.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Çç"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"cc","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Çç" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_a.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĆćĈĉĊċČč"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "cccccccc",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ĆćĈĉĊċČč" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_additional.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ḉḉ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"cc","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/c/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ḉḉ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `c`.

Target character:
```
% ./tools/generate-alphabet-diacritical-mark.rb c
## Generate mapping about Unicode and UTF-8
["U+00e7", "ç", ["0xc3", "0xa7"]]
["U+0107", "ć", ["0xc4", "0x87"]]
["U+0109", "ĉ", ["0xc4", "0x89"]]
["U+010b", "ċ", ["0xc4", "0x8b"]]
["U+010d", "č", ["0xc4", "0x8d"]]
["U+1e09", "ḉ", ["0xe1", "0xb8", "0x89"]]
--------------------------------------------------
## Generate target characters
ÇçĆćĈĉĊċČčḈḉ
```