### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `p`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1319,6 +1319,22 @@ grn_nfkc_normalize_unify_diacritical_mark_is_o(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_p(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended Additional
+     * U+1E55 LATIN SMALL LETTER P WITH ACUTE
+     * U+1E57 LATIN SMALL LETTER P WITH DOT ABOVE
+     * Uppercase counterparts (U+1E56) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    utf8_char[0] == 0xe1 && utf8_char[1] == 0xb9 &&
+    (0x95 <= utf8_char[2] && utf8_char[2] <= 0x97));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_r(const unsigned char *utf8_char)
 {
   return (
@@ -1626,6 +1642,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_o(utf8_char)) {
     *unified = 'o';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_p(utf8_char)) {
+    *unified = 'p';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
     *unified = 'r';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/p/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/p/latin_extended_additional.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṔṕṖṗ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "pppp",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/p/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/p/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṔṕṖṗ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `p`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb p
## Generate mapping about Unicode and UTF-8
["U+1e55", "ṕ", ["0xe1", "0xb9", "0x95"]]
["U+1e57", "ṗ", ["0xe1", "0xb9", "0x97"]]
--------------------------------------------------
## Generate target characters
ṔṕṖṗ
```