### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `d`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -973,7 +973,7 @@ grn_nfkc_normalize_unify_diacritical_mark_is_d(const unsigned char *utf8_char)
      * U+1E0F LATIN SMALL LETTER D WITH LINE BELOW
      * U+1E11 LATIN SMALL LETTER D WITH CEDILLA
      * U+1E13 LATIN SMALL LETTER D WITH CIRCUMFLEX BELOW
-     * Uppercase counterparts (U+1E0C, U+1E0E, U+1E10, U+1E12, U+1E14,) are
+     * Uppercase counterparts (U+1E0C, U+1E0E, U+1E10, U+1E12, U+1E14) are
      * covered by the following condition but they are never appeared here.
      * Because NFKC normalization converts them to their lowercase equivalents.
      */

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -957,6 +957,30 @@ grn_nfkc_normalize_unify_diacritical_mark_is_c(const unsigned char *utf8_char)
     (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 && utf8_char[2] == 0x89));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_d(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+010F LATIN SMALL LETTER D WITH CARON
+     */
+    (utf8_char[0] == 0xc4 && utf8_char[1] == 0x8f) ||
+    /*
+     * Latin Extended Additional
+     * U+1E0B LATIN SMALL LETTER D WITH DOT ABOVE
+     * U+1E0D LATIN SMALL LETTER D WITH DOT BELOW
+     * U+1E0F LATIN SMALL LETTER D WITH LINE BELOW
+     * U+1E11 LATIN SMALL LETTER D WITH CEDILLA
+     * U+1E13 LATIN SMALL LETTER D WITH CIRCUMFLEX BELOW
+     * Uppercase counterparts (U+1E0C, U+1E0E, U+1E10, U+1E12, U+1E14,) are
+     * covered by the following condition but they are never appeared here.
+     * Because NFKC normalization converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (0x8b <= utf8_char[2] && utf8_char[2] <= 0x93)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -975,6 +999,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_c(utf8_char)) {
     *unified = 'c';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_d(utf8_char)) {
+    *unified = 'd';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_a.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ďď"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"dd","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ďď" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_additional.expected
@@ -1,0 +1,27 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḊḋḌḍḎḏḐḑḒḓ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "dddddddddd",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/d/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḊḋḌḍḎḏḐḑḒḓ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `d`.

Target character:

```
% ./tools/generate-alphabet-diacritical-mark.rb d
## Generate mapping about Unicode and UTF-8
["U+010f", "ď", ["0xc4", "0x8f"]]
["U+1e0b", "ḋ", ["0xe1", "0xb8", "0x8b"]]
["U+1e0d", "ḍ", ["0xe1", "0xb8", "0x8d"]]
["U+1e0f", "ḏ", ["0xe1", "0xb8", "0x8f"]]
["U+1e11", "ḑ", ["0xe1", "0xb8", "0x91"]]
["U+1e13", "ḓ", ["0xe1", "0xb8", "0x93"]]
--------------------------------------------------
## Generate target characters
ĎďḊḋḌḍḎḏḐḑḒḓ
```