### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `j`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1105,6 +1105,22 @@ grn_nfkc_normalize_unify_diacritical_mark_is_h(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_j(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+0135 LATIN SMALL LETTER J WITH CIRCUMFLEX
+     */
+    (utf8_char[0] == 0xc4 && utf8_char[1] == 0xb5) ||
+    /*
+     * Latin Extended-B
+     * U+01F0 LATIN SMALL LETTER J WITH CARON
+     */
+    (utf8_char[0] == 0xc7 && utf8_char[1] == 0xb0));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_k(const unsigned char *utf8_char)
 {
   return (
@@ -1399,6 +1415,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_h(utf8_char)) {
     *unified = 'h';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_j(utf8_char)) {
+    *unified = 'j';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_k(utf8_char)) {
     *unified = 'k';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_a.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Ĵĵ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"jj","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Ĵĵ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_b.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ǰ"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"j","types":["alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/j/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ǰ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `j`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb j
## Generate mapping about Unicode and UTF-8
["U+0135", "ĵ", ["0xc4", "0xb5"]]
["U+01f0", "ǰ", ["0xc7", "0xb0"]]
--------------------------------------------------
## Generate target characters
Ĵĵǰ
```