### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `e`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -981,6 +981,69 @@ grn_nfkc_normalize_unify_diacritical_mark_is_d(const unsigned char *utf8_char)
      (0x8b <= utf8_char[2] && utf8_char[2] <= 0x93)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_e(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00E8 LATIN SMALL LETTER E WITH GRAVE
+     * U+00E9 LATIN SMALL LETTER E WITH ACUTE
+     * U+00EA LATIN SMALL LETTER E WITH CIRCUMFLEX
+     * U+00EB LATIN SMALL LETTER E WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xc3 && 0xa8 <= utf8_char[1] && utf8_char[1] <= 0xab) ||
+    /*
+     * Latin Extended-A
+     * U+0113 LATIN SMALL LETTER E WITH MACRON
+     * U+0115 LATIN SMALL LETTER E WITH BREVE
+     * U+0117 LATIN SMALL LETTER E WITH DOT ABOVE
+     * U+0119 LATIN SMALL LETTER E WITH OGONEK
+     * U+011B LATIN SMALL LETTER E WITH CARON
+     * Uppercase counterparts (U+0114, U+0116, U+0118, U+011A) are covered
+     * by the following condition but they are never appeared here. Because
+     * NFKC normalization converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc4 && 0x93 <= utf8_char[1] && utf8_char[1] <= 0x9b) ||
+    /*
+     * Latin Extended-B
+     * U+0205 LATIN SMALL LETTER E WITH DOUBLE GRAVE
+     * U+0207 LATIN SMALL LETTER E WITH INVERTED BREVE
+     * U+0229 LATIN SMALL LETTER E WITH CEDILLA
+     * Uppercase counterparts (U+0206) are covered by the following condition
+     * but they are never appeared here. Because NFKC normalization converts
+     * them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc8 && ((0x85 <= utf8_char[1] && utf8_char[1] <= 0x87) ||
+                              utf8_char[1] == 0xa9)) ||
+    /*
+     * Latin Extended Additional
+     * U+1E15 LATIN SMALL LETTER E WITH MACRON AND GRAVE
+     * U+1E17 LATIN SMALL LETTER E WITH MACRON AND ACUTE
+     * U+1E19 LATIN SMALL LETTER E WITH CIRCUMFLEX BELOW
+     * U+1E1B LATIN SMALL LETTER E WITH TILDE BELOW
+     * U+1E1D LATIN SMALL LETTER E WITH CEDILLA AND BREVE
+     *
+     * U+1EB9 LATIN SMALL LETTER E WITH DOT BELOW
+     * U+1EBB LATIN SMALL LETTER E WITH HOOK ABOVE
+     * U+1EBD LATIN SMALL LETTER E WITH TILDE
+     * U+1EBF LATIN SMALL LETTER E WITH CIRCUMFLEX AND ACUTE
+     *
+     * U+1EC1 LATIN SMALL LETTER E WITH CIRCUMFLEX AND GRAVE
+     * U+1EC3 LATIN SMALL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
+     * U+1EC5 LATIN SMALL LETTER E WITH CIRCUMFLEX AND TILDE
+     * U+1EC7 LATIN SMALL LETTER E WITH CIRCUMFLEX AND DOT BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (0x95 <= utf8_char[2] && utf8_char[2] <= 0x9d)) ||
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba &&
+     (0xb9 <= utf8_char[2] && utf8_char[2] <= 0xbf)) ||
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xbb &&
+     (0x81 <= utf8_char[2] && utf8_char[2] <= 0x87)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1002,6 +1065,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_d(utf8_char)) {
     *unified = 'd';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_e(utf8_char)) {
+    *unified = 'e';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_1_supplement.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ÈÉÊËèéêë"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "eeeeeeee",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ÈÉÊËèéêë" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_a.expected
@@ -1,0 +1,27 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĒēĔĕĖėĘęĚě"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "eeeeeeeeee",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ĒēĔĕĖėĘęĚě" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_additional.expected
@@ -1,0 +1,43 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḔḕḖḗḘḙḚḛḜḝẸẹẺẻẼẽẾếỀềỂểỄễỆệ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "eeeeeeeeeeeeeeeeeeeeeeeeee",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḔḕḖḗḘḙḚḛḜḝẸẹẺẻẼẽẾếỀềỂểỄễỆệ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_b.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ȄȅȆȇȨȩ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "eeeeee",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/e/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ȄȅȆȇȨȩ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `e`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb e
## Generate mapping about Unicode and UTF-8
["U+00e8", "è", ["0xc3", "0xa8"]]
["U+00e9", "é", ["0xc3", "0xa9"]]
["U+00ea", "ê", ["0xc3", "0xaa"]]
["U+00eb", "ë", ["0xc3", "0xab"]]
["U+0113", "ē", ["0xc4", "0x93"]]
["U+0115", "ĕ", ["0xc4", "0x95"]]
["U+0117", "ė", ["0xc4", "0x97"]]
["U+0119", "ę", ["0xc4", "0x99"]]
["U+011b", "ě", ["0xc4", "0x9b"]]
["U+0205", "ȅ", ["0xc8", "0x85"]]
["U+0207", "ȇ", ["0xc8", "0x87"]]
["U+0229", "ȩ", ["0xc8", "0xa9"]]
["U+1e15", "ḕ", ["0xe1", "0xb8", "0x95"]]
["U+1e17", "ḗ", ["0xe1", "0xb8", "0x97"]]
["U+1e19", "ḙ", ["0xe1", "0xb8", "0x99"]]
["U+1e1b", "ḛ", ["0xe1", "0xb8", "0x9b"]]
["U+1e1d", "ḝ", ["0xe1", "0xb8", "0x9d"]]
["U+1eb9", "ẹ", ["0xe1", "0xba", "0xb9"]]
["U+1ebb", "ẻ", ["0xe1", "0xba", "0xbb"]]
["U+1ebd", "ẽ", ["0xe1", "0xba", "0xbd"]]
["U+1ebf", "ế", ["0xe1", "0xba", "0xbf"]]
["U+1ec1", "ề", ["0xe1", "0xbb", "0x81"]]
["U+1ec3", "ể", ["0xe1", "0xbb", "0x83"]]
["U+1ec5", "ễ", ["0xe1", "0xbb", "0x85"]]
["U+1ec7", "ệ", ["0xe1", "0xbb", "0x87"]]
--------------------------------------------------
## Generate target characters
ÈÉÊËèéêëĒēĔĕĖėĘęĚěȄȅȆȇȨȩḔḕḖḗḘḙḚḛḜḝẸẹẺẻẼẽẾếỀềỂểỄễỆệ
```