### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `z`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1549,6 +1549,32 @@ grn_nfkc_normalize_unify_diacritical_mark_is_y(const unsigned char *utf8_char)
      (0xb3 <= utf8_char[2] && utf8_char[2] <= 0xb9)));
 }
 
+grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_z(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+017A LATIN SMALL LETTER Z WITH ACUTE
+     * U+017C LATIN SMALL LETTER Z WITH DOT ABOVE
+     * U+017E LATIN SMALL LETTER Z WITH CARON
+     * Uppercase counterparts (e.g. U+017B) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc5 && 0xba <= utf8_char[1] && utf8_char[1] <= 0xbe) ||
+    /*
+     * Latin Extended Additional
+     * U+1E91 LATIN SMALL LETTER Z WITH CIRCUMFLEX
+     * U+1E93 LATIN SMALL LETTER Z WITH DOT BELOW
+     * U+1E95 LATIN SMALL LETTER Z WITH LINE BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba &&
+     (0x91 <= utf8_char[2] && utf8_char[2] <= 0x95)));
+}
+
 /*
  * This function assumes that the input utf8_char is a valid UTF-8 character.
  * It is the caller's responsibility to ensure that utf8_char is valid UTF-8
@@ -1618,6 +1644,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_y(utf8_char)) {
     *unified = 'y';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_z(utf8_char)) {
+    *unified = 'z';
     return unified;
   } else {
     return utf8_char;

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_a.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŹźŻżŽž"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "zzzzzz",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŹźŻżŽž" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_additional.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ẐẑẒẓẔẕ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "zzzzzz",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/z/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ẐẑẒẓẔẕ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `z`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb z
## Generate mapping about Unicode and UTF-8
["U+017a", "ź", ["0xc5", "0xba"]]
["U+017c", "ż", ["0xc5", "0xbc"]]
["U+017e", "ž", ["0xc5", "0xbe"]]
["U+1e91", "ẑ", ["0xe1", "0xba", "0x91"]]
["U+1e93", "ẓ", ["0xe1", "0xba", "0x93"]]
["U+1e95", "ẕ", ["0xe1", "0xba", "0x95"]]
--------------------------------------------------
## Generate target characters
ŹźŻżŽžẐẑẒẓẔẕ
```