### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `h`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1072,6 +1072,38 @@ grn_nfkc_normalize_unify_diacritical_mark_is_g(const unsigned char *utf8_char)
     (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 && utf8_char[2] == 0xa1));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_h(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+0125 LATIN SMALL LETTER H WITH CIRCUMFLEX
+     */
+    (utf8_char[0] == 0xc4 && utf8_char[1] == 0xa5) ||
+    /*
+     * Latin Extended-B
+     * U+021F LATIN SMALL LETTER H WITH CARON
+     */
+    (utf8_char[0] == 0xc8 && utf8_char[1] == 0x9f) ||
+    /*
+     * Latin Extended Additional
+     * U+1E23 LATIN SMALL LETTER H WITH DOT ABOVE
+     * U+1E25 LATIN SMALL LETTER H WITH DOT BELOW
+     * U+1E27 LATIN SMALL LETTER H WITH DIAERESIS
+     * U+1E29 LATIN SMALL LETTER H WITH CEDILLA
+     * U+1E2B LATIN SMALL LETTER H WITH BREVE BELOW
+     * Uppercase counterparts (e.g. U+1E24) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     *
+     * U+1E96 LATIN SMALL LETTER H WITH LINE BELOW
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (0xa3 <= utf8_char[2] && utf8_char[2] <= 0xab)) ||
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba && utf8_char[2] == 0x96));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1099,6 +1131,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_g(utf8_char)) {
     *unified = 'g';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_h(utf8_char)) {
+    *unified = 'h';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_a.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ĥĥ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"hh","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ĥĥ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_additional.expected
@@ -1,0 +1,28 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḢḣḤḥḦḧḨḩḪḫẖ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "hhhhhhhhhhh",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḢḣḤḥḦḧḨḩḪḫẖ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_b.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ȟȟ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"hh","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/h/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ȟȟ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `h`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb h
## Generate mapping about Unicode and UTF-8
["U+0125", "ĥ", ["0xc4", "0xa5"]]
["U+021f", "ȟ", ["0xc8", "0x9f"]]
["U+1e23", "ḣ", ["0xe1", "0xb8", "0xa3"]]
["U+1e25", "ḥ", ["0xe1", "0xb8", "0xa5"]]
["U+1e27", "ḧ", ["0xe1", "0xb8", "0xa7"]]
["U+1e29", "ḩ", ["0xe1", "0xb8", "0xa9"]]
["U+1e2b", "ḫ", ["0xe1", "0xb8", "0xab"]]
["U+1e96", "ẖ", ["0xe1", "0xba", "0x96"]]
--------------------------------------------------
## Generate target characters
ĤĥȞȟḢḣḤḥḦḧḨḩḪḫẖ
```