### PR TITLE
logger: Change grn_logger_output_close() not to be run before grn_logger_init()

### DIFF
--- a/lib/logger.c
+++ b/lib/logger.c
@@ -378,6 +378,9 @@ default_logger_reopen(grn_ctx *ctx, void *user_data)
 static void
 default_logger_fin(grn_ctx *ctx, void *user_data)
 {
+  if (!logger_inited) {
+    return;
+  }
   grn_logger_output_close(ctx, &default_logger_output);
 }
 


### PR DESCRIPTION
Crash on Windows when `grn_logger_output_close()` is run before `grn_logger_init()`.
Therefore, we changed it so that it does not close() when not init().  

PGroonga uses a usage where close() is run before init().
(That is the behavior when setting the logger with `grn_logger_set()`.)