### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `y`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1507,6 +1507,48 @@ grn_nfkc_normalize_unify_diacritical_mark_is_x(const unsigned char *utf8_char)
     (0x8b <= utf8_char[2] && utf8_char[2] <= 0x8d));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_y(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin-1 Supplement
+     * U+00FD LATIN SMALL LETTER Y WITH ACUTE
+     * U+00FF LATIN SMALL LETTER Y WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xc3 && utf8_char[1] == 0xbd) ||
+    (utf8_char[0] == 0xc3 && utf8_char[1] == 0xbf) ||
+    /*
+     * Latin Extended-A
+     * U+0177 LATIN SMALL LETTER Y WITH CIRCUMFLEX
+     */
+    (utf8_char[0] == 0xc5 && utf8_char[1] == 0xb7) ||
+    /*
+     * Latin Extended-B
+     * U+0233 LATIN SMALL LETTER Y WITH MACRON
+     */
+    (utf8_char[0] == 0xc8 && utf8_char[1] == 0xb3) ||
+    /*
+     * Latin Extended Additional
+     * U+1E8F LATIN SMALL LETTER Y WITH DOT ABOVE
+     * U+1E99 LATIN SMALL LETTER Y WITH RING ABOVE
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba &&
+     (utf8_char[2] == 0x8f || utf8_char[2] == 0x99)) ||
+    /*
+     * Latin Extended Additional
+     * U+1EF3 LATIN SMALL LETTER Y WITH GRAVE
+     * U+1EF5 LATIN SMALL LETTER Y WITH DOT BELOW
+     * U+1EF7 LATIN SMALL LETTER Y WITH HOOK ABOVE
+     * U+1EF9 LATIN SMALL LETTER Y WITH TILDE
+     * Uppercase counterparts (e.g. U+1EF4) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xbb &&
+     (0xb3 <= utf8_char[2] && utf8_char[2] <= 0xb9)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1573,6 +1615,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_x(utf8_char)) {
     *unified = 'x';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_y(utf8_char)) {
+    *unified = 'y';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_1_supplement.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_1_supplement.expected
@@ -1,0 +1,20 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ýýÿ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "yyy",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_1_supplement.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_1_supplement.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ýýÿ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_a.expected
@@ -1,0 +1,20 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŶŷŸ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "yyy",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŶŷŸ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_additional.expected
@@ -1,0 +1,28 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ẎẏẙỲỳỴỵỶỷỸỹ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "yyyyyyyyyyy",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ẎẏẙỲỳỴỵỶỷỸỹ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_b.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ȳȳ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"yy","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/y/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ȳȳ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `y`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb y
## Generate mapping about Unicode and UTF-8
["U+00fd", "ý", ["0xc3", "0xbd"]]
["U+00ff", "ÿ", ["0xc3", "0xbf"]]
["U+0177", "ŷ", ["0xc5", "0xb7"]]
["U+0233", "ȳ", ["0xc8", "0xb3"]]
["U+1e8f", "ẏ", ["0xe1", "0xba", "0x8f"]]
["U+1e99", "ẙ", ["0xe1", "0xba", "0x99"]]
["U+1ef3", "ỳ", ["0xe1", "0xbb", "0xb3"]]
["U+1ef5", "ỵ", ["0xe1", "0xbb", "0xb5"]]
["U+1ef7", "ỷ", ["0xe1", "0xbb", "0xb7"]]
["U+1ef9", "ỹ", ["0xe1", "0xbb", "0xb9"]]
--------------------------------------------------
## Generate target characters
ÝýÿŶŷŸȲȳẎẏẙỲỳỴỵỶỷỸỹ
```