### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `i`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1116,6 +1116,50 @@ grn_nfkc_normalize_unify_diacritical_mark_is_h(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_i(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00EC LATIN SMALL LETTER I WITH GRAVE
+     * U+00ED LATIN SMALL LETTER I WITH ACUTE
+     * U+00EE LATIN SMALL LETTER I WITH CIRCUMFLEX
+     * U+00EF LATIN SMALL LETTER I WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xc3 && 0xac <= utf8_char[1] && utf8_char[1] <= 0xaf) ||
+    /*
+     * Latin Extended-A
+     * U+0129 LATIN SMALL LETTER I WITH TILDE
+     * U+012B LATIN SMALL LETTER I WITH MACRON
+     * U+012D LATIN SMALL LETTER I WITH BREVE
+     * U+012F LATIN SMALL LETTER I WITH OGONEK
+     * Uppercase counterparts (e.g. U+012A) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc4 && 0xa9 <= utf8_char[1] && utf8_char[1] <= 0xaf) ||
+    /*
+     * Latin Extended-B
+     * U+01D0 LATIN SMALL LETTER I WITH CARON
+     * U+0209 LATIN SMALL LETTER I WITH DOUBLE GRAVE
+     * U+020B LATIN SMALL LETTER I WITH INVERTED BREVE
+     */
+    (utf8_char[0] == 0xc7 && utf8_char[1] == 0x90) ||
+    (utf8_char[0] == 0xc8 && (utf8_char[1] == 0x89 || utf8_char[1] == 0x8b)) ||
+    /*
+     * Latin Extended Additional
+     * U+1E2D LATIN SMALL LETTER I WITH TILDE BELOW
+     * U+1E2F LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE
+     * U+1EC9 LATIN SMALL LETTER I WITH HOOK ABOVE
+     * U+1ECB LATIN SMALL LETTER I WITH DOT BELOW
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (utf8_char[2] == 0xad || utf8_char[2] == 0xaf)) ||
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xbb &&
+     (utf8_char[2] == 0x89 || utf8_char[2] == 0x8b)));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_j(const unsigned char *utf8_char)
 {
   return (
@@ -1676,6 +1720,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_h(utf8_char)) {
     *unified = 'h';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_i(utf8_char)) {
+    *unified = 'i';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_j(utf8_char)) {
     *unified = 'j';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_1_supplement.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ÌÍÎÏìíîï"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "iiiiiiii",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ÌÍÎÏìíîï" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĨĩĪīĬĭĮįİ"   WITH_TYPES
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĨĩĪīĬĭĮįİı"   WITH_TYPES
 [
   [
     0,
@@ -6,7 +6,7 @@ normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĨĩĪ�
     0.0
   ],
   {
-    "normalized": "iiiiiiiii̇",
+    "normalized": "iiiiiiiii̇ı",
     "types": [
       "alpha",
       "alpha",
@@ -18,6 +18,7 @@ normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĨĩĪ�
       "alpha",
       "alpha",
       "others",
+      "alpha",
       "null"
     ],
     "checks": [

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.expected
@@ -1,0 +1,27 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĨĩĪīĬĭĮįİ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "iiiiiiiii̇",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.test
@@ -1,6 +1,10 @@
 #@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+# TODO: "İ U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE" is broken with
+# NormalizerNFKC150 or older. It should be fixed with NormalizreNFKC160 or later.
+# We need to revisit how to write this test when we implement it.
+# See also: https://github.com/groonga/groonga/issues/1939
 normalize \
   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
-  "ĨĩĪīĬĭĮįİ" \
+  "ĨĩĪīĬĭĮįİı" \
   WITH_TYPES
 #@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ĨĩĪīĬĭĮįİ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_additional.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḬḭḮḯỈỉỊị"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "iiiiiiii",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḬḭḮḯỈỉỊị" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_b.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ǏǐȈȉȊȋ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "iiiiii",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/i/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ǏǐȈȉȊȋ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `i`.

Note that "U+0130  LATIN CAPITAL LETTER I WITH DOT ABOVE" isn't normalized correctly.
It should be normalized to "U+0069  LATIN SMALL LETTER I" but it's normalized to "U+0069  LATIN SMALL LETTER I" and "U+0307  COMBINING DOT ABOVE". It will not be fixed in `NormalizerNFKC150` or older to keep backward compatibility. It should be fixed in `NormalizerNFKC160` or later. See also: #1939

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb i
## Generate mapping about Unicode and UTF-8
["U+00ec", "ì", ["0xc3", "0xac"]]
["U+00ed", "í", ["0xc3", "0xad"]]
["U+00ee", "î", ["0xc3", "0xae"]]
["U+00ef", "ï", ["0xc3", "0xaf"]]
["U+0129", "ĩ", ["0xc4", "0xa9"]]
["U+012b", "ī", ["0xc4", "0xab"]]
["U+012d", "ĭ", ["0xc4", "0xad"]]
["U+012f", "į", ["0xc4", "0xaf"]]
["U+01d0", "ǐ", ["0xc7", "0x90"]]
["U+0209", "ȉ", ["0xc8", "0x89"]]
["U+020b", "ȋ", ["0xc8", "0x8b"]]
["U+1e2d", "ḭ", ["0xe1", "0xb8", "0xad"]]
["U+1e2f", "ḯ", ["0xe1", "0xb8", "0xaf"]]
["U+1ec9", "ỉ", ["0xe1", "0xbb", "0x89"]]
["U+1ecb", "ị", ["0xe1", "0xbb", "0x8b"]]
--------------------------------------------------
## Generate target characters
ÌÍÎÏìíîïĨĩĪīĬĭĮįİǏǐȈȉȊȋḬḭḮḯỈỉỊị
```