### PR TITLE
NormalizerNFKC unify_alphabet_diacritical_mark: Add a comment because only `q` does not unify

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -1698,6 +1698,7 @@ grn_nfkc_normalize_unify_alphabet_diacritical_mark(
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_p(utf8_char)) {
     *unified = 'p';
     return unified;
+  // 'q' has no diacritical marks.
   } else if (grn_nfkc_normalize_unify_diacritical_mark_is_r(utf8_char)) {
     *unified = 'r';
     return unified;


### PR DESCRIPTION
GitHub: GH-1755

`q` has no diacritical marks.

```
% ./tools/generate-alphabet-diacritical-mark.rb q
## Generate mapping about Unicode and UTF-8
--------------------------------------------------
## Generate target characters
```