### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `x`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1491,6 +1491,22 @@ grn_nfkc_normalize_unify_diacritical_mark_is_w(const unsigned char *utf8_char)
     (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba && utf8_char[2] == 0x98));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_x(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended Additional
+     * U+1E8B LATIN SMALL LETTER X WITH DOT ABOVE
+     * U+1E8D LATIN SMALL LETTER X WITH DIAERESIS
+     * Uppercase counterparts (U+1E8C) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    utf8_char[0] == 0xe1 && utf8_char[1] == 0xba &&
+    (0x8b <= utf8_char[2] && utf8_char[2] <= 0x8d));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1554,6 +1570,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_w(utf8_char)) {
     *unified = 'w';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_x(utf8_char)) {
+    *unified = 'x';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/x/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/x/latin_extended_additional.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ẊẋẌẍ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "xxxx",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/x/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/x/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ẊẋẌẍ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `x`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb x
## Generate mapping about Unicode and UTF-8
["U+1e8b", "ẋ", ["0xe1", "0xba", "0x8b"]]
["U+1e8d", "ẍ", ["0xe1", "0xba", "0x8d"]]
--------------------------------------------------
## Generate target characters
ẊẋẌẍ
```