### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: remove diacritical mark for `v`

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1463,6 +1463,22 @@ grn_nfkc_normalize_unify_diacritical_mark_is_u(const unsigned char *utf8_char)
 }
 
 grn_inline static bool
+grn_nfkc_normalize_unify_diacritical_mark_is_v(const unsigned char *utf8_char)
+{
+  return (
+    /*
+     * Latin Extended Additional
+     * U+1E7D LATIN SMALL LETTER V WITH TILDE
+     * U+1E7F LATIN SMALL LETTER V WITH DOT BELOW
+     * Uppercase counterparts (U+1E7E) are covered by the following
+     * condition but they are never appeared here. Because NFKC normalization
+     * converts them to their lowercase equivalents.
+     */
+    utf8_char[0] == 0xe1 && utf8_char[1] == 0xb9 &&
+    (0xbd <= utf8_char[2] && utf8_char[2] <= 0xbf));
+}
+
+grn_inline static bool
 grn_nfkc_normalize_unify_diacritical_mark_is_w(const unsigned char *utf8_char)
 {
   return (
@@ -1635,6 +1651,9 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_u(utf8_char)) {
     *unified = 'u';
+    return unified;
+  } else if (grn_nfkc_normalize_unify_diacritical_mark_is_v(utf8_char)) {
+    *unified = 'v';
     return unified;
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_w(utf8_char)) {
     *unified = 'w';

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/v/latin_extended_additional.expected
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/v/latin_extended_additional.expected
@@ -1,0 +1,21 @@
+normalize   'NormalizerNFKC("unify_alphabet_diacritical_mark", true)'   "ṼṽṾṿ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "vvvv",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": [
+
+    ]
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/v/latin_extended_additional.test
+++ b/test/command/suite/normalizers/nfkc/unify_alphabet_diacritical_mark/v/latin_extended_additional.test
@@ -1,0 +1,6 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("unify_alphabet_diacritical_mark", true)' \
+  "ṼṽṾṿ" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: GH-1755

Implementation of grn_nfkc_normalize_unify_alphabet_diacritical_mark(). Commit to normalize to `v`.

Target characters:

```
% ./tools/generate-alphabet-diacritical-mark.rb v
## Generate mapping about Unicode and UTF-8
["U+1e7d", "ṽ", ["0xe1", "0xb9", "0xbd"]]
["U+1e7f", "ṿ", ["0xe1", "0xb9", "0xbf"]]
--------------------------------------------------
## Generate target characters
ṼṽṾṿ
```