### PR TITLE
docs api/grn_obj: move grn_obj_rename() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -39,22 +39,13 @@ msgstr "リファレンス"
 msgid "We are currently switching to automatic generation using Doxygen."
 msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 
-msgid "ctxが使用するdbにおいてobjに対応する名前をnameに更新します。objは永続オブジェクトでなければいけません。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "新しい名前を指定します。"
-msgstr ""
-
-msgid "nameパラメータのsize（byte）を指定します。"
-msgstr ""
-
 msgid "一時的なobjectであるobjをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
 msgid "永続的な、table, column, exprなどは解放してはいけません。一般的には、一時的か永続的かを気にしなくてよい :c:func:`grn_obj_unlink()` を用いるべきです。"
+msgstr ""
+
+msgid "対象objectを指定します。"
 msgstr ""
 
 msgid "objの型を変更します。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -23,14 +23,6 @@ Reference
 
    TODO...
 
-.. c:function:: grn_rc grn_obj_rename(grn_ctx *ctx, grn_obj *obj, const char *name, unsigned int name_size)
-
-   ctxが使用するdbにおいてobjに対応する名前をnameに更新します。objは永続オブジェクトでなければいけません。
-
-   :param obj: 対象objectを指定します。
-   :param name: 新しい名前を指定します。
-   :param name_size: nameパラメータのsize（byte）を指定します。
-
 .. c:function:: grn_rc grn_obj_close(grn_ctx *ctx, grn_obj *obj)
 
    一時的なobjectであるobjをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1037,6 +1037,19 @@ grn_ctx_remove(grn_ctx *ctx, const char *name, int name_size, uint32_t flags);
 GRN_API grn_rc
 grn_ctx_remove_by_id(grn_ctx *ctx, grn_id id, uint32_t flags);
 
+/**
+ * \brief Rename a persistent object in the database used by the context.
+ *
+ *        This function updates the name of the specified object (`obj`) to the
+ *        new name provided. The object must be a persistent object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object to be renamed.
+ * \param name The new name for the given object.
+ * \param name_size The size of the `name` in bytes.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_obj_rename(grn_ctx *ctx,
                grn_obj *obj,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.