### PR TITLE
docs: api/grn_table: move grn_table_update_by_id() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -60,15 +60,6 @@ msgstr ""
 msgid "keybufのサイズ(byte長)を指定します。"
 msgstr ""
 
-msgid "tableのidに対応するレコードのkeyを変更します。新しいkeyとそのbyte長をdest_keyとdest_key_sizeに指定します。"
-msgstr ""
-
-msgid "この操作は、``GRN_TABLE_DAT_KEY`` 型のテーブルのみ使用できます。"
-msgstr ""
-
-msgid "レコードIDを指定します。"
-msgstr ""
-
 msgid "tableのレコードを特定の条件でグループ化します。"
 msgstr ""
 

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -36,15 +36,6 @@ Reference
    :param keybuf: keyを格納するバッファ(呼出側で準備する)を指定します。
    :param buf_size: keybufのサイズ(byte長)を指定します。
 
-.. c:function:: grn_rc grn_table_update_by_id(grn_ctx *ctx, grn_obj *table, grn_id id, const void *dest_key, unsigned int dest_key_size)
-
-   tableのidに対応するレコードのkeyを変更します。新しいkeyとそのbyte長をdest_keyとdest_key_sizeに指定します。
-
-   この操作は、``GRN_TABLE_DAT_KEY`` 型のテーブルのみ使用できます。
-
-   :param table: 対象tableを指定します。
-   :param id: レコードIDを指定します。
-
 .. c:type:: grn_table_sort_key
 
    TODO...

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -183,7 +183,7 @@ grn_table_delete_by_id(grn_ctx *ctx, grn_obj *table, grn_id id);
  *        This operation supports only \ref GRN_TABLE_DAT_KEY.
  *
  * \param ctx The context object.
- * \param table The table.
+ * \param table The \ref GRN_TABLE_DAT_KEY table.
  * \param id ID of record to be updated.
  * \param dest_key New key.
  * \param dest_key_size Size of `dest_key` in bytes.

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -190,7 +190,7 @@ grn_table_delete_by_id(grn_ctx *ctx, grn_obj *table, grn_id id);
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  *         For example, \ref GRN_OPERATION_NOT_PERMITTED is returned if the
- *         other than \ref GRN_TABLE_DAT_KEY is specified.
+ *         table other than \ref GRN_TABLE_DAT_KEY is specified.
  */
 GRN_API grn_rc
 grn_table_update_by_id(grn_ctx *ctx,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -178,6 +178,20 @@ grn_table_delete(grn_ctx *ctx,
  */
 GRN_API grn_rc
 grn_table_delete_by_id(grn_ctx *ctx, grn_obj *table, grn_id id);
+/**
+ * \brief Update the key of the record matching ID in the table.
+ *        This operation supports only \ref GRN_TABLE_DAT_KEY.
+ *
+ * \param ctx The context object.
+ * \param table The table.
+ * \param id ID of record to be updated.
+ * \param dest_key New key.
+ * \param dest_key_size Size of `dest_key` in bytes.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_OPERATION_NOT_PERMITTED is returned if the
+ *         other than \ref GRN_TABLE_DAT_KEY is specified.
+ */
 GRN_API grn_rc
 grn_table_update_by_id(grn_ctx *ctx,
                        grn_obj *table,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.