### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `o`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1196,6 +1196,78 @@ grn_nfkc_normalize_unify_diacritical_mark_is_n(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_o(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00F2 LATIN SMALL LETTER O WITH GRAVE
+     * U+00F3 LATIN SMALL LETTER O WITH ACUTE
+     * U+00F4 LATIN SMALL LETTER O WITH CIRCUMFLEX
+     * U+00F5 LATIN SMALL LETTER O WITH TILDE
+     * U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xc3 && 0xb2 <= utf8_char[1] && utf8_char[1] <= 0xb6) ||
+    /*
+     * Latin Extended-A
+     * U+014D LATIN SMALL LETTER O WITH MACRON
+     * U+014F LATIN SMALL LETTER O WITH BREVE
+     * U+0151 LATIN SMALL LETTER O WITH DOUBLE ACUTE
+     * Uppercase counterparts (U+014E) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc5 && ((0x8d <= utf8_char[1] && utf8_char[1] <= 0x8f) ||
+                              utf8_char[1] == 0x91)) ||
+    /*
+     * Latin Extended-B
+     * U+01A1 LATIN SMALL LETTER O WITH HORN
+     * U+01D2 LATIN SMALL LETTER O WITH CARON
+     * U+01EB LATIN SMALL LETTER O WITH OGONEK
+     * U+01ED LATIN SMALL LETTER O WITH OGONEK AND MACRON
+     * U+020D LATIN SMALL LETTER O WITH DOUBLE GRAVE
+     * U+020F LATIN SMALL LETTER O WITH INVERTED BREVE
+     * U+022B LATIN SMALL LETTER O WITH DIAERESIS AND MACRON
+     * U+022D LATIN SMALL LETTER O WITH TILDE AND MACRON
+     * U+022F LATIN SMALL LETTER O WITH DOT ABOVE
+     * U+0231 LATIN SMALL LETTER O WITH DOT ABOVE AND MACRON
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xc6 && utf8_char[1] == 0xa1) ||
+    (utf8_char[0] == 0xc7 &&
+     ((utf8_char[1] == 0x92) ||
+      (0xab <= utf8_char[1] && utf8_char[1] <= 0xad))) ||
+    (utf8_char[0] == 0xc8 &&
+     ((0x8d <= utf8_char[1] && utf8_char[1] <= 0x8f) ||
+      (0xab <= utf8_char[1] && utf8_char[1] <= 0xb1))) ||
+    /*
+     * Latin Extended Additional
+     * U+1E4D LATIN SMALL LETTER O WITH TILDE AND ACUTE
+     * U+1E4F LATIN SMALL LETTER O WITH TILDE AND DIAERESIS
+     * U+1E51 LATIN SMALL LETTER O WITH MACRON AND GRAVE
+     * U+1E53 LATIN SMALL LETTER O WITH MACRON AND ACUTE
+     * U+1ECD LATIN SMALL LETTER O WITH DOT BELOW
+     * U+1ECF LATIN SMALL LETTER O WITH HOOK ABOVE
+     * U+1ED1 LATIN SMALL LETTER O WITH CIRCUMFLEX AND ACUTE
+     * U+1ED3 LATIN SMALL LETTER O WITH CIRCUMFLEX AND GRAVE
+     * U+1ED5 LATIN SMALL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
+     * U+1ED7 LATIN SMALL LETTER O WITH CIRCUMFLEX AND TILDE
+     * U+1ED9 LATIN SMALL LETTER O WITH CIRCUMFLEX AND DOT BELOW
+     * U+1EDB LATIN SMALL LETTER O WITH HORN AND ACUTE
+     * U+1EDD LATIN SMALL LETTER O WITH HORN AND GRAVE
+     * U+1EDF LATIN SMALL LETTER O WITH HORN AND HOOK ABOVE
+     * U+1EE1 LATIN SMALL LETTER O WITH HORN AND TILDE
+     * U+1EE3 LATIN SMALL LETTER O WITH HORN AND DOT BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 &&
+     ((utf8_char[1] == 0xb9 && 0x8d <= utf8_char[2] && utf8_char[2] <= 0x93) ||
+      (utf8_char[1] == 0xbb && 0x8d <= utf8_char[2] && utf8_char[2] <= 0xa3))));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_r(const unsigned char *utf8_char)
 {
   return (
@@ -1270,6 +1342,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
     *unified = 'r';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_o(utf8_char)) {
+    *unified = 'o';
     return unified;
   } else {
     return utf8_char;

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1222,22 +1222,28 @@ grn_nfkc_normalize_unify_diacritical_mark_is_o(const unsigned char *utf8_char)
     /*
      * Latin Extended-B
      * U+01A1 LATIN SMALL LETTER O WITH HORN
+     */
+    (utf8_char[0] == 0xc6 && utf8_char[1] == 0xa1) ||
+    /*
+     * Latin Extended-B
      * U+01D2 LATIN SMALL LETTER O WITH CARON
      * U+01EB LATIN SMALL LETTER O WITH OGONEK
      * U+01ED LATIN SMALL LETTER O WITH OGONEK AND MACRON
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xc7 &&
+     ((utf8_char[1] == 0x92) ||
+      (0xab <= utf8_char[1] && utf8_char[1] <= 0xad))) ||
+    /*
+     * Latin Extended-B
      * U+020D LATIN SMALL LETTER O WITH DOUBLE GRAVE
      * U+020F LATIN SMALL LETTER O WITH INVERTED BREVE
      * U+022B LATIN SMALL LETTER O WITH DIAERESIS AND MACRON
      * U+022D LATIN SMALL LETTER O WITH TILDE AND MACRON
      * U+022F LATIN SMALL LETTER O WITH DOT ABOVE
      * U+0231 LATIN SMALL LETTER O WITH DOT ABOVE AND MACRON
-     *
      * Each missing one is an upper case.
      */
-    (utf8_char[0] == 0xc6 && utf8_char[1] == 0xa1) ||
-    (utf8_char[0] == 0xc7 &&
-     ((utf8_char[1] == 0x92) ||
-      (0xab <= utf8_char[1] && utf8_char[1] <= 0xad))) ||
     (utf8_char[0] == 0xc8 &&
      ((0x8d <= utf8_char[1] && utf8_char[1] <= 0x8f) ||
       (0xab <= utf8_char[1] && utf8_char[1] <= 0xb1))) ||

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1346,11 +1346,11 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_n(utf8_char)) {
     *unified = 'n';
     return unified;
-  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
-    *unified = 'r';
-    return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_o(utf8_char)) {
     *unified = 'o';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
+    *unified = 'r';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_1_supplement.expected
@@ -1,0 +1,27 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ÒÓÔÕÖòóôõö"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "oooooooooo",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ÒÓÔÕÖòóôõö" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_a.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŌōŎŏŐő"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "oooooo",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŌōŎŏŐő" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_additional.expected
@@ -1,0 +1,49 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṌṍṎṏṐṑṒṓỌọỎỏỐốỒồỔổỖỗỘộỚớỜờỞởỠỡỢợ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "oooooooooooooooooooooooooooooooo",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṌṍṎṏṐṑṒṓỌọỎỏỐốỒồỔổỖỗỘộỚớỜờỞởỠỡỢợ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_b.expected
@@ -1,0 +1,37 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ƠơǑǒǪǫǬǭȌȍȎȏȪȫȬȭȮȯȰȱ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "oooooooooooooooooooo",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/o/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ƠơǑǒǪǫǬǭȌȍȎȏȪȫȬȭȮȯȰȱ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `o`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb o
## Generate mapping about Unicode and UTF-8
["U+00f2", "ò", ["0xc3", "0xb2"]]
["U+00f3", "ó", ["0xc3", "0xb3"]]
["U+00f4", "ô", ["0xc3", "0xb4"]]
["U+00f5", "õ", ["0xc3", "0xb5"]]
["U+00f6", "ö", ["0xc3", "0xb6"]]
["U+014d", "ō", ["0xc5", "0x8d"]]
["U+014f", "ŏ", ["0xc5", "0x8f"]]
["U+0151", "ő", ["0xc5", "0x91"]]
["U+01a1", "ơ", ["0xc6", "0xa1"]]
["U+01d2", "ǒ", ["0xc7", "0x92"]]
["U+01eb", "ǫ", ["0xc7", "0xab"]]
["U+01ed", "ǭ", ["0xc7", "0xad"]]
["U+020d", "ȍ", ["0xc8", "0x8d"]]
["U+020f", "ȏ", ["0xc8", "0x8f"]]
["U+022b", "ȫ", ["0xc8", "0xab"]]
["U+022d", "ȭ", ["0xc8", "0xad"]]
["U+022f", "ȯ", ["0xc8", "0xaf"]]
["U+0231", "ȱ", ["0xc8", "0xb1"]]
["U+1e4d", "ṍ", ["0xe1", "0xb9", "0x8d"]]
["U+1e4f", "ṏ", ["0xe1", "0xb9", "0x8f"]]
["U+1e51", "ṑ", ["0xe1", "0xb9", "0x91"]]
["U+1e53", "ṓ", ["0xe1", "0xb9", "0x93"]]
["U+1ecd", "ọ", ["0xe1", "0xbb", "0x8d"]]
["U+1ecf", "ỏ", ["0xe1", "0xbb", "0x8f"]]
["U+1ed1", "ố", ["0xe1", "0xbb", "0x91"]]
["U+1ed3", "ồ", ["0xe1", "0xbb", "0x93"]]
["U+1ed5", "ổ", ["0xe1", "0xbb", "0x95"]]
["U+1ed7", "ỗ", ["0xe1", "0xbb", "0x97"]]
["U+1ed9", "ộ", ["0xe1", "0xbb", "0x99"]]
["U+1edb", "ớ", ["0xe1", "0xbb", "0x9b"]]
["U+1edd", "ờ", ["0xe1", "0xbb", "0x9d"]]
["U+1edf", "ở", ["0xe1", "0xbb", "0x9f"]]
["U+1ee1", "ỡ", ["0xe1", "0xbb", "0xa1"]]
["U+1ee3", "ợ", ["0xe1", "0xbb", "0xa3"]]
--------------------------------------------------
## Generate target characters
ÒÓÔÕÖòóôõöŌōŎŏŐőƠơǑǒǪǫǬǭȌȍȎȏȪȫȬȭȮȯȰȱṌṍṎṏṐṑṒṓỌọỎỏỐốỒồỔổỖỗỘộỚớỜờỞởỠỡỢợ
```