### PR TITLE
packages ubuntu focal: unify dependency packages

### DIFF
--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -27,7 +27,7 @@ RUN \
     libssl-dev \
     libstemmer-dev \
     libxxhash-dev \
-    libzmq3-dev | libzmq-dev\
+    libzmq3-dev \
     libzstd-dev \
     lsb-release \
     ninja-build \

--- a/packages/apt/ubuntu-focal/Dockerfile
+++ b/packages/apt/ubuntu-focal/Dockerfile
@@ -23,13 +23,11 @@ RUN \
     liblz4-dev \
     libmecab-dev \
     libmsgpack-dev \
-    libpcre3-dev \
     libsimdjson-dev \
     libssl-dev \
     libstemmer-dev \
-    libthrift-dev \
     libxxhash-dev \
-    libzmq3-dev \
+    libzmq3-dev | libzmq-dev\
     libzstd-dev \
     lsb-release \
     ninja-build \

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -19,6 +19,7 @@ Build-Depends:
   libxxhash-dev,
   libzmq3-dev | libzmq-dev,
   libzstd-dev,
+  lsb-release,
   ninja-build,
   pkg-config,
   rapidjson-dev,


### PR DESCRIPTION
Build (ubuntu-focal-amd64) job on CI check build error before we build package on Launchpad.

If we build packages on Launchpad, dependency packages are installed based on control.in. On the other hand, if we build packages on CI, depndency packages are installed based on Dockerfile.

So, the dependency packages of control.in and Dockerfile msut be same.

The current different points of control.in and Dockerfile as below.

```diff
--- /tmp/Dockerfile	2024-09-03 15:34:20.335871523 +0900
+++ /tmp/control.in	2024-09-03 15:34:41.244334634 +0900
@@ -1,22 +1,17 @@
-autoconf-archive
-build-essential
-ccache
 cmake
 debhelper
-devscripts
-dh-apparmor
 libedit-dev
 libevent-dev
 liblz4-dev
 libmecab-dev
 libmsgpack-dev
-libpcre3-dev
 libsimdjson-dev
 libssl-dev
 libstemmer-dev
-libthrift-dev
+# Broken. xtl-dev dependency is missing.
+#  libxsimd-dev
 libxxhash-dev
-libzmq3-dev
+libzmq3-dev | libzmq-dev
 libzstd-dev
-lsb-release
 ninja-build
```