### PR TITLE
docs error: add error debugging tips

### DIFF
--- a/include/groonga/error.h
+++ b/include/groonga/error.h
@@ -38,10 +38,13 @@ grn_windows_error_code_to_rc(int error_code);
  *
  *  \section error_details Additional Error Details
  *
- *  For more detailed error information, check the `ctx->rc` field to find the
- *  specific error code.
+ *  For more detailed error information, check the `ctx->rc`(\ref _grn_ctx::rc)
+ *  field to find the specific error code.
  *
  *  Additional information may also be available in the
- * `ctx->errbuf` field. This field contains any relevant error messages or
- *  diagnostic details that can help with debugging.
+ *  `ctx->errbuf`(\ref _grn_ctx::errbuf) field. This field contains any
+ *  relevant error messages or diagnostic details that can help with
+ *  debugging.
+ *
+ *  For further details, see \ref _grn_ctx.
  */

--- a/include/groonga/error.h
+++ b/include/groonga/error.h
@@ -33,3 +33,15 @@ grn_windows_error_code_to_rc(int error_code);
 #ifdef __cplusplus
 }
 #endif
+
+/*! \page error_debugging Error Debugging
+ *
+ *  \section error_details Additional Error Details
+ *
+ *  For more detailed error information, check the `ctx->rc` field to find the
+ *  specific error code.
+ *
+ *  Additional information may also be available in the
+ * `ctx->errbuf` field. This field contains any relevant error messages or
+ *  diagnostic details that can help with debugging.
+ */

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -927,17 +927,13 @@ grn_obj_get_value(grn_ctx *ctx, grn_obj *obj, grn_id id, grn_obj *value);
  *            you must use functions such as \ref grn_table_at to check the
  *            existence of each record.
  *
- * \note If an error occurs and the return value is `-1`, check `ctx->rc` for
- *       the specific error code (e.g., \ref GRN_NO_MEMORY_AVAILABLE,
- *       \ref GRN_INVALID_ARGUMENT). Additional details might be available in
- *       `ctx->errbuf`.
- *
  * \param ctx The context object
  * \param obj The target fixed-size column
  * \param offset The starting record ID for retrieving values
  * \param values A pointer to an array where the values will be stored
  *
- * \return The number of records retrieved, or `-1` if an error occurred.
+ * \return The number of records retrieved on success, `-1` on error.
+ *         For more details about error, see the \ref error_debugging.
  */
 GRN_API int
 grn_obj_get_values(grn_ctx *ctx, grn_obj *obj, grn_id offset, void **values);


### PR DESCRIPTION
GitHub: GH-1817
ref: https://github.com/groonga/groonga/pull/1898#discussion_r1730768565

Adding shared error debugging documentation will be useful because It's easier to be referenced across functions.
- https://www.doxygen.nl/manual/commands.html#cmdpage