### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `k`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1104,6 +1104,33 @@ grn_nfkc_normalize_unify_diacritical_mark_is_h(const unsigned char *utf8_char)
     (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba && utf8_char[2] == 0x96));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_k(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+0137 LATIN SMALL LETTER K WITH CEDILLA
+     */
+    (utf8_char[0] == 0xc4 && utf8_char[1] == 0xb7) ||
+    /*
+     * Latin Extended-B
+     * U+01E9 LATIN SMALL LETTER K WITH CARON
+     */
+    (utf8_char[0] == 0xc7 && utf8_char[1] == 0xa9) ||
+    /*
+     * Latin Extended Additional
+     * U+1E31 LATIN SMALL LETTER K WITH ACUTE
+     * U+1E33 LATIN SMALL LETTER K WITH DOT BELOW
+     * U+1E35 LATIN SMALL LETTER K WITH LINE BELOW
+     * Uppercase counterparts (e.g. U+1E32) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (0xb1 <= utf8_char[2] && utf8_char[2] <= 0xb5)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1134,6 +1161,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_h(utf8_char)) {
     *unified = 'h';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_k(utf8_char)) {
+    *unified = 'k';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_a.actual
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_a.actual
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ķķ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"kk","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ķķ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_additional.actual
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_additional.actual
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḰḱḲḳḴḵ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "kkkkkk",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḰḱḲḳḴḵ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_b.actual
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_b.actual
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ǩǩ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"kk","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/k/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ǩǩ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `k`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb k
## Generate mapping about Unicode and UTF-8
["U+0137", "ķ", ["0xc4", "0xb7"]]
["U+01e9", "ǩ", ["0xc7", "0xa9"]]
["U+1e31", "ḱ", ["0xe1", "0xb8", "0xb1"]]
["U+1e33", "ḳ", ["0xe1", "0xb8", "0xb3"]]
["U+1e35", "ḵ", ["0xe1", "0xb8", "0xb5"]]
--------------------------------------------------
## Generate target characters
ĶķǨǩḰḱḲḳḴḵ
```