### PR TITLE
docs: api/grn_table: move grn_table_columns() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -18,9 +18,6 @@ msgstr ""
 msgid "パラメータ"
 msgstr ""
 
-msgid "戻り値"
-msgstr ""
-
 msgid "``grn_table``"
 msgstr ""
 
@@ -112,19 +109,4 @@ msgid "実行する演算の種類を指定します。"
 msgstr ""
 
 msgid "table1とtable2から重複するレコードを取り除いた結果をそれぞれres1, res2に格納します。"
-msgstr ""
-
-msgid "nameパラメータから始まるtableのカラムIDをresパラメータに格納します。name_sizeパラメータが0の場合はすべてのカラムIDを格納します。"
-msgstr ""
-
-msgid "取得したいカラム名のprefixを指定します。"
-msgstr ""
-
-msgid "nameパラメータの長さを指定します。"
-msgstr ""
-
-msgid "結果を格納する ``GRN_TABLE_HASH_KEY`` のtableを指定します。"
-msgstr ""
-
-msgid "格納したカラムIDの数を返します。"
 msgstr ""

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -98,13 +98,3 @@ Reference
    :param table2: 対象table2を指定します。
    :param res1: 結果を格納するtableを指定します。
    :param res2: 結果を格納するtableを指定します。
-
-.. c:function:: int grn_table_columns(grn_ctx *ctx, grn_obj *table, const char *name, unsigned int name_size, grn_obj *res)
- 
-   nameパラメータから始まるtableのカラムIDをresパラメータに格納します。name_sizeパラメータが0の場合はすべてのカラムIDを格納します。
-
-   :param table: 対象tableを指定します。
-   :param name: 取得したいカラム名のprefixを指定します。
-   :param name_size: nameパラメータの長さを指定します。
-   :param res: 結果を格納する ``GRN_TABLE_HASH_KEY`` のtableを指定します。
-   :return: 格納したカラムIDの数を返します。

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -712,6 +712,17 @@ grn_table_setoperation(grn_ctx *ctx,
 GRN_API grn_rc
 grn_table_difference(
   grn_ctx *ctx, grn_obj *table1, grn_obj *table2, grn_obj *res1, grn_obj *res2);
+/**
+ * \brief Store the column IDs of the table starting with `name` in `res`.
+ *
+ * \param ctx The context object.
+ * \param table The table.
+ * \param name The column name prefix.
+ * \param name_size Size of `name` in bytes. If `0`, you get all column IDs.
+ * \param res The \ref GRN_TABLE_HASH_KEY table to store results.
+ *
+ * \return The number of IDs.
+ */
 GRN_API int
 grn_table_columns(grn_ctx *ctx,
                   grn_obj *table,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.