### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `m`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1159,6 +1159,24 @@ grn_nfkc_normalize_unify_diacritical_mark_is_l(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_m(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended Additional
+     * U+1E3F LATIN SMALL LETTER M WITH ACUTE
+     * U+1E41 LATIN SMALL LETTER M WITH DOT ABOVE
+     * U+1E43 LATIN SMALL LETTER M WITH DOT BELOW
+     * Uppercase counterparts (e.g. U+1E42) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xe1 &&
+     ((utf8_char[1] == 0xb8 && utf8_char[2] == 0xbf) ||
+      (utf8_char[1] == 0xb9 && 0x81 <= utf8_char[2] && utf8_char[2] <= 0x83))));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_n(const unsigned char *utf8_char)
 {
   return (
@@ -1405,6 +1423,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_l(utf8_char)) {
     *unified = 'l';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_m(utf8_char)) {
+    *unified = 'm';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_n(utf8_char)) {
     *unified = 'n';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/m/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/m/latin_extended_additional.expected
@@ -1,0 +1,23 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ḾḿṀṁṂṃ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "mmmmmm",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/m/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/m/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ḾḿṀṁṂṃ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `m`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb m
## Generate mapping about Unicode and UTF-8
["U+1e3f", "ḿ", ["0xe1", "0xb8", "0xbf"]]
["U+1e41", "ṁ", ["0xe1", "0xb9", "0x81"]]
["U+1e43", "ṃ", ["0xe1", "0xb9", "0x83"]]
--------------------------------------------------
## Generate target characters
ḾḿṀṁṂṃ
```