### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `f`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1045,6 +1045,17 @@ grn_nfkc_normalize_unify_diacritical_mark_is_e(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_f(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended Additional
+     * U+1E1F LATIN SMALL LETTER F WITH DOT ABOVE
+     */
+    utf8_char[0] == 0xe1 && utf8_char[1] == 0xb8 && utf8_char[2] == 0x9f);
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_g(const unsigned char *utf8_char)
 {
   return (
@@ -1393,6 +1404,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_e(utf8_char)) {
     *unified = 'e';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_f(utf8_char)) {
+    *unified = 'f';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_g(utf8_char)) {
     *unified = 'g';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/f/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/f/latin_extended_additional.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ḟḟ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"ff","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/f/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/f/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ḟḟ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `f`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb f
## Generate mapping about Unicode and UTF-8
["U+1e1f", "ḟ", ["0xe1", "0xb8", "0x9f"]]
--------------------------------------------------
## Generate target characters
Ḟḟ
```