### PR TITLE
grn_obj_unlink: return grn_rc

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1196,7 +1196,7 @@ grn_obj_reinit(grn_ctx *ctx, grn_obj *obj, grn_id domain, uint8_t flags);
  *
  * If the decreased reference count is zero, the object is closed.
  */
-GRN_API void
+GRN_API grn_rc
 grn_obj_unlink(grn_ctx *ctx, grn_obj *obj);
 GRN_API grn_rc
 grn_obj_refer(grn_ctx *ctx, grn_obj *obj);

--- a/lib/db.c
+++ b/lib/db.c
@@ -13221,14 +13221,12 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               current_reference_count);
       GRN_API_RETURN(rc);
     } else {
-      rc = grn_obj_close(ctx, obj);
-      return rc;
+      return grn_obj_close(ctx, obj);
     }
   }
 
   if (!GRN_DB_OBJP(obj)) {
-    rc = grn_obj_close(ctx, obj);
-    return rc;
+    return grn_obj_close(ctx, obj);
   }
 
   grn_db_obj *db_obj = DB_OBJ(obj);
@@ -13254,8 +13252,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               current_reference_count);
       GRN_API_RETURN(rc);
     } else {
-      rc = grn_obj_close(ctx, obj);
-      return rc;
+      return grn_obj_close(ctx, obj);
     }
   }
 
@@ -13297,8 +13294,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
           obj,
           vp->lock,
           vp->ptr);
-      rc = ctx->rc;
-      GRN_API_RETURN(rc);
+      GRN_API_RETURN(ctx->rc);
     }
     uint32_t current_lock;
     uint32_t *lock_pointer = &vp->lock;

--- a/lib/db.c
+++ b/lib/db.c
@@ -13321,9 +13321,8 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               obj,
                               current_lock,
                               current_reference_count);
-      grn_rc rc = GRN_SUCCESS;
       if (current_lock == 0) {
-        rc = grn_obj_close(ctx, obj);
+        grn_rc rc = grn_obj_close(ctx, obj);
         grn_log_reference_count("%p: unlink: done: %u: %p: %u\n",
                                 ctx,
                                 id,

--- a/lib/db.c
+++ b/lib/db.c
@@ -13295,7 +13295,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
           obj,
           vp->lock,
           vp->ptr);
-      GRN_API_RETURN(GRN_INVALID_ARGUMENT);
+      GRN_API_RETURN(ctx->rc);
     }
     uint32_t current_lock;
     uint32_t *lock_pointer = &vp->lock;

--- a/lib/db.c
+++ b/lib/db.c
@@ -13324,6 +13324,12 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
       grn_rc rc = GRN_SUCCESS;
       if (current_lock == 0) {
         rc = grn_obj_close(ctx, obj);
+        grn_log_reference_count("%p: unlink: done: %u: %p: %u\n",
+                                ctx,
+                                id,
+                                obj,
+                                current_reference_count);
+        GRN_API_RETURN(rc);
       } else {
         grn_log_reference_count("%p: unlink: unlock: %u: %p: %u: %u\n",
                                 ctx,
@@ -13351,7 +13357,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                             id,
                             obj,
                             current_reference_count);
-    GRN_API_RETURN(rc);
+    GRN_API_RETURN(GRN_SUCCESS);
   }
   GRN_API_RETURN(GRN_SUCCESS);
 }

--- a/lib/db.c
+++ b/lib/db.c
@@ -13199,8 +13199,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
   }
 
   if (obj->header.type == GRN_DB) {
-    rc = grn_obj_close(ctx, obj);
-    return rc;
+    return grn_obj_close(ctx, obj);
   }
 
   if (obj->header.type == GRN_ACCESSOR) {

--- a/lib/db.c
+++ b/lib/db.c
@@ -13193,9 +13193,8 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
 grn_rc
 grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
 {
-  grn_rc rc = GRN_SUCCESS;
   if (!obj) {
-    return rc;
+    return GRN_SUCCESS;
   }
 
   if (obj->header.type == GRN_DB) {
@@ -13212,6 +13211,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               accessor->reference_count);
       accessor->reference_count--;
       uint32_t current_reference_count = accessor->reference_count;
+      grn_rc rc = GRN_SUCCESS;
       if (current_reference_count == 0) {
         rc = grn_obj_close(ctx, obj);
       }
@@ -13242,6 +13242,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               db_obj->reference_count);
       db_obj->reference_count--;
       uint32_t current_reference_count = db_obj->reference_count;
+      grn_rc rc = GRN_SUCCESS;
       if (current_reference_count == 0) {
         rc = grn_obj_close(ctx, obj);
       }
@@ -13259,11 +13260,11 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
   /* Don't unlink built-in objects. We must update the same condition
    * in grn_ctx_at() when we need to unlink built-in objects. */
   if (id < GRN_N_RESERVED_TYPES) {
-    return rc;
+    return GRN_SUCCESS;
   }
 
   if (!grn_enable_reference_count) {
-    return rc;
+    return GRN_SUCCESS;
   }
 
   GRN_API_ENTER;
@@ -13294,7 +13295,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
           obj,
           vp->lock,
           vp->ptr);
-      GRN_API_RETURN(ctx->rc);
+      GRN_API_RETURN(GRN_INVALID_ARGUMENT);
     }
     uint32_t current_lock;
     uint32_t *lock_pointer = &vp->lock;
@@ -13320,6 +13321,7 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                               obj,
                               current_lock,
                               current_reference_count);
+      grn_rc rc = GRN_SUCCESS;
       if (current_lock == 0) {
         rc = grn_obj_close(ctx, obj);
       } else {
@@ -13349,8 +13351,9 @@ grn_obj_unlink(grn_ctx *ctx, grn_obj *obj)
                             id,
                             obj,
                             current_reference_count);
+    GRN_API_RETURN(rc);
   }
-  GRN_API_RETURN(rc);
+  GRN_API_RETURN(GRN_SUCCESS);
 }
 
 void


### PR DESCRIPTION
Because `grn_obj_unlink()` may set `GRN_INVALID_ARGUMENT` to `ctx->rc` when an error occures in this function.

Also, `grn_obj_close()` returns `grn_rc`.
So, `grn_obj_unlink()` should also return `grn_rc`.

This changes API but this doesn't break backward compatibility.
Because no code exist that use the return value of `grn_obj_unlink()`.