### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `t`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1386,6 +1386,42 @@ grn_nfkc_normalize_unify_diacritical_mark_is_s(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_t(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended-A
+     * U+0163 LATIN SMALL LETTER T WITH CEDILLA
+     * U+0165 LATIN SMALL LETTER T WITH CARON
+     * Uppercase counterparts (e.g. U+0164) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    (utf8_char[0] == 0xc5 && 0xa3 <= utf8_char[1] && utf8_char[1] <= 0xa5) ||
+    /*
+     * Latin Extended-B
+     * U+021B LATIN SMALL LETTER T WITH COMMA BELOW
+     */
+    (utf8_char[0] == 0xc8 && utf8_char[1] == 0x9b) ||
+    /*
+     * Latin Extended Additional
+     * U+1E6B LATIN SMALL LETTER T WITH DOT ABOVE
+     * U+1E6D LATIN SMALL LETTER T WITH DOT BELOW
+     * U+1E6F LATIN SMALL LETTER T WITH LINE BELOW
+     * U+1E71 LATIN SMALL LETTER T WITH CIRCUMFLEX BELOW
+     *
+     * Each missing one is an upper case.
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xb9 &&
+     (0xab <= utf8_char[2] && utf8_char[2] <= 0xb1)) ||
+    /*
+     * Latin Extended Additional
+     * U+1E97 LATIN SMALL LETTER T WITH DIAERESIS
+     */
+    (utf8_char[0] == 0xe1 && utf8_char[1] == 0xba && utf8_char[2] == 0x97));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_u(const unsigned char *utf8_char)
 {
   return (
@@ -1632,6 +1668,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_s(utf8_char)) {
     *unified = 's';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_t(utf8_char)) {
+    *unified = 't';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_u(utf8_char)) {
     *unified = 'u';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_a.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_a.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ŢţŤť"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "tttt",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_a.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_a.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ŢţŤť" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_additional.expected
@@ -1,0 +1,26 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṪṫṬṭṮṯṰṱẗ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ttttttttt",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṪṫṬṭṮṯṰṱẗ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_b.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_b.expected
@@ -1,0 +1,2 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "Țț"   WITH_TYPES
+[[0,0.0,0.0],{"normalized":"tt","types":["alpha","alpha","null"],"checks":[]}]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_b.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/t/latin_extended_b.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "Țț" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `t`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb t
## Generate mapping about Unicode and UTF-8
["U+0163", "ţ", ["0xc5", "0xa3"]]
["U+0165", "ť", ["0xc5", "0xa5"]]
["U+021b", "ț", ["0xc8", "0x9b"]]
["U+1e6b", "ṫ", ["0xe1", "0xb9", "0xab"]]
["U+1e6d", "ṭ", ["0xe1", "0xb9", "0xad"]]
["U+1e6f", "ṯ", ["0xe1", "0xb9", "0xaf"]]
["U+1e71", "ṱ", ["0xe1", "0xb9", "0xb1"]]
["U+1e97", "ẗ", ["0xe1", "0xba", "0x97"]]
--------------------------------------------------
## Generate target characters
ŢţŤťȚțṪṫṬṭṮṯṰṱẗ
```