### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `u`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1341,6 +1341,83 @@ grn_nfkc_normalize_unify_diacritical_mark_is_s(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_u(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00F9 LATIN SMALL LETTER U WITH GRAVE
+     * U+00FA LATIN SMALL LETTER U WITH ACUTE
+     * U+00FB LATIN SMALL LETTER U WITH CIRCUMFLEX
+     * U+00FC LATIN SMALL LETTER U WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xc3 && 0xb9 <= utf8_char[1] && utf8_char[1] <= 0xbc) ||
+    /*
+     * Latin Extended-A
+     * U+0169 LATIN SMALL LETTER U WITH TILDE
+     * U+016B LATIN SMALL LETTER U WITH MACRON
+     * U+016D LATIN SMALL LETTER U WITH BREVE
+     * U+016F LATIN SMALL LETTER U WITH RING ABOVE
+     * U+0171 LATIN SMALL LETTER U WITH DOUBLE ACUTE
+     * U+0173 LATIN SMALL LETTER U WITH OGONEK
+     * Uppercase counterparts (e.g. #U+016A) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc5 && 0xa9 <= utf8_char[1] && utf8_char[1] <= 0xb3) ||
+    /*
+     * Latin Extended-B
+     * U+01B0 LATIN SMALL LETTER U WITH HORN
+     */
+    (utf8_char[0] == 0xc6 && utf8_char[1] == 0xb0) ||
+    /*
+     * Latin Extended-B
+     * U+01D4 LATIN SMALL LETTER U WITH CARON
+     * U+01D6 LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
+     * U+01D8 LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
+     * U+01DA LATIN SMALL LETTER U WITH DIAERESIS AND CARON
+     * U+01DC LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xc7 && 0x94 <= utf8_char[1] && utf8_char[1] <= 0x9c) ||
+    /*
+     * Latin Extended-B
+     * U+0215 LATIN SMALL LETTER U WITH DOUBLE GRAVE
+     * U+0217 LATIN SMALL LETTER U WITH INVERTED BREVE
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xc8 && 0x95 <= utf8_char[1] && utf8_char[1] <= 0x97) ||
+    /*
+     * Latin Extended Additional
+     * U+1E73 LATIN SMALL LETTER U WITH DIAERESIS BELOW
+     * U+1E75 LATIN SMALL LETTER U WITH TILDE BELOW
+     * U+1E77 LATIN SMALL LETTER U WITH CIRCUMFLEX BELOW
+     * U+1E79 LATIN SMALL LETTER U WITH TILDE AND ACUTE
+     * U+1E7B LATIN SMALL LETTER U WITH MACRON AND DIAERESIS
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb9 &&
+     (0xb3 <= utf8_char[2] && utf8_char[2] <= 0xbb)) ||
+    /*
+     * Latin Extended Additional
+     * U+1EE5 LATIN SMALL LETTER U WITH DOT BELOW
+     * U+1EE7 LATIN SMALL LETTER U WITH HOOK ABOVE
+     * U+1EE9 LATIN SMALL LETTER U WITH HORN AND ACUTE
+     * U+1EEB LATIN SMALL LETTER U WITH HORN AND GRAVE
+     * U+1EED LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE
+     * U+1EEF LATIN SMALL LETTER U WITH HORN AND TILDE
+     * U+1EF1 LATIN SMALL LETTER U WITH HORN AND DOT BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xbb &&
+     (0xa5 <= utf8_char[2] && utf8_char[2] <= 0xb1)));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_w(const unsigned char *utf8_char)
 {
   return (
@@ -1417,6 +1494,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_s(utf8_char)) {
     *unified = 's';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_u(utf8_char)) {
+    *unified = 'u';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_w(utf8_char)) {
     *unified = 'w';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_1_supplement.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ÙÚÛÜùúûü"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "uuuuuuuu",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ÙÚÛÜùúûü" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_a.expected
@@ -1,0 +1,29 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŨũŪūŬŭŮůŰűŲų"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "uuuuuuuuuuuu",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŨũŪūŬŭŮůŰűŲų" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_additional.expected
@@ -1,0 +1,41 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṲṳṴṵṶṷṸṹṺṻỤụỦủỨứỪừỬửỮữỰự"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "uuuuuuuuuuuuuuuuuuuuuuuu",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṲṳṴṵṶṷṸṹṺṻỤụỦủỨứỪừỬửỮữỰự" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_b.expected
@@ -1,0 +1,33 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ƯưǓǔǕǖǗǘǙǚǛǜȔȕȖȗ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "uuuuuuuuuuuuuuuu",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/u/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ƯưǓǔǕǖǗǘǙǚǛǜȔȕȖȗ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `u`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb u
## Generate mapping about Unicode and UTF-8
["U+00f9", "ù", ["0xc3", "0xb9"]]
["U+00fa", "ú", ["0xc3", "0xba"]]
["U+00fb", "û", ["0xc3", "0xbb"]]
["U+00fc", "ü", ["0xc3", "0xbc"]]
["U+0169", "ũ", ["0xc5", "0xa9"]]
["U+016b", "ū", ["0xc5", "0xab"]]
["U+016d", "ŭ", ["0xc5", "0xad"]]
["U+016f", "ů", ["0xc5", "0xaf"]]
["U+0171", "ű", ["0xc5", "0xb1"]]
["U+0173", "ų", ["0xc5", "0xb3"]]
["U+01b0", "ư", ["0xc6", "0xb0"]]
["U+01d4", "ǔ", ["0xc7", "0x94"]]
["U+01d6", "ǖ", ["0xc7", "0x96"]]
["U+01d8", "ǘ", ["0xc7", "0x98"]]
["U+01da", "ǚ", ["0xc7", "0x9a"]]
["U+01dc", "ǜ", ["0xc7", "0x9c"]]
["U+0215", "ȕ", ["0xc8", "0x95"]]
["U+0217", "ȗ", ["0xc8", "0x97"]]
["U+1e73", "ṳ", ["0xe1", "0xb9", "0xb3"]]
["U+1e75", "ṵ", ["0xe1", "0xb9", "0xb5"]]
["U+1e77", "ṷ", ["0xe1", "0xb9", "0xb7"]]
["U+1e79", "ṹ", ["0xe1", "0xb9", "0xb9"]]
["U+1e7b", "ṻ", ["0xe1", "0xb9", "0xbb"]]
["U+1ee5", "ụ", ["0xe1", "0xbb", "0xa5"]]
["U+1ee7", "ủ", ["0xe1", "0xbb", "0xa7"]]
["U+1ee9", "ứ", ["0xe1", "0xbb", "0xa9"]]
["U+1eeb", "ừ", ["0xe1", "0xbb", "0xab"]]
["U+1eed", "ử", ["0xe1", "0xbb", "0xad"]]
["U+1eef", "ữ", ["0xe1", "0xbb", "0xaf"]]
["U+1ef1", "ự", ["0xe1", "0xbb", "0xb1"]]
--------------------------------------------------
## Generate target characters
ÙÚÛÜùúûüŨũŪūŬŭŮůŰűŲųƯưǓǔǕǖǗǘǙǚǛǜȔȕȖȗṲṳṴṵṶṷṸṹṺṻỤụỦủỨứỪừỬửỮữỰự
```