### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `w`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1340,6 +1340,35 @@ grn_nfkc_normalize_unify_diacritical_mark_is_s(const unsigned char *utf8_char)
      (0xa1 <= utf8_char[2] && utf8_char[2] <= 0xa9)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_w(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+0175 LATIN SMALL LETTER W WITH CIRCUMFLEX
+     */
+    (utf8_char[0] == 0xc5 && utf8_char[1] == 0xb5) ||
+    /*
+     * Latin Extended Additional
+     * U+1E81 LATIN SMALL LETTER W WITH GRAVE
+     * U+1E83 LATIN SMALL LETTER W WITH ACUTE
+     * U+1E85 LATIN SMALL LETTER W WITH DIAERESIS
+     * U+1E87 LATIN SMALL LETTER W WITH DOT ABOVE
+     * U+1E89 LATIN SMALL LETTER W WITH DOT BELOW
+     * Uppercase counterparts (e.g. U+1E82) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba &&
+     (0x81 <= utf8_char[2] && utf8_char[2] <= 0x89)) ||
+    /*
+     * Latin Extended Additional
+     * U+1E98 LATIN SMALL LETTER W WITH RING ABOVE
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba && utf8_char[2] == 0x98));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1388,6 +1417,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_s(utf8_char)) {
     *unified = 's';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_w(utf8_char)) {
+    *unified = 'w';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_a.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ŵŵ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"ww","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ŵŵ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_additional.expected
@@ -1,0 +1,28 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ẀẁẂẃẄẅẆẇẈẉẘ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "wwwwwwwwwww",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/w/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ẀẁẂẃẄẅẆẇẈẉẘ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `w`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb w
## Generate mapping about Unicode and UTF-8
["U+0175", "ŵ", ["0xc5", "0xb5"]]
["U+1e81", "ẁ", ["0xe1", "0xba", "0x81"]]
["U+1e83", "ẃ", ["0xe1", "0xba", "0x83"]]
["U+1e85", "ẅ", ["0xe1", "0xba", "0x85"]]
["U+1e87", "ẇ", ["0xe1", "0xba", "0x87"]]
["U+1e89", "ẉ", ["0xe1", "0xba", "0x89"]]
["U+1e98", "ẘ", ["0xe1", "0xba", "0x98"]]
--------------------------------------------------
## Generate target characters
ŴŵẀẁẂẃẄẅẆẇẈẉẘ
```