### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `g`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1044,6 +1044,34 @@ grn_nfkc_normalize_unify_diacritical_mark_is_e(const unsigned char *utf8_char)
      (0x81 <= utf8_char[2] && utf8_char[2] <= 0x87)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_g(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+011D LATIN SMALL LETTER G WITH CIRCUMFLEX
+     * U+011F LATIN SMALL LETTER G WITH BREVE
+     * U+0121 LATIN SMALL LETTER G WITH DOT ABOVE
+     * U+0123 LATIN SMALL LETTER G WITH CEDILLA
+     * Uppercase counterparts (U+011E, U+0120, U+0122) are covered by the
+     * following condition but they are never appeared here. Because NFKC
+     * normalization converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc4 && 0x9d <= utf8_char[1] && utf8_char[1] <= 0xa3) ||
+    /*
+     * Latin Extended-B
+     * U+01E7 LATIN SMALL LETTER G WITH CARON
+     * U+01F5 LATIN SMALL LETTER G WITH ACUTE
+     */
+    (utf8_char[0] == 0xc7 && (utf8_char[1] == 0xa7 || utf8_char[1] == 0xb5)) ||
+    /*
+     * Latin Extended Additional
+     * U+1E21 LATIN SMALL LETTER G WITH MACRON
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 && utf8_char[2] == 0xa1));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1068,6 +1096,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_e(utf8_char)) {
     *unified = 'e';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_g(utf8_char)) {
+    *unified = 'g';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_a.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĜĝĞğĠġĢģ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "gggggggg",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ĜĝĞğĠġĢģ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_additional.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ḡḡ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"gg","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ḡḡ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_b.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ǦǧǴǵ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "gggg",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/g/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ǦǧǴǵ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `g`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb g
## Generate mapping about Unicode and UTF-8
["U+011d", "ĝ", ["0xc4", "0x9d"]]
["U+011f", "ğ", ["0xc4", "0x9f"]]
["U+0121", "ġ", ["0xc4", "0xa1"]]
["U+0123", "ģ", ["0xc4", "0xa3"]]
["U+01e7", "ǧ", ["0xc7", "0xa7"]]
["U+01f5", "ǵ", ["0xc7", "0xb5"]]
["U+1e21", "ḡ", ["0xe1", "0xb8", "0xa1"]]
--------------------------------------------------
## Generate target characters
ĜĝĞğĠġĢģǦǧǴǵḠḡ
```