### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `l`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1131,6 +1131,33 @@ grn_nfkc_normalize_unify_diacritical_mark_is_k(const unsigned char *utf8_char)
      (0xb1 <= utf8_char[2] && utf8_char[2] <= 0xb5)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_l(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+013A LATIN SMALL LETTER L WITH ACUTE
+     * U+013C LATIN SMALL LETTER L WITH CEDILLA
+     * U+013E LATIN SMALL LETTER L WITH CARON
+     * Uppercase counterparts (e.g. U+013B) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc4 && 0xba <= utf8_char[1] && utf8_char[1] <= 0xbe) ||
+    /*
+     * Latin Extended Additional
+     * U+1E37 LATIN SMALL LETTER L WITH DOT BELOW
+     * U+1E39 LATIN SMALL LETTER L WITH DOT BELOW AND MACRON
+     * U+1E3B LATIN SMALL LETTER L WITH LINE BELOW
+     * U+1E3D LATIN SMALL LETTER L WITH CIRCUMFLEX BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 &&
+     (0xb7 <= utf8_char[2] && utf8_char[2] <= 0xbd)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1164,6 +1191,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_k(utf8_char)) {
     *unified = 'k';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_l(utf8_char)) {
+    *unified = 'l';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_a.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ĹĺĻļĽľ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "llllll",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ĹĺĻļĽľ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_additional.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḶḷḸḹḺḻḼḽ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "llllllll",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/l/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḶḷḸḹḺḻḼḽ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `l`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb l
## Generate mapping about Unicode and UTF-8
["U+013a", "ĺ", ["0xc4", "0xba"]]
["U+013c", "ļ", ["0xc4", "0xbc"]]
["U+013e", "ľ", ["0xc4", "0xbe"]]
["U+1e37", "ḷ", ["0xe1", "0xb8", "0xb7"]]
["U+1e39", "ḹ", ["0xe1", "0xb8", "0xb9"]]
["U+1e3b", "ḻ", ["0xe1", "0xb8", "0xbb"]]
["U+1e3d", "ḽ", ["0xe1", "0xb8", "0xbd"]]
--------------------------------------------------
## Generate target characters
ĹĺĻļĽľḶḷḸḹḺḻḼḽ
```