### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `s`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1306,6 +1306,40 @@ grn_nfkc_normalize_unify_diacritical_mark_is_r(const unsigned char *utf8_char)
      (0x99 <= utf8_char[2] && utf8_char[2] <= 0x9f)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_s(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+015B LATIN SMALL LETTER S WITH ACUTE
+     * U+015D LATIN SMALL LETTER S WITH CIRCUMFLEX
+     * U+015F LATIN SMALL LETTER S WITH CEDILLA
+     * U+0161 LATIN SMALL LETTER S WITH CARON
+     * Uppercase counterparts (e.g. U+015C) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc5 && 0x9b <= utf8_char[1] && utf8_char[1] <= 0xa1) ||
+    /*
+     * Latin Extended-B
+     * U+0219 LATIN SMALL LETTER S WITH COMMA BELOW
+     */
+    (utf8_char[0] == 0xc8 && utf8_char[1] == 0x99) ||
+    /*
+     * Latin Extended Additional
+     * U+1E61 LATIN SMALL LETTER S WITH DOT ABOVE
+     * U+1E63 LATIN SMALL LETTER S WITH DOT BELOW
+     * U+1E65 LATIN SMALL LETTER S WITH ACUTE AND DOT ABOVE
+     * U+1E67 LATIN SMALL LETTER S WITH CARON AND DOT ABOVE
+     * U+1E69 LATIN SMALL LETTER S WITH DOT BELOW AND DOT ABOVE
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb9 &&
+     (0xa1 <= utf8_char[2] && utf8_char[2] <= 0xa9)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1351,6 +1385,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
     *unified = 'r';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_s(utf8_char)) {
+    *unified = 's';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_a.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŚśŜŝŞşŠš"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ssssssss",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŚśŜŝŞşŠš" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_additional.expected
@@ -1,0 +1,27 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṠṡṢṣṤṥṦṧṨṩ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ssssssssss",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṠṡṢṣṤṥṦṧṨṩ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_b.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Șș"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"ss","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/s/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Șș" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `s`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb s
## Generate mapping about Unicode and UTF-8
["U+015b", "ś", ["0xc5", "0x9b"]]
["U+015d", "ŝ", ["0xc5", "0x9d"]]
["U+015f", "ş", ["0xc5", "0x9f"]]
["U+0161", "š", ["0xc5", "0xa1"]]
["U+0219", "ș", ["0xc8", "0x99"]]
["U+1e61", "ṡ", ["0xe1", "0xb9", "0xa1"]]
["U+1e63", "ṣ", ["0xe1", "0xb9", "0xa3"]]
["U+1e65", "ṥ", ["0xe1", "0xb9", "0xa5"]]
["U+1e67", "ṧ", ["0xe1", "0xb9", "0xa7"]]
["U+1e69", "ṩ", ["0xe1", "0xb9", "0xa9"]]
--------------------------------------------------
## Generate target characters
ŚśŜŝŞşŠšȘșṠṡṢṣṤṥṦṧṨṩ
```