### PR TITLE
packages ubuntu jammy: unify dependency packages

### DIFF
--- a/packages/apt/ubuntu-jammy/Dockerfile
+++ b/packages/apt/ubuntu-jammy/Dockerfile
@@ -26,7 +26,6 @@ RUN \
     libsimdjson-dev \
     libssl-dev \
     libstemmer-dev \
-    libthrift-dev \
     libxxhash-dev \
     libzmq3-dev \
     libzstd-dev \


### PR DESCRIPTION
Currently, building on Launchpad during release was a one-shot process, and dealing with build failures is challenging.
To mitigate this, we're setting up a CI environment that mimics the Launchpad environment for testing.

However, the dependency packages listed in `control.in` and `Dockerfile` are different, making the test ineffective. This change unifies the dependency packages in `Dockerfile` to match those in `control.in` to ensure consistency between the test and actual build environments.