### PR TITLE
packages: add support for Amazon Linux 2023

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -192,6 +192,7 @@ jobs:
           - almalinux-8-aarch64
           - almalinux-9-x86_64
           - almalinux-9-aarch64
+          - amazon-linux-2023-x86_64
         include:
           - id: debian-bookworm-arm64
             timeout-minutes: 60
@@ -224,7 +225,7 @@ jobs:
           id=${{ matrix.id }}
           os_version=${id%-*}
           os=${os_version%-*}
-          version=${os_version#*-}
+          version=${os_version##*-}
           architecture=${id##*-}
 
           if [ "${os}" = "debian" ] || [ "${os}" = "ubuntu" ]; then
@@ -238,12 +239,14 @@ jobs:
             fi
           else
             TASK_NAMESPACE=yum
+            # amazon-linux -> amazonlinux
+            docker_os=${os/-/}
             if [ "${architecture}" = "x86_64" ]; then
               TARGET="${os_version}"
-              TEST_DOCKER_IMAGE="${os}:${version}"
+              TEST_DOCKER_IMAGE="${docker_os}:${version}"
             else
               TARGET="${id}"
-              TEST_DOCKER_IMAGE="arm64v8/${os}:${version}"
+              TEST_DOCKER_IMAGE="arm64v8/${docker_os}:${version}"
             fi
           fi
           echo "TASK_NAMESPACE=${TASK_NAMESPACE}" >> ${GITHUB_ENV}

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -81,6 +81,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
       "almalinux-8-aarch64",
       "almalinux-9",
       "almalinux-9-aarch64",
+      "amazon-linux-2023",
     ]
   end
 

--- a/packages/yum/amazon-linux-2023/Dockerfile
+++ b/packages/yum/amazon-linux-2023/Dockerfile
@@ -1,0 +1,30 @@
+ARG FROM=amazonlinux:2023
+FROM ${FROM}
+
+ARG DEBUG
+ARG APACHE_ARROW_VERSION
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf update -y ${quiet} && \
+  dnf install -y ${quiet} \
+    https://apache.jfrog.io/artifactory/arrow/amazon-linux/$(cut -d: -f6 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
+  dnf groupinstall -y ${quiet} "Development Tools" && \
+  dnf install -y ${quiet} \
+    arrow-devel-${APACHE_ARROW_VERSION} \
+    cmake \
+    intltool \
+    libedit-devel \
+    libevent-devel \
+    libstemmer-devel \
+    libzstd-devel \
+    lz4-devel \
+    openssl-devel \
+    php-devel \
+    pkgconfig \
+    ruby \
+    tar \
+    which \
+    xxhash-devel \
+    zlib-devel && \
+  dnf clean ${quiet} all

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -1,6 +1,7 @@
 # -*- sh-shell: rpm -*-
 
-%define _rhel %{?rhel:%{rhel}}%{!?rhel:0}
+%define _amzn %{?amzn:%{amzn}}%{!?amzn:0}
+%define is_amazon_linux (%{_amzn} != 0)
 
 %if ! %{defined cmake}
 %define cmake %{cmake3}
@@ -28,12 +29,16 @@ BuildRequires:	libedit-devel
 BuildRequires:	libstemmer-devel
 BuildRequires:	libzstd-devel
 BuildRequires:	lz4-devel
+%if ! %{is_amazon_linux}
 BuildRequires:	mecab-devel
 BuildRequires:	msgpack-devel
+%endif
 BuildRequires:	openssl-devel
 BuildRequires:	pkgconfig
 BuildRequires:	ruby
+%if ! %{is_amazon_linux}
 BuildRequires:	simdjson-devel
+%endif
 # Old xsimd-devel doesn't work. At least 9.0.0 or older don't work.
 # See also -DGRN_WITH_XSIMD=bundled with cmake.
 #BuildRequires:	xsimd-devel
@@ -59,8 +64,10 @@ License:	LGPLv2 and (MIT or GPLv2)
 Requires:	arrow@APACHE_ARROW_MAJOR_VERSION@-libs
 Requires:	libzstd
 Requires:	lz4
+%if ! %{is_amazon_linux}
 Requires:	msgpack
 Requires:	simdjson
+%endif
 Requires:	xxhash-libs
 Requires:	zlib
 Requires(post):	/sbin/ldconfig
@@ -133,11 +140,14 @@ Summary:	Libraries and header files for Groonga
 Group:		Development/Libraries
 Requires:	%{name}-libs = %{version}-%{release}
 Requires:	arrow-devel >= @APACHE_ARROW_VERSION@
+%if ! %{is_amazon_linux}
 Requires:	msgpack-devel
+%endif
 
 %description devel
 Libraries and header files for Groonga
 
+%if ! %{is_amazon_linux}
 %package tokenizer-mecab
 Summary:	MeCab tokenizer for Groonga
 Group:		Applications/Text
@@ -146,6 +156,7 @@ Requires:	mecab-ipadic
 
 %description tokenizer-mecab
 MeCab tokenizer for Groonga
+%endif
 
 %package token-filter-stem
 Summary:	Stemming token filter for Groonga
@@ -156,7 +167,6 @@ Requires:	libstemmer
 %description token-filter-stem
 Stemming token filter for Groonga. Name is TokenFilterStem.
 
-%if %{_rhel} >= 8
 %package plugin-h3
 Summary:	H3 related plugin for Groonga
 Group:		Applications/Text
@@ -167,7 +177,6 @@ H# plugin for Groonga.
 
 This provides TokenH3Index by tokenizers/h3_index and
 h3_*() functions by functions/h3.
-%endif
 
 %package plugin-suggest
 Summary:	Suggest plugin for Groonga
@@ -177,6 +186,7 @@ Requires:	%{name}-libs = %{version}-%{release}
 %description plugin-suggest
 Suggest plugin for Groonga
 
+%if ! %{is_amazon_linux}
 %package munin-plugins
 Summary:	Munin plugins for Groonga
 Group:		Applications/System
@@ -186,6 +196,7 @@ Requires(post):	munin-node
 
 %description munin-plugins
 Munin plugins for Groonga
+%endif
 
 %prep
 #% define optflags -O0
@@ -201,9 +212,13 @@ Munin plugins for Groonga
   -DGRN_WITH_BLOSC=bundled \
   -DGRN_WITH_DOC=ON \
   -DGRN_WITH_EXAMPLES=ON \
+%if ! %{is_amazon_linux}
   -DGRN_WITH_MECAB=ON \
+%endif
   -DGRN_WITH_MRUBY=ON \
+%if ! %{is_amazon_linux}
   -DGRN_WITH_MUNIN_PLUGINS=ON \
+%endif
   -DGRN_WITH_TOOLS=ON \
   -DGRN_WITH_XSIMD=bundled
 %cmake_build
@@ -211,7 +226,7 @@ Munin plugins for Groonga
 
 %install
 %cmake_install
-# Workaround for old CMake on CentOS 7 and AlmaLinux 9.
+# Workaround for old CMake on AlmaLinux 9.
 # It seems that preventing installing FetchContent library by EXCLUDE_FROM_ALL
 # doesn't work with old CMake.
 rm -rf $RPM_BUILD_ROOT%{_includedir}/h3/
@@ -231,6 +246,7 @@ mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/run/groonga
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/groonga/db
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/log/groonga
 
+%if ! %{is_amazon_linux}
 mv $RPM_BUILD_ROOT%{_datadir}/groonga/munin/ $RPM_BUILD_ROOT%{_datadir}/
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/munin/plugin-conf.d/
 cat <<EOC > $RPM_BUILD_ROOT%{_sysconfdir}/munin/plugin-conf.d/groonga
@@ -253,6 +269,7 @@ cat <<EOC > $RPM_BUILD_ROOT%{_sysconfdir}/munin/plugin-conf.d/groonga
   env.gqtp_pid_path %{_rundir}/groonga/groonga-gqtp.pid
   env.gqtp_query_log_path %{_localstatedir}/log/groonga/query-gqtp.log
 EOC
+%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -281,9 +298,11 @@ exit 0
 
 %post libs -p /sbin/ldconfig
 
+%if ! %{is_amazon_linux}
 %post munin-plugins
 %{_sbindir}/munin-node-configure --shell --remove-also | grep -e 'groonga_' | sh
 %systemd_post munin-node
+%endif
 
 %preun server-gqtp
 %systemd_preun groonga-server-gqtp.service
@@ -299,9 +318,11 @@ exit 0
 
 %postun libs -p /sbin/ldconfig
 
+%if ! %{is_amazon_linux}
 %postun munin-plugins
 %{_sbindir}/munin-node-configure --shell --remove-also | grep -e 'groonga_' | sh
 %systemd_postun munin-node
+%endif
 
 
 %files
@@ -355,6 +376,10 @@ exit 0
 %{_datadir}/groonga/groonga-log/
 %{_datadir}/groonga/html/
 %{_datadir}/groonga/mruby/
+%if %{is_amazon_linux}
+%{_datadir}/groonga/msgpack-c/
+%{_datadir}/groonga/simdjson/
+%endif
 %{_datadir}/groonga/xsimd/
 %config(noreplace) %{_sysconfdir}/groonga/synonyms.tsv
 
@@ -404,13 +429,11 @@ exit 0
 %{_libdir}/pkgconfig/groonga*.pc
 %{_libdir}/cmake/Groonga/*.cmake
 
-%if %{_rhel} >= 8
 %files plugin-h3
 %defattr(-,root,root,-)
 %{_libdir}/groonga/plugins/functions/h3.so
 %{_libdir}/groonga/plugins/tokenizers/h3_index.so
 %{_datadir}/groonga/h3/
-%endif
 
 %files plugin-suggest
 %defattr(-,root,root,-)
@@ -418,18 +441,22 @@ exit 0
 %dir %{_libdir}/groonga/plugins
 %{_libdir}/groonga/plugins/suggest/suggest.so
 
+%if ! %{is_amazon_linux}
 %files tokenizer-mecab
 %defattr(-,root,root,-)
 %{_libdir}/groonga/plugins/tokenizers/mecab.so
+%endif
 
 %files token-filter-stem
 %defattr(-,root,root,-)
 %{_libdir}/groonga/plugins/token_filters/stem.so
 
+%if ! %{is_amazon_linux}
 %files munin-plugins
 %defattr(-,root,root,-)
 %{_datadir}/munin/plugins/*
 %config(noreplace) %{_sysconfdir}/munin/plugin-conf.d/*
+%endif
 
 %changelog
 * Tue Sep 03 2024 Horimoto Yasuhiro <horimoto@clear-code.com> - 14.0.7-1

--- a/test/command/suite/column_create/path/existent.test
+++ b/test/command/suite/column_create/path/existent.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 #$GRN_ENABLE_REFERENCE_COUNT=no
 
 table_create Data TABLE_NO_KEY

--- a/test/command/suite/object_list/full.test
+++ b/test/command/suite/object_list/full.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 #$GRN_ENABLE_REFERENCE_COUNT=no
 
 plugin_register functions/vector

--- a/test/command/suite/schema/plugins.test
+++ b/test/command/suite/schema/plugins.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 #$GRN_QUERY_EXPANDER_TSV_SYNONYMS_FILE=#{db_directory}/synonyms.tsv
 #@copy-path fixture/query_expander/tsv/expand.tsv #{db_directory}/synonyms.tsv
 plugin_register query_expanders/tsv

--- a/test/command/suite/schema/tables/columns/compress/filter_byte_delta.test
+++ b/test/command/suite/schema/tables/columns/compress/filter_byte_delta.test
@@ -1,4 +1,5 @@
 #@require-feature blosc
+#@require-feature mecab
 
 table_create Logs TABLE_NO_KEY
 column_create Logs messages COLUMN_VECTOR|COMPRESS_ZSTD|COMPRESS_FILTER_BYTE_DELTA ShortText

--- a/test/command/suite/schema/tables/columns/compress/filter_shuffle.test
+++ b/test/command/suite/schema/tables/columns/compress/filter_shuffle.test
@@ -1,4 +1,5 @@
 #@require-feature blosc
+#@require-feature mecab
 
 table_create Logs TABLE_NO_KEY
 column_create Logs messages COLUMN_VECTOR|COMPRESS_ZSTD|COMPRESS_FILTER_SHUFFLE ShortText

--- a/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_1byte.test
+++ b/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_1byte.test
@@ -1,4 +1,5 @@
 #@require-feature blosc
+#@require-feature mecab
 
 table_create Logs TABLE_NO_KEY
 column_create Logs scores \

--- a/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_2bytes.test
+++ b/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_2bytes.test
@@ -1,4 +1,5 @@
 #@require-feature blosc
+#@require-feature mecab
 
 table_create Logs TABLE_NO_KEY
 column_create Logs scores \

--- a/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_bytes.test
+++ b/test/command/suite/schema/tables/columns/compress/filter_truncate_precision_bytes.test
@@ -1,4 +1,5 @@
 #@require-feature blosc
+#@require-feature mecab
 
 table_create Logs TABLE_NO_KEY
 column_create Logs scores \

--- a/test/command/suite/schema/tables/columns/compress/lz4.test
+++ b/test/command/suite/schema/tables/columns/compress/lz4.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY
 column_create Logs message COLUMN_SCALAR|COMPRESS_LZ4 Text
 

--- a/test/command/suite/schema/tables/columns/compress/zlib.test
+++ b/test/command/suite/schema/tables/columns/compress/zlib.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY
 column_create Logs message COLUMN_SCALAR|COMPRESS_ZLIB Text
 

--- a/test/command/suite/schema/tables/columns/compress/zstd.test
+++ b/test/command/suite/schema/tables/columns/compress/zstd.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY
 column_create Logs message COLUMN_SCALAR|COMPRESS_ZSTD Text
 

--- a/test/command/suite/schema/tables/columns/invalid/error.test
+++ b/test/command/suite/schema/tables/columns/invalid/error.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/invalid/ignore.test
+++ b/test/command/suite/schema/tables/columns/invalid/ignore.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/invalid/warn.test
+++ b/test/command/suite/schema/tables/columns/invalid/warn.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/missing/add.test
+++ b/test/command/suite/schema/tables/columns/missing/add.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/missing/ignore.test
+++ b/test/command/suite/schema/tables/columns/missing/ignore.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/missing/nil.test
+++ b/test/command/suite/schema/tables/columns/missing/nil.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY

--- a/test/command/suite/schema/tables/columns/type/index_large.test
+++ b/test/command/suite/schema/tables/columns/type/index_large.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Posts TABLE_HASH_KEY ShortText
 column_create Posts title COLUMN_SCALAR ShortText
 column_create Posts content COLUMN_SCALAR Text

--- a/test/command/suite/schema/tables/columns/type/index_medium.test
+++ b/test/command/suite/schema/tables/columns/type/index_medium.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Posts TABLE_HASH_KEY ShortText
 column_create Posts title COLUMN_SCALAR ShortText
 column_create Posts content COLUMN_SCALAR Text

--- a/test/command/suite/schema/tables/columns/type/index_small.test
+++ b/test/command/suite/schema/tables/columns/type/index_small.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Posts TABLE_HASH_KEY ShortText
 column_create Posts title COLUMN_SCALAR ShortText
 column_create Posts content COLUMN_SCALAR Text

--- a/test/command/suite/schema/tables/columns/type/scalar.test
+++ b/test/command/suite/schema/tables/columns/type/scalar.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY
 column_create Logs message COLUMN_SCALAR Text
 

--- a/test/command/suite/schema/tables/columns/type/vector.test
+++ b/test/command/suite/schema/tables/columns/type/vector.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_DAT_KEY ShortText --normalizer NormalizerAuto
 
 table_create Posts TABLE_HASH_KEY ShortText

--- a/test/command/suite/schema/tables/columns/type/vector_bfloat16.test
+++ b/test/command/suite/schema/tables/columns/type/vector_bfloat16.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_DAT_KEY ShortText --normalizer NormalizerAuto
 
 table_create Posts TABLE_HASH_KEY ShortText

--- a/test/command/suite/schema/tables/columns/type/vector_token.test
+++ b/test/command/suite/schema/tables/columns/type/vector_token.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Terms TABLE_PAT_KEY ShortText \
   --normalizer NormalizerNFKC121 \
   --default_tokenizer TokenNgram

--- a/test/command/suite/schema/tables/columns/type/vector_weight32.test
+++ b/test/command/suite/schema/tables/columns/type/vector_weight32.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_DAT_KEY ShortText --normalizer NormalizerAuto
 
 table_create Posts TABLE_HASH_KEY ShortText

--- a/test/command/suite/schema/tables/normalizer.test
+++ b/test/command/suite/schema/tables/normalizer.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_PAT_KEY ShortText --normalizer NormalizerAuto
 
 schema

--- a/test/command/suite/schema/tables/normalizer_with_options.test
+++ b/test/command/suite/schema/tables/normalizer_with_options.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Tags TABLE_PAT_KEY ShortText \
   --normalizer 'NormalizerNFKC100("unify_kana", true)'
 

--- a/test/command/suite/schema/tables/normalizers_with_options.test
+++ b/test/command/suite/schema/tables/normalizers_with_options.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Substitutions TABLE_PAT_KEY ShortText
 column_create Substitutions substituted COLUMN_SCALAR ShortText
 

--- a/test/command/suite/schema/tables/token_filters.test
+++ b/test/command/suite/schema/tables/token_filters.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 plugin_register token_filters/stop_word
 
 table_create Terms TABLE_PAT_KEY ShortText \

--- a/test/command/suite/schema/tables/token_filters_with_options.test
+++ b/test/command/suite/schema/tables/token_filters_with_options.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 plugin_register token_filters/stop_word
 
 table_create Terms TABLE_PAT_KEY ShortText \

--- a/test/command/suite/schema/tables/tokenizer.test
+++ b/test/command/suite/schema/tables/tokenizer.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenBigram
 
 schema

--- a/test/command/suite/schema/tables/tokenizer_with_options.test
+++ b/test/command/suite/schema/tables/tokenizer_with_options.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer 'TokenNgram("n", 4)'
 

--- a/test/command/suite/schema/tables/type/array.test
+++ b/test/command/suite/schema/tables/type/array.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY
 
 schema

--- a/test/command/suite/schema/tables/type/hash_table.test
+++ b/test/command/suite/schema/tables/type/hash_table.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Users TABLE_HASH_KEY ShortText
 
 schema

--- a/test/command/suite/schema/tables/value_type/reference.test
+++ b/test/command/suite/schema/tables/value_type/reference.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Users TABLE_HASH_KEY ShortText
 
 table_create Logs TABLE_NO_KEY --value_type Users

--- a/test/command/suite/schema/tables/value_type/type.test
+++ b/test/command/suite/schema/tables/value_type/type.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Logs TABLE_NO_KEY --value_type Int32
 
 schema

--- a/test/command/suite/select/filter/near_phrase/mecab.expected
+++ b/test/command/suite/select/filter/near_phrase/mecab.expected
@@ -1,37 +1,3 @@
-tokenize TokenMecab '京都府 東京都'
-[
-  [
-    0,
-    0.0,
-    0.0
-  ],
-  [
-    {
-      "value": "京都",
-      "position": 0,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "府",
-      "position": 1,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "東京",
-      "position": 2,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "都",
-      "position": 3,
-      "force_prefix": false,
-      "force_prefix_search": false
-    }
-  ]
-]
 table_create Entries TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Entries content COLUMN_SCALAR Text

--- a/test/command/suite/select/filter/near_phrase/mecab.test
+++ b/test/command/suite/select/filter/near_phrase/mecab.test
@@ -1,6 +1,4 @@
-#@on-error omit
-tokenize TokenMecab '京都府 東京都'
-#@on-error default
+#@require-feature mecab
 
 table_create Entries TABLE_NO_KEY
 column_create Entries content COLUMN_SCALAR Text

--- a/test/command/suite/select/filter/ordered_near_phrase/mecab.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/mecab.expected
@@ -1,37 +1,3 @@
-tokenize TokenMecab '京都府 東京都'
-[
-  [
-    0,
-    0.0,
-    0.0
-  ],
-  [
-    {
-      "value": "京都",
-      "position": 0,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "府",
-      "position": 1,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "東京",
-      "position": 2,
-      "force_prefix": false,
-      "force_prefix_search": false
-    },
-    {
-      "value": "都",
-      "position": 3,
-      "force_prefix": false,
-      "force_prefix_search": false
-    }
-  ]
-]
 table_create Entries TABLE_NO_KEY
 [[0,0.0,0.0],true]
 column_create Entries content COLUMN_SCALAR Text

--- a/test/command/suite/select/filter/ordered_near_phrase/mecab.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/mecab.test
@@ -1,6 +1,4 @@
-#@on-error omit
-tokenize TokenMecab '京都府 東京都'
-#@on-error default
+#@require-feature mecab
 
 table_create Entries TABLE_NO_KEY
 column_create Entries content COLUMN_SCALAR Text

--- a/test/command/suite/select/fuzzy/tokenize.test
+++ b/test/command/suite/select/fuzzy/tokenize.test
@@ -1,11 +1,11 @@
+#@require-feature mecab
+
 table_create Memos TABLE_NO_KEY
 column_create Memos content COLUMN_SCALAR ShortText
 
-#@on-error omit
 table_create Lexicon TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenMecab \
   --normalizer NormalizerNFKC150
-#@on-error default
 column_create Lexicon memos_content \
   COLUMN_INDEX|WITH_POSITION Memos content
 

--- a/test/command/suite/select/output_columns/star/function_call.test
+++ b/test/command/suite/select/output_columns/star/function_call.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Memos TABLE_NO_KEY
 column_create Memos column1 COLUMN_SCALAR ShortText
 column_create Memos column2 COLUMN_SCALAR ShortText

--- a/test/command/suite/select/query/match/with_index/token_mecab/use_reading.test
+++ b/test/command/suite/select/query/match/with_index/token_mecab/use_reading.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Menus TABLE_NO_KEY
 column_create Menus name COLUMN_SCALAR Text
 

--- a/test/command/suite/table_create/default_tokenizer/mecab/default.test
+++ b/test/command/suite/table_create/default_tokenizer/mecab/default.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Memos TABLE_NO_KEY
 column_create Memos content COLUMN_SCALAR Text
 

--- a/test/command/suite/table_create/default_tokenizer/mecab/normalize.test
+++ b/test/command/suite/table_create/default_tokenizer/mecab/normalize.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 table_create Memos TABLE_NO_KEY
 column_create Memos content COLUMN_SCALAR Text
 

--- a/test/command/suite/table_create/path/existent.test
+++ b/test/command/suite/table_create/path/existent.test
@@ -1,3 +1,5 @@
+#@require-feature mecab
+
 #$GRN_ENABLE_REFERENCE_COUNT=no
 
 table_create Data TABLE_NO_KEY --path data

--- a/test/command/suite/token_filters/nfkc100/unify_kana.test
+++ b/test/command/suite/token_filters/nfkc100/unify_kana.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   "私は林檎を食べます。" \
   --token_filters 'TokenFilterNFKC100("unify_kana", true)'
-#@on-error default

--- a/test/command/suite/token_filters/nfkc121/unify_kana.test
+++ b/test/command/suite/token_filters/nfkc121/unify_kana.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   "私は林檎を食べます。" \
   --token_filters 'TokenFilterNFKC121("unify_kana", true)'
-#@on-error default

--- a/test/command/suite/token_filters/nfkc130/unify_kana.test
+++ b/test/command/suite/token_filters/nfkc130/unify_kana.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   "私は林檎を食べます。" \
   --token_filters 'TokenFilterNFKC130("unify_kana", true)'
-#@on-error default

--- a/test/command/suite/token_filters/nfkc150/unify_kana.test
+++ b/test/command/suite/token_filters/nfkc150/unify_kana.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   "私は林檎を食べます。" \
   --token_filters 'TokenFilterNFKC150("unify_kana", true)'
-#@on-error default

--- a/test/command/suite/tokenizer_list/default.test
+++ b/test/command/suite/tokenizer_list/default.test
@@ -1,1 +1,3 @@
+#@require-feature mecab
+
 tokenizer_list

--- a/test/command/suite/tokenizers/mecab/chunk/comma.test
+++ b/test/command/suite/tokenizers/mecab/chunk/comma.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン,エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/exclamation_mark.test
+++ b/test/command/suite/tokenizers/mecab/chunk/exclamation_mark.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン!エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/fullwidth_exclamation_mark.test
+++ b/test/command/suite/tokenizers/mecab/chunk/fullwidth_exclamation_mark.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン！エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/fullwidth_question_mark.test
+++ b/test/command/suite/tokenizers/mecab/chunk/fullwidth_question_mark.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン？エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/ideographic_comma.test
+++ b/test/command/suite/tokenizers/mecab/chunk/ideographic_comma.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン、エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/ideographic_full_stop.test
+++ b/test/command/suite/tokenizers/mecab/chunk/ideographic_full_stop.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン。エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/ideographic_space.test
+++ b/test/command/suite/tokenizers/mecab/chunk/ideographic_space.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン　エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/multiple_delimiters_in_one_chunk.test
+++ b/test/command/suite/tokenizers/mecab/chunk/multiple_delimiters_in_one_chunk.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本。エンジン。エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/period.test
+++ b/test/command/suite/tokenizers/mecab/chunk/period.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン.エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/question_mark.test
+++ b/test/command/suite/tokenizers/mecab/chunk/question_mark.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン?エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/space.test
+++ b/test/command/suite/tokenizers/mecab/chunk/space.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン エンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/chunk/threshold.test
+++ b/test/command/suite/tokenizers/mecab/chunk/threshold.test
@@ -1,5 +1,6 @@
+#@require-feature mecab
+
 #$GRN_MECAB_CHUNKED_TOKENIZE_ENABLED=yes
 #$GRN_MECAB_CHUNK_SIZE_THRESHOLD=30
-#@on-error omit
+
 tokenize TokenMecab '日本のエンジンとエンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/full_width_space/first.test
+++ b/test/command/suite/tokenizers/mecab/full_width_space/first.test
@@ -1,1 +1,3 @@
+#@require-feature mecab
+
 tokenize TokenMecab '　日本'

--- a/test/command/suite/tokenizers/mecab/full_width_space/last.test
+++ b/test/command/suite/tokenizers/mecab/full_width_space/last.test
@@ -1,1 +1,3 @@
+#@require-feature mecab
+
 tokenize TokenMecab '日本　'

--- a/test/command/suite/tokenizers/mecab/full_width_space/only.test
+++ b/test/command/suite/tokenizers/mecab/full_width_space/only.test
@@ -1,1 +1,3 @@
+#@require-feature mecab
+
 tokenize TokenMecab '　'

--- a/test/command/suite/tokenizers/mecab/multiple_tokens.test
+++ b/test/command/suite/tokenizers/mecab/multiple_tokens.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本のエンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/one_token.test
+++ b/test/command/suite/tokenizers/mecab/one_token.test
@@ -1,3 +1,3 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize TokenMecab '日本'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/chunk_size_threshold.test
+++ b/test/command/suite/tokenizers/mecab/options/chunk_size_threshold.test
@@ -1,5 +1,5 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("chunked_tokenize", true, "chunk_size_threshold", 30)' \
   '日本のエンジンとエンジン'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/include_class.test
+++ b/test/command/suite/tokenizers/mecab/options/include_class.test
@@ -1,5 +1,5 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true)' \
   'これはペンです。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/include_form.test
+++ b/test/command/suite/tokenizers/mecab/options/include_form.test
@@ -1,5 +1,5 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_form", true)' \
   '行きました'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/include_reading.test
+++ b/test/command/suite/tokenizers/mecab/options/include_reading.test
@@ -1,5 +1,5 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_reading", true)' \
   '焼き肉と焼肉とyakiniku'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/negative.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/negative.test
@@ -1,7 +1,7 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "-助詞", \
               "target_class", "+")' \
   '私の名前は山田です。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/one.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/one.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "名詞")' \
   '私の名前は山田です。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/positive.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/positive.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "+名詞")' \
   '私の名前は山田です。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/subclass0.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/subclass0.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "名詞/代名詞")' \
   '私の名前は山田です。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/subclass1.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/subclass1.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "名詞/固有名詞/人名")' \
   '私の名前は山田です。東京生まれです。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/target_class/subclass2.test
+++ b/test/command/suite/tokenizers/mecab/options/target_class/subclass2.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("include_class", true, \
               "target_class", "名詞/固有名詞/人名/姓")' \
   '私の名前は山田太郎です。'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/use_base_form.expected
+++ b/test/command/suite/tokenizers/mecab/options/use_base_form.expected
@@ -1,4 +1,4 @@
-tokenize   'TokenMecab("use_base_form", true)'    '支える 支えられた 支えた'
+tokenize   'TokenMecab("use_base_form", true)'   '支える 支えられた 支えた'
 [
   [
     0,

--- a/test/command/suite/tokenizers/mecab/options/use_base_form.test
+++ b/test/command/suite/tokenizers/mecab/options/use_base_form.test
@@ -1,1 +1,5 @@
-tokenize   'TokenMecab("use_base_form", true)'    '支える 支えられた 支えた'
+#@require-feature mecab
+
+tokenize \
+  'TokenMecab("use_base_form", true)' \
+  '支える 支えられた 支えた'

--- a/test/command/suite/tokenizers/mecab/options/use_reading_add.test
+++ b/test/command/suite/tokenizers/mecab/options/use_reading_add.test
@@ -1,5 +1,5 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   '焼き肉と焼肉とyakiniku'
-#@on-error default

--- a/test/command/suite/tokenizers/mecab/options/use_reading_get.test
+++ b/test/command/suite/tokenizers/mecab/options/use_reading_get.test
@@ -1,6 +1,6 @@
-#@on-error omit
+#@require-feature mecab
+
 tokenize \
   'TokenMecab("use_reading", true)' \
   '焼き肉と焼肉とyakiniku' \
   --mode GET
-#@on-error default

--- a/test/command/suite/wal_recover/db/auto_recovery/keys_repair.test
+++ b/test/command/suite/wal_recover/db/auto_recovery/keys_repair.test
@@ -2,6 +2,7 @@
 # processed by workers. Workers never use primary WAL role.
 #@require-interface stdio
 
+#@require-feature mecab
 #@require-feature message_pack
 
 #$GROONGA_ALLOW_DATABASE_REOPEN=yes


### PR DESCRIPTION
GitHub: fix GH-1845

Amazon Linux 2023 package doesn't have MeCab support because Amazon Linux 2023 doesn't provide MeCab package. Existing tests work without MeCab support. (Tests that need MeCab support are omitted.)

Amazon Linux 2023 doesn't provide MessagePack packages but MessagePack support is enabled by using bundled MessagePack.

Amazon Linux 2023 doesn't provide simdjson packages but simdjson support is enabled by using bundled simdjson.

Reported by Watson. Thanks!!!

Reported by takoyaki-nyokki. Thanks!!!