### PR TITLE
grn_obj_close: do nothing and return GRN_SUCCESS for NULL

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -13062,7 +13062,6 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
   case GRN_PVECTOR:
     grn_rc rc = grn_pvector_fin(ctx, obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_ACCESSOR:
     {
       grn_accessor *p, *n;
@@ -13076,15 +13075,12 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
   case GRN_SNIP:
     grn_rc rc = grn_snip_close(ctx, (grn_snip *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_STRING:
     grn_rc rc = grn_string_close(ctx, obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_HIGHLIGHTER:
     grn_rc rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_CURSOR_TABLE_PAT_KEY:
     grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
     break;
@@ -13112,35 +13108,27 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
   case GRN_DB:
     grn_rc rc = grn_db_close(ctx, obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_TABLE_PAT_KEY:
     grn_rc rc = grn_pat_close(ctx, (grn_pat *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_TABLE_DAT_KEY:
     grn_rc rc = grn_dat_close(ctx, (grn_dat *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_TABLE_HASH_KEY:
     grn_rc rc = grn_hash_close(ctx, (grn_hash *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_TABLE_NO_KEY:
     grn_rc rc = grn_array_close(ctx, (grn_array *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_COLUMN_VAR_SIZE:
     grn_rc rc = grn_ja_close(ctx, (grn_ja *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_COLUMN_FIX_SIZE:
     grn_rc rc = grn_ra_close(ctx, (grn_ra *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_COLUMN_INDEX:
     grn_rc rc = grn_ii_close(ctx, (grn_ii *)obj);
     GRN_API_RETURN(rc);
-    break;
   case GRN_PROC:
     {
       uint32_t i;
@@ -13165,7 +13153,6 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
   case GRN_EXPR:
     grn_rc rc = grn_expr_close(ctx, obj);
     GRN_API_RETURN(rc);
-    break;
   }
   GRN_API_RETURN(GRN_SUCCESS);
 }

--- a/lib/db.c
+++ b/lib/db.c
@@ -13041,24 +13041,28 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
   case GRN_BULK:
   case GRN_UVECTOR:
   case GRN_MSG:
-    obj->header.type = GRN_VOID;
-    grn_bulk_fin(ctx, obj);
-    if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
-      GRN_FREE(obj);
-    }
-    GRN_API_RETURN(GRN_SUCCESS);
-  case GRN_PTR:
-    if (obj->header.impl_flags & GRN_OBJ_OWN) {
-      if (GRN_BULK_VSIZE(obj) == sizeof(grn_obj *)) {
-        grn_obj_close(ctx, GRN_PTR_VALUE(obj));
+    {
+      obj->header.type = GRN_VOID;
+      grn_rc rc = grn_bulk_fin(ctx, obj);
+      if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
+        GRN_FREE(obj);
       }
+      GRN_API_RETURN(rc);
     }
-    obj->header.type = GRN_VOID;
-    grn_bulk_fin(ctx, obj);
-    if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
-      GRN_FREE(obj);
+  case GRN_PTR:
+    {
+      if (obj->header.impl_flags & GRN_OBJ_OWN) {
+        if (GRN_BULK_VSIZE(obj) == sizeof(grn_obj *)) {
+          grn_obj_close(ctx, GRN_PTR_VALUE(obj));
+        }
+      }
+      obj->header.type = GRN_VOID;
+      grn_rc rc = grn_bulk_fin(ctx, obj);
+      if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
+        GRN_FREE(obj);
+      }
+      GRN_API_RETURN(rc);
     }
-    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_PVECTOR:
     {
       grn_rc rc = grn_pvector_fin(ctx, obj);

--- a/lib/db.c
+++ b/lib/db.c
@@ -13159,8 +13159,8 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
       grn_proc *p = (grn_proc *)obj;
       /*
         if (obj->header.domain) {
-        grn_hash_delete(ctx, ctx->impl->qe, &obj->header.domain,
-        sizeof(grn_id), NULL);
+          grn_hash_delete(ctx, ctx->impl->qe, &obj->header.domain,
+          sizeof(grn_id), NULL);
         }
       */
       for (i = 0; i < p->nvars; i++) {

--- a/lib/db.c
+++ b/lib/db.c
@@ -13073,13 +13073,13 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_SNIP:
-    grn_rc rc = grn_snip_close(ctx, (grn_snip *)obj);
+    rc = grn_snip_close(ctx, (grn_snip *)obj);
     GRN_API_RETURN(rc);
   case GRN_STRING:
-    grn_rc rc = grn_string_close(ctx, obj);
+    rc = grn_string_close(ctx, obj);
     GRN_API_RETURN(rc);
   case GRN_HIGHLIGHTER:
-    grn_rc rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
+    rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
     GRN_API_RETURN(rc);
   case GRN_CURSOR_TABLE_PAT_KEY:
     grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
@@ -13106,28 +13106,28 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     GRN_FREE(obj);
     break;
   case GRN_DB:
-    grn_rc rc = grn_db_close(ctx, obj);
+    rc = grn_db_close(ctx, obj);
     GRN_API_RETURN(rc);
   case GRN_TABLE_PAT_KEY:
-    grn_rc rc = grn_pat_close(ctx, (grn_pat *)obj);
+    rc = grn_pat_close(ctx, (grn_pat *)obj);
     GRN_API_RETURN(rc);
   case GRN_TABLE_DAT_KEY:
-    grn_rc rc = grn_dat_close(ctx, (grn_dat *)obj);
+    rc = grn_dat_close(ctx, (grn_dat *)obj);
     GRN_API_RETURN(rc);
   case GRN_TABLE_HASH_KEY:
-    grn_rc rc = grn_hash_close(ctx, (grn_hash *)obj);
+    rc = grn_hash_close(ctx, (grn_hash *)obj);
     GRN_API_RETURN(rc);
   case GRN_TABLE_NO_KEY:
-    grn_rc rc = grn_array_close(ctx, (grn_array *)obj);
+    rc = grn_array_close(ctx, (grn_array *)obj);
     GRN_API_RETURN(rc);
   case GRN_COLUMN_VAR_SIZE:
-    grn_rc rc = grn_ja_close(ctx, (grn_ja *)obj);
+    rc = grn_ja_close(ctx, (grn_ja *)obj);
     GRN_API_RETURN(rc);
   case GRN_COLUMN_FIX_SIZE:
-    grn_rc rc = grn_ra_close(ctx, (grn_ra *)obj);
+    rc = grn_ra_close(ctx, (grn_ra *)obj);
     GRN_API_RETURN(rc);
   case GRN_COLUMN_INDEX:
-    grn_rc rc = grn_ii_close(ctx, (grn_ii *)obj);
+    rc = grn_ii_close(ctx, (grn_ii *)obj);
     GRN_API_RETURN(rc);
   case GRN_PROC:
     {
@@ -13151,7 +13151,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_EXPR:
-    grn_rc rc = grn_expr_close(ctx, obj);
+    rc = grn_expr_close(ctx, obj);
     GRN_API_RETURN(rc);
   }
   GRN_API_RETURN(GRN_SUCCESS);

--- a/lib/db.c
+++ b/lib/db.c
@@ -13179,8 +13179,9 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
       grn_rc rc = grn_expr_close(ctx, obj);
       GRN_API_RETURN(rc);
     }
+  default:
+    GRN_API_RETURN(GRN_SUCCESS);
   }
-  GRN_API_RETURN(GRN_SUCCESS);
 }
 
 void

--- a/lib/db.c
+++ b/lib/db.c
@@ -13060,7 +13060,8 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_PVECTOR:
-    GRN_API_RETURN(grn_pvector_fin(ctx, obj));
+    grn_rc rc = grn_pvector_fin(ctx, obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_ACCESSOR:
     {
@@ -13073,13 +13074,16 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_SNIP:
-    GRN_API_RETURN(grn_snip_close(ctx, (grn_snip *)obj));
+    grn_rc rc = grn_snip_close(ctx, (grn_snip *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_STRING:
-    GRN_API_RETURN(grn_string_close(ctx, obj));
+    grn_rc rc = grn_string_close(ctx, obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_HIGHLIGHTER:
-    GRN_API_RETURN(grn_highlighter_close(ctx, (grn_highlighter *)obj));
+    grn_rc rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_CURSOR_TABLE_PAT_KEY:
     grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
@@ -13106,28 +13110,36 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     GRN_FREE(obj);
     break;
   case GRN_DB:
-    GRN_API_RETURN(grn_db_close(ctx, obj));
+    grn_rc rc = grn_db_close(ctx, obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_TABLE_PAT_KEY:
-    GRN_API_RETURN(grn_pat_close(ctx, (grn_pat *)obj));
+    grn_rc rc = grn_pat_close(ctx, (grn_pat *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_TABLE_DAT_KEY:
-    GRN_API_RETURN(grn_dat_close(ctx, (grn_dat *)obj));
+    grn_rc rc = grn_dat_close(ctx, (grn_dat *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_TABLE_HASH_KEY:
-    GRN_API_RETURN(grn_hash_close(ctx, (grn_hash *)obj));
+    grn_rc rc = grn_hash_close(ctx, (grn_hash *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_TABLE_NO_KEY:
-    GRN_API_RETURN(grn_array_close(ctx, (grn_array *)obj));
+    grn_rc rc = grn_array_close(ctx, (grn_array *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_COLUMN_VAR_SIZE:
-    GRN_API_RETURN(grn_ja_close(ctx, (grn_ja *)obj));
+    grn_rc rc = grn_ja_close(ctx, (grn_ja *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_COLUMN_FIX_SIZE:
-    GRN_API_RETURN(grn_ra_close(ctx, (grn_ra *)obj));
+    grn_rc rc = grn_ra_close(ctx, (grn_ra *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_COLUMN_INDEX:
-    GRN_API_RETURN(grn_ii_close(ctx, (grn_ii *)obj));
+    grn_rc rc = grn_ii_close(ctx, (grn_ii *)obj);
+    GRN_API_RETURN(rc);
     break;
   case GRN_PROC:
     {
@@ -13151,7 +13163,8 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_EXPR:
-    GRN_API_RETURN(grn_expr_close(ctx, obj));
+    grn_rc rc = grn_expr_close(ctx, obj);
+    GRN_API_RETURN(rc);
     break;
   }
   GRN_API_RETURN(GRN_SUCCESS);

--- a/lib/db.c
+++ b/lib/db.c
@@ -13036,7 +13036,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
       GRN_FREE(obj);
     }
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_VOID:
   case GRN_BULK:
   case GRN_UVECTOR:
@@ -13046,7 +13046,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
       GRN_FREE(obj);
     }
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_PTR:
     if (obj->header.impl_flags & GRN_OBJ_OWN) {
       if (GRN_BULK_VSIZE(obj) == sizeof(grn_obj *)) {
@@ -13058,7 +13058,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
       GRN_FREE(obj);
     }
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_PVECTOR:
     {
       grn_rc rc = grn_pvector_fin(ctx, obj);
@@ -13073,7 +13073,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
         GRN_FREE(p);
       }
     }
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_SNIP:
     {
       grn_rc rc = grn_snip_close(ctx, (grn_snip *)obj);
@@ -13091,28 +13091,28 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
   case GRN_CURSOR_TABLE_PAT_KEY:
     grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_TABLE_DAT_KEY:
     grn_dat_cursor_close(ctx, (grn_dat_cursor *)obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_TABLE_HASH_KEY:
     grn_hash_cursor_close(ctx, (grn_hash_cursor *)obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_TABLE_NO_KEY:
     grn_array_cursor_close(ctx, (grn_array_cursor *)obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_COLUMN_INDEX:
     grn_index_cursor_close(ctx, obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_COLUMN_GEO_INDEX:
     grn_geo_cursor_close(ctx, obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_CURSOR_CONFIG:
     grn_config_cursor_close(ctx, (grn_config_cursor *)obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_TYPE:
     GRN_FREE(obj);
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_DB:
     {
       grn_rc rc = grn_db_close(ctx, obj);
@@ -13173,7 +13173,7 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
       }
       GRN_FREE(obj);
     }
-    break;
+    GRN_API_RETURN(GRN_SUCCESS);
   case GRN_EXPR:
     {
       grn_rc rc = grn_expr_close(ctx, obj);

--- a/lib/db.c
+++ b/lib/db.c
@@ -12974,187 +12974,185 @@ grn_table_close_columns(grn_ctx *ctx, grn_obj *table)
 grn_rc
 grn_obj_close(grn_ctx *ctx, grn_obj *obj)
 {
-  GRN_API_ENTER;
   if (!obj) {
-    GRN_API_RETURN(GRN_SUCCESS);
+    return GRN_SUCCESS;
   }
 
-  if (obj) {
-    if (GRN_DB_OBJP(obj)) {
-      grn_id id = DB_OBJ(obj)->id;
-      grn_obj *db = DB_OBJ(obj)->db;
-      grn_hook_entry entry;
+  GRN_API_ENTER;
+  if (GRN_DB_OBJP(obj)) {
+    grn_id id = DB_OBJ(obj)->id;
+    grn_obj *db = DB_OBJ(obj)->db;
+    grn_hook_entry entry;
 
-      grn_log_reference_count("%p: close: %u: %p\n", ctx, id, obj);
+    grn_log_reference_count("%p: close: %u: %p\n", ctx, id, obj);
 
-      if (id != GRN_ID_NIL && !(id & GRN_OBJ_TMP_OBJECT) && db) {
-        grn_db_remove_deferred_unref(ctx, db, id);
-        if (grn_reference_count_should_log(ctx, obj->header.type)) {
-          const char *name;
-          uint32_t name_size = 0;
-          name = _grn_table_key(ctx, db, id, &name_size);
-          GRN_LOG(ctx,
-                  GRN_LOG_REFERENCE_COUNT,
-                  "[obj][close] <%u>(<%.*s>):<%u>(<%s>)",
-                  id,
-                  name_size,
-                  name,
-                  obj->header.type,
-                  grn_obj_type_to_string(obj->header.type));
-        }
+    if (id != GRN_ID_NIL && !(id & GRN_OBJ_TMP_OBJECT) && db) {
+      grn_db_remove_deferred_unref(ctx, db, id);
+      if (grn_reference_count_should_log(ctx, obj->header.type)) {
+        const char *name;
+        uint32_t name_size = 0;
+        name = _grn_table_key(ctx, db, id, &name_size);
+        GRN_LOG(ctx,
+                GRN_LOG_REFERENCE_COUNT,
+                "[obj][close] <%u>(<%.*s>):<%u>(<%s>)",
+                id,
+                name_size,
+                name,
+                obj->header.type,
+                grn_obj_type_to_string(obj->header.type));
       }
-
-      if (grn_obj_is_table(ctx, obj) && (id & GRN_OBJ_TMP_OBJECT)) {
-        grn_table_close_columns(ctx, obj);
-      }
-      if (DB_OBJ(obj)->finalizer) {
-        DB_OBJ(obj)->finalizer(ctx, 1, &obj, &DB_OBJ(obj)->user_data);
-      }
-      if (DB_OBJ(obj)->source) {
-        GRN_FREE(DB_OBJ(obj)->source);
-      }
-      for (entry = 0; entry < GRN_N_HOOK_ENTRIES; entry++) {
-        grn_hook_free(ctx, DB_OBJ(obj)->hooks[entry]);
-      }
-      if (id & GRN_OBJ_TMP_OBJECT) {
-        grn_obj_clear_option_values(ctx, obj);
-        if (grn_obj_is_table(ctx, obj)) {
-          grn_ctx_impl_columns_cache_delete(ctx, id);
-        } else if (grn_obj_is_column(ctx, obj)) {
-          grn_ctx_impl_columns_cache_delete(ctx, obj->header.domain);
-        }
-      }
-      grn_obj_delete_by_id(ctx, DB_OBJ(obj)->db, id, GRN_FALSE);
     }
-    switch (obj->header.type) {
-    case GRN_VECTOR:
-      if (obj->u.v.body && !(obj->header.impl_flags & GRN_OBJ_REFER)) {
-        grn_obj_close(ctx, obj->u.v.body);
+
+    if (grn_obj_is_table(ctx, obj) && (id & GRN_OBJ_TMP_OBJECT)) {
+      grn_table_close_columns(ctx, obj);
+    }
+    if (DB_OBJ(obj)->finalizer) {
+      DB_OBJ(obj)->finalizer(ctx, 1, &obj, &DB_OBJ(obj)->user_data);
+    }
+    if (DB_OBJ(obj)->source) {
+      GRN_FREE(DB_OBJ(obj)->source);
+    }
+    for (entry = 0; entry < GRN_N_HOOK_ENTRIES; entry++) {
+      grn_hook_free(ctx, DB_OBJ(obj)->hooks[entry]);
+    }
+    if (id & GRN_OBJ_TMP_OBJECT) {
+      grn_obj_clear_option_values(ctx, obj);
+      if (grn_obj_is_table(ctx, obj)) {
+        grn_ctx_impl_columns_cache_delete(ctx, id);
+      } else if (grn_obj_is_column(ctx, obj)) {
+        grn_ctx_impl_columns_cache_delete(ctx, obj->header.domain);
       }
-      if (obj->u.v.sections) {
-        GRN_FREE(obj->u.v.sections);
-      }
-      if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
-        GRN_FREE(obj);
-      }
-      break;
-    case GRN_VOID:
-    case GRN_BULK:
-    case GRN_UVECTOR:
-    case GRN_MSG:
-      obj->header.type = GRN_VOID;
-      grn_bulk_fin(ctx, obj);
-      if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
-        GRN_FREE(obj);
-      }
-      break;
-    case GRN_PTR:
-      if (obj->header.impl_flags & GRN_OBJ_OWN) {
-        if (GRN_BULK_VSIZE(obj) == sizeof(grn_obj *)) {
-          grn_obj_close(ctx, GRN_PTR_VALUE(obj));
-        }
-      }
-      obj->header.type = GRN_VOID;
-      grn_bulk_fin(ctx, obj);
-      if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
-        GRN_FREE(obj);
-      }
-      break;
-    case GRN_PVECTOR:
-      GRN_API_RETURN(grn_pvector_fin(ctx, obj));
-      break;
-    case GRN_ACCESSOR:
-      {
-        grn_accessor *p, *n;
-        for (p = (grn_accessor *)obj; p; p = n) {
-          grn_obj_unref(ctx, p->obj);
-          n = p->next;
-          GRN_FREE(p);
-        }
-      }
-      break;
-    case GRN_SNIP:
-      GRN_API_RETURN(grn_snip_close(ctx, (grn_snip *)obj));
-      break;
-    case GRN_STRING:
-      GRN_API_RETURN(grn_string_close(ctx, obj));
-      break;
-    case GRN_HIGHLIGHTER:
-      GRN_API_RETURN(grn_highlighter_close(ctx, (grn_highlighter *)obj));
-      break;
-    case GRN_CURSOR_TABLE_PAT_KEY:
-      grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
-      break;
-    case GRN_CURSOR_TABLE_DAT_KEY:
-      grn_dat_cursor_close(ctx, (grn_dat_cursor *)obj);
-      break;
-    case GRN_CURSOR_TABLE_HASH_KEY:
-      grn_hash_cursor_close(ctx, (grn_hash_cursor *)obj);
-      break;
-    case GRN_CURSOR_TABLE_NO_KEY:
-      grn_array_cursor_close(ctx, (grn_array_cursor *)obj);
-      break;
-    case GRN_CURSOR_COLUMN_INDEX:
-      grn_index_cursor_close(ctx, obj);
-      break;
-    case GRN_CURSOR_COLUMN_GEO_INDEX:
-      grn_geo_cursor_close(ctx, obj);
-      break;
-    case GRN_CURSOR_CONFIG:
-      grn_config_cursor_close(ctx, (grn_config_cursor *)obj);
-      break;
-    case GRN_TYPE:
+    }
+    grn_obj_delete_by_id(ctx, DB_OBJ(obj)->db, id, GRN_FALSE);
+  }
+  switch (obj->header.type) {
+  case GRN_VECTOR:
+    if (obj->u.v.body && !(obj->header.impl_flags & GRN_OBJ_REFER)) {
+      grn_obj_close(ctx, obj->u.v.body);
+    }
+    if (obj->u.v.sections) {
+      GRN_FREE(obj->u.v.sections);
+    }
+    if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
       GRN_FREE(obj);
-      break;
-    case GRN_DB:
-      GRN_API_RETURN(grn_db_close(ctx, obj));
-      break;
-    case GRN_TABLE_PAT_KEY:
-      GRN_API_RETURN(grn_pat_close(ctx, (grn_pat *)obj));
-      break;
-    case GRN_TABLE_DAT_KEY:
-      GRN_API_RETURN(grn_dat_close(ctx, (grn_dat *)obj));
-      break;
-    case GRN_TABLE_HASH_KEY:
-      GRN_API_RETURN(grn_hash_close(ctx, (grn_hash *)obj));
-      break;
-    case GRN_TABLE_NO_KEY:
-      GRN_API_RETURN(grn_array_close(ctx, (grn_array *)obj));
-      break;
-    case GRN_COLUMN_VAR_SIZE:
-      GRN_API_RETURN(grn_ja_close(ctx, (grn_ja *)obj));
-      break;
-    case GRN_COLUMN_FIX_SIZE:
-      GRN_API_RETURN(grn_ra_close(ctx, (grn_ra *)obj));
-      break;
-    case GRN_COLUMN_INDEX:
-      GRN_API_RETURN(grn_ii_close(ctx, (grn_ii *)obj));
-      break;
-    case GRN_PROC:
-      {
-        uint32_t i;
-        grn_proc *p = (grn_proc *)obj;
-        /*
+    }
+    break;
+  case GRN_VOID:
+  case GRN_BULK:
+  case GRN_UVECTOR:
+  case GRN_MSG:
+    obj->header.type = GRN_VOID;
+    grn_bulk_fin(ctx, obj);
+    if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
+      GRN_FREE(obj);
+    }
+    break;
+  case GRN_PTR:
+    if (obj->header.impl_flags & GRN_OBJ_OWN) {
+      if (GRN_BULK_VSIZE(obj) == sizeof(grn_obj *)) {
+        grn_obj_close(ctx, GRN_PTR_VALUE(obj));
+      }
+    }
+    obj->header.type = GRN_VOID;
+    grn_bulk_fin(ctx, obj);
+    if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
+      GRN_FREE(obj);
+    }
+    break;
+  case GRN_PVECTOR:
+    GRN_API_RETURN(grn_pvector_fin(ctx, obj));
+    break;
+  case GRN_ACCESSOR:
+    {
+      grn_accessor *p, *n;
+      for (p = (grn_accessor *)obj; p; p = n) {
+        grn_obj_unref(ctx, p->obj);
+        n = p->next;
+        GRN_FREE(p);
+      }
+    }
+    break;
+  case GRN_SNIP:
+    GRN_API_RETURN(grn_snip_close(ctx, (grn_snip *)obj));
+    break;
+  case GRN_STRING:
+    GRN_API_RETURN(grn_string_close(ctx, obj));
+    break;
+  case GRN_HIGHLIGHTER:
+    GRN_API_RETURN(grn_highlighter_close(ctx, (grn_highlighter *)obj));
+    break;
+  case GRN_CURSOR_TABLE_PAT_KEY:
+    grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
+    break;
+  case GRN_CURSOR_TABLE_DAT_KEY:
+    grn_dat_cursor_close(ctx, (grn_dat_cursor *)obj);
+    break;
+  case GRN_CURSOR_TABLE_HASH_KEY:
+    grn_hash_cursor_close(ctx, (grn_hash_cursor *)obj);
+    break;
+  case GRN_CURSOR_TABLE_NO_KEY:
+    grn_array_cursor_close(ctx, (grn_array_cursor *)obj);
+    break;
+  case GRN_CURSOR_COLUMN_INDEX:
+    grn_index_cursor_close(ctx, obj);
+    break;
+  case GRN_CURSOR_COLUMN_GEO_INDEX:
+    grn_geo_cursor_close(ctx, obj);
+    break;
+  case GRN_CURSOR_CONFIG:
+    grn_config_cursor_close(ctx, (grn_config_cursor *)obj);
+    break;
+  case GRN_TYPE:
+    GRN_FREE(obj);
+    break;
+  case GRN_DB:
+    GRN_API_RETURN(grn_db_close(ctx, obj));
+    break;
+  case GRN_TABLE_PAT_KEY:
+    GRN_API_RETURN(grn_pat_close(ctx, (grn_pat *)obj));
+    break;
+  case GRN_TABLE_DAT_KEY:
+    GRN_API_RETURN(grn_dat_close(ctx, (grn_dat *)obj));
+    break;
+  case GRN_TABLE_HASH_KEY:
+    GRN_API_RETURN(grn_hash_close(ctx, (grn_hash *)obj));
+    break;
+  case GRN_TABLE_NO_KEY:
+    GRN_API_RETURN(grn_array_close(ctx, (grn_array *)obj));
+    break;
+  case GRN_COLUMN_VAR_SIZE:
+    GRN_API_RETURN(grn_ja_close(ctx, (grn_ja *)obj));
+    break;
+  case GRN_COLUMN_FIX_SIZE:
+    GRN_API_RETURN(grn_ra_close(ctx, (grn_ra *)obj));
+    break;
+  case GRN_COLUMN_INDEX:
+    GRN_API_RETURN(grn_ii_close(ctx, (grn_ii *)obj));
+    break;
+  case GRN_PROC:
+    {
+      uint32_t i;
+      grn_proc *p = (grn_proc *)obj;
+      /*
         if (obj->header.domain) {
-          grn_hash_delete(ctx, ctx->impl->qe, &obj->header.domain,
+        grn_hash_delete(ctx, ctx->impl->qe, &obj->header.domain,
         sizeof(grn_id), NULL);
         }
-        */
-        for (i = 0; i < p->nvars; i++) {
-          grn_obj_close(ctx, &p->vars[i].value);
-        }
-        GRN_REALLOC(p->vars, 0);
-        grn_obj_close(ctx, &p->name_buf);
-        if (p->obj.range != GRN_ID_NIL) {
-          grn_plugin_close(ctx, p->obj.range);
-        }
-        GRN_FREE(obj);
+      */
+      for (i = 0; i < p->nvars; i++) {
+        grn_obj_close(ctx, &p->vars[i].value);
       }
-      break;
-    case GRN_EXPR:
-      GRN_API_RETURN(grn_expr_close(ctx, obj));
-      break;
+      GRN_REALLOC(p->vars, 0);
+      grn_obj_close(ctx, &p->name_buf);
+      if (p->obj.range != GRN_ID_NIL) {
+        grn_plugin_close(ctx, p->obj.range);
+      }
+      GRN_FREE(obj);
     }
+    break;
+  case GRN_EXPR:
+    GRN_API_RETURN(grn_expr_close(ctx, obj));
+    break;
   }
   GRN_API_RETURN(GRN_SUCCESS);
 }

--- a/lib/db.c
+++ b/lib/db.c
@@ -12974,8 +12974,11 @@ grn_table_close_columns(grn_ctx *ctx, grn_obj *table)
 grn_rc
 grn_obj_close(grn_ctx *ctx, grn_obj *obj)
 {
-  grn_rc rc = GRN_INVALID_ARGUMENT;
   GRN_API_ENTER;
+  if (!obj) {
+    GRN_API_RETURN(GRN_SUCCESS);
+  }
+
   if (obj) {
     if (GRN_DB_OBJP(obj)) {
       grn_id id = DB_OBJ(obj)->id;
@@ -13034,14 +13037,13 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
       if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
         GRN_FREE(obj);
       }
-      rc = GRN_SUCCESS;
       break;
     case GRN_VOID:
     case GRN_BULK:
     case GRN_UVECTOR:
     case GRN_MSG:
       obj->header.type = GRN_VOID;
-      rc = grn_bulk_fin(ctx, obj);
+      grn_bulk_fin(ctx, obj);
       if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
         GRN_FREE(obj);
       }
@@ -13053,13 +13055,13 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
         }
       }
       obj->header.type = GRN_VOID;
-      rc = grn_bulk_fin(ctx, obj);
+      grn_bulk_fin(ctx, obj);
       if (obj->header.impl_flags & GRN_OBJ_ALLOCATED) {
         GRN_FREE(obj);
       }
       break;
     case GRN_PVECTOR:
-      rc = grn_pvector_fin(ctx, obj);
+      GRN_API_RETURN(grn_pvector_fin(ctx, obj));
       break;
     case GRN_ACCESSOR:
       {
@@ -13070,16 +13072,15 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
           GRN_FREE(p);
         }
       }
-      rc = GRN_SUCCESS;
       break;
     case GRN_SNIP:
-      rc = grn_snip_close(ctx, (grn_snip *)obj);
+      GRN_API_RETURN(grn_snip_close(ctx, (grn_snip *)obj));
       break;
     case GRN_STRING:
-      rc = grn_string_close(ctx, obj);
+      GRN_API_RETURN(grn_string_close(ctx, obj));
       break;
     case GRN_HIGHLIGHTER:
-      rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
+      GRN_API_RETURN(grn_highlighter_close(ctx, (grn_highlighter *)obj));
       break;
     case GRN_CURSOR_TABLE_PAT_KEY:
       grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
@@ -13104,31 +13105,30 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
       break;
     case GRN_TYPE:
       GRN_FREE(obj);
-      rc = GRN_SUCCESS;
       break;
     case GRN_DB:
-      rc = grn_db_close(ctx, obj);
+      GRN_API_RETURN(grn_db_close(ctx, obj));
       break;
     case GRN_TABLE_PAT_KEY:
-      rc = grn_pat_close(ctx, (grn_pat *)obj);
+      GRN_API_RETURN(grn_pat_close(ctx, (grn_pat *)obj));
       break;
     case GRN_TABLE_DAT_KEY:
-      rc = grn_dat_close(ctx, (grn_dat *)obj);
+      GRN_API_RETURN(grn_dat_close(ctx, (grn_dat *)obj));
       break;
     case GRN_TABLE_HASH_KEY:
-      rc = grn_hash_close(ctx, (grn_hash *)obj);
+      GRN_API_RETURN(grn_hash_close(ctx, (grn_hash *)obj));
       break;
     case GRN_TABLE_NO_KEY:
-      rc = grn_array_close(ctx, (grn_array *)obj);
+      GRN_API_RETURN(grn_array_close(ctx, (grn_array *)obj));
       break;
     case GRN_COLUMN_VAR_SIZE:
-      rc = grn_ja_close(ctx, (grn_ja *)obj);
+      GRN_API_RETURN(grn_ja_close(ctx, (grn_ja *)obj));
       break;
     case GRN_COLUMN_FIX_SIZE:
-      rc = grn_ra_close(ctx, (grn_ra *)obj);
+      GRN_API_RETURN(grn_ra_close(ctx, (grn_ra *)obj));
       break;
     case GRN_COLUMN_INDEX:
-      rc = grn_ii_close(ctx, (grn_ii *)obj);
+      GRN_API_RETURN(grn_ii_close(ctx, (grn_ii *)obj));
       break;
     case GRN_PROC:
       {
@@ -13149,15 +13149,14 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
           grn_plugin_close(ctx, p->obj.range);
         }
         GRN_FREE(obj);
-        rc = GRN_SUCCESS;
       }
       break;
     case GRN_EXPR:
-      rc = grn_expr_close(ctx, obj);
+      GRN_API_RETURN(grn_expr_close(ctx, obj));
       break;
     }
   }
-  GRN_API_RETURN(rc);
+  GRN_API_RETURN(GRN_SUCCESS);
 }
 
 void

--- a/lib/db.c
+++ b/lib/db.c
@@ -13060,8 +13060,10 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_PVECTOR:
-    grn_rc rc = grn_pvector_fin(ctx, obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_pvector_fin(ctx, obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_ACCESSOR:
     {
       grn_accessor *p, *n;
@@ -13073,14 +13075,20 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_SNIP:
-    rc = grn_snip_close(ctx, (grn_snip *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_snip_close(ctx, (grn_snip *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_STRING:
-    rc = grn_string_close(ctx, obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_string_close(ctx, obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_HIGHLIGHTER:
-    rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_highlighter_close(ctx, (grn_highlighter *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_CURSOR_TABLE_PAT_KEY:
     grn_pat_cursor_close(ctx, (grn_pat_cursor *)obj);
     break;
@@ -13106,29 +13114,45 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     GRN_FREE(obj);
     break;
   case GRN_DB:
-    rc = grn_db_close(ctx, obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_db_close(ctx, obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_TABLE_PAT_KEY:
-    rc = grn_pat_close(ctx, (grn_pat *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_pat_close(ctx, (grn_pat *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_TABLE_DAT_KEY:
-    rc = grn_dat_close(ctx, (grn_dat *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_dat_close(ctx, (grn_dat *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_TABLE_HASH_KEY:
-    rc = grn_hash_close(ctx, (grn_hash *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_hash_close(ctx, (grn_hash *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_TABLE_NO_KEY:
-    rc = grn_array_close(ctx, (grn_array *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_array_close(ctx, (grn_array *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_COLUMN_VAR_SIZE:
-    rc = grn_ja_close(ctx, (grn_ja *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_ja_close(ctx, (grn_ja *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_COLUMN_FIX_SIZE:
-    rc = grn_ra_close(ctx, (grn_ra *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_ra_close(ctx, (grn_ra *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_COLUMN_INDEX:
-    rc = grn_ii_close(ctx, (grn_ii *)obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_ii_close(ctx, (grn_ii *)obj);
+      GRN_API_RETURN(rc);
+    }
   case GRN_PROC:
     {
       uint32_t i;
@@ -13151,8 +13175,10 @@ grn_obj_close(grn_ctx *ctx, grn_obj *obj)
     }
     break;
   case GRN_EXPR:
-    rc = grn_expr_close(ctx, obj);
-    GRN_API_RETURN(rc);
+    {
+      grn_rc rc = grn_expr_close(ctx, obj);
+      GRN_API_RETURN(rc);
+    }
   }
   GRN_API_RETURN(GRN_SUCCESS);
 }

--- a/test/unit/util/test-snip.c
+++ b/test/unit/util/test-snip.c
@@ -781,7 +781,7 @@ test_html_mapping_escape(void)
 void
 test_close_with_null(void)
 {
-  grn_test_assert_equal_rc(GRN_INVALID_ARGUMENT, grn_obj_close(&context, NULL));
+  grn_test_assert_equal_rc(GRN_SUCCESS, grn_obj_close(&context, NULL));
 }
 
 void


### PR DESCRIPTION
Generally, functions for release resource do nothing when NULL is specified like "free(NULL)".

This changes API but this doesn't break backward compatibility.
Because no code exist that use the return value of `grn_obj_close()` when we specify `grn_obj_close(ctx, NULL)` as below.

---

Following functions use the return value of `grn_obj_close()`.

```
./lib/com.c:  if (ctx == msg->ctx) { return grn_obj_close(ctx, obj); }
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  rc = grn_obj_close(ctx, obj);
./lib/db.c:  return grn_obj_close(ctx, obj); 
```

---

`grn_obj_close()` is used in `grn_msg_close()`.
However, the return value of `grn_msg_close()` uses no one.

```
% grep -r grn_msg_close ./**/*.c
./lib/com.c:grn_msg_close(grn_ctx *ctx, grn_obj *obj)
./lib/com.c:    grn_msg_close(ctx, msg);
./lib/com.c:    grn_msg_close(ctx, msg);
./src/grnslap.c:  grn_msg_close(ctx, msg);
./src/groonga.c:        grn_msg_close(&edge->ctx, msg);
./src/groonga.c:        grn_msg_close(ctx, msg);
./src/groonga.c:        grn_msg_close(&edge->ctx, obj);
./src/groonga.c:        grn_msg_close(ctx, obj);
./src/groonga.c:  grn_msg_close(ctx, (grn_obj *)msg);
./src/groonga.c:    grn_msg_close(ctx, msg);
./src/groonga.c:          grn_msg_close(ctx, msg);
./src/groonga.c:          grn_msg_close(ctx, msg);
./src/groonga.c:    grn_msg_close(ctx, msg);
./src/groonga.c:      grn_msg_close(ctx, msg);
```

---

`grn_obj_close()` is used in `grn_obj_remove_other()`.
`grn_obj_remove_other()` is used in `grn_obj_remove_internal()`.

`grn_obj_remove_internal()` is used as below.

```
./lib/db.c:      rc = grn_obj_remove_internal(ctx, target, flags);
./lib/db.c:      rc = grn_obj_remove_internal(ctx, column, flags);
./lib/db.c:        rc = grn_obj_remove_internal(ctx, obj, 0);
./lib/db.c:          rc = grn_obj_remove_internal(ctx, obj, 0);
./lib/db.c:          rc = grn_obj_remove_internal(ctx, obj, 0);
./lib/db.c:        rc = grn_obj_remove_internal(ctx, obj, 0);
./lib/db.c:          rc = grn_obj_remove_internal(ctx, object, flags);
./lib/db.c:          rc = grn_obj_remove_internal(ctx, object, flags);
./lib/db.c:      rc = grn_obj_remove_internal(ctx, obj, flags);
./lib/db.c:    rc = grn_obj_remove_internal(ctx, obj, flags);
./lib/db.c:      rc = grn_obj_remove_internal(ctx, obj, flags);
```

---

`grn_obj_remove_internal()` is used in `remove_index()`.
However, `grn_obj_remove_internal()` is not called when `target` is `NULL` as below.

```c
    if (!target) { ... }     } else if (target->header.type == GRN_COLUMN_INDEX) {
      // TODO: multicolumn  MULTI_COLUMN_INDEXP
      rc = grn_obj_remove_internal(ctx, target, flags); }
```
So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `remove_columns_raw()`
However, `grn_obj_remove_internal()` is not called when `column` is `NULL` as below.

```c
    if (column) {
      rc = grn_obj_remove_internal(ctx, column, flags);
      if (rc != GRN_SUCCESS) {
        grn_obj_unlink(ctx, column);
        break;
      }
    } ...
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `grn_obj_remove_db_index_columns()`.
However, `grn_obj_remove_internal()` is not called when `obj` is `NULL` as below.

```c
      if (obj && obj->header.type == GRN_COLUMN_INDEX) {
        rc = grn_obj_remove_internal(ctx, obj, 0);
        ...
      }
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `grn_obj_remove_db_reference_columns()`.
However, `grn_obj_remove_internal()` is not called when `obj` is `NULL` as below.

```c
    while ((id = grn_table_cursor_next_inline(ctx, cur)) != GRN_ID_NIL) {
      grn_obj *obj = grn_ctx_at(ctx, id);
      grn_obj *range = NULL;

      if (!obj) {
        continue;
      }

...

        switch (range->header.type) {
        case GRN_TABLE_NO_KEY:
        case GRN_TABLE_HASH_KEY:
        case GRN_TABLE_PAT_KEY:
        case GRN_TABLE_DAT_KEY:
          rc = grn_obj_remove_internal(ctx, obj, 0);
          break;
        }
...
    }
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `grn_obj_remove_db_reference_tables()`.
However, `grn_obj_remove_internal()` is not called when `obj` is `NULL` as below.

```c
    while ((id = grn_table_cursor_next_inline(ctx, cur)) != GRN_ID_NIL) {
      grn_obj *obj = grn_ctx_at(ctx, id);
      grn_obj *domain = NULL;

      if (!obj) {
        continue;
      }

...

        switch (domain->header.type) {
        case GRN_TABLE_NO_KEY:
        case GRN_TABLE_HASH_KEY:
        case GRN_TABLE_PAT_KEY:
        case GRN_TABLE_DAT_KEY:
          rc = grn_obj_remove_internal(ctx, obj, 0);
          break;
        }

...

    }
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `grn_obj_remove_db_all_tables()`
However, `grn_obj_remove_internal()` is not called when `obj` is `NULL` as below.

```c
    while ((id = grn_table_cursor_next_inline(ctx, cur)) != GRN_ID_NIL) {
      grn_obj *obj = grn_ctx_at(ctx, id);

      if (!obj) {
        continue;
      }

...

      switch (obj->header.type) {
      case GRN_TABLE_NO_KEY:
      case GRN_TABLE_HASH_KEY:
      case GRN_TABLE_PAT_KEY:
      case GRN_TABLE_DAT_KEY:
        rc = grn_obj_remove_internal(ctx, obj, 0);
        break;
      }

...

    }
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `remove_reference_tables_raw()`.
However, `grn_obj_remove_internal()` is not called when `object` is `NULL` as below.

```c
      object = grn_ctx_at(ctx, id);
      if (!object) {

        ...

      switch (object->header.type) {
      case GRN_TABLE_HASH_KEY:
      case GRN_TABLE_PAT_KEY:
      case GRN_TABLE_DAT_KEY:
        if (DB_OBJ(object)->id == table_id) {
          break;
        }

        if (object->header.domain == table_id) {
          rc = grn_obj_remove_internal(ctx, object, flags);
          is_removed = (grn_table_at(ctx, db, id) == GRN_ID_NIL);
        }
        break;

      ...

      case GRN_COLUMN_VAR_SIZE:
      case GRN_COLUMN_FIX_SIZE:
        if (object->header.domain == table_id) {
          break;
        }
        if (DB_OBJ(object)->range == table_id) {
          rc = grn_obj_remove_internal(ctx, object, flags);
          is_removed = (grn_table_at(ctx, db, id) == GRN_ID_NIL);
        }
        break;

      ...
    }
```

So, this changes API does not affect. 

---

`grn_obj_remove_internal()` is used in `grn_ctx_remove_by_id_internal()`.
However, `grn_obj_remove_internal()` is not called when `obj` is `NULL` as below.

```c
  if (obj) {
    grn_rc rc;
    if (is_top_level) {
      rc = grn_obj_remove_flags(ctx, obj, flags);
    } else {
      rc = grn_obj_remove_internal(ctx, obj, flags);
    }
    ...
  }
```

So, this changes API does not affect. 

---

`grn_obj_remove_flags()` is used as below.

```
./lib/db.c:  return grn_obj_remove_flags(ctx, obj, 0);
./lib/db.c:  return grn_obj_remove_flags(ctx, obj, GRN_OBJ_REMOVE_DEPENDENT);
./lib/db.c:    grn_rc rc = grn_obj_remove_flags(ctx, obj, flags);
./lib/db.c:      rc = grn_obj_remove_flags(ctx, obj, flags);
```

`grn_obj_remove_flags()` is used in `grn_ctx_remove_by_id_internal()`.
However, `grn_obj_remove_flags()` is not called when `obj` is `NULL` as below.

```c
  if (obj) {
    grn_rc rc;
    if (is_top_level) {
      rc = grn_obj_remove_flags(ctx, obj, flags);
    } else {
      rc = grn_obj_remove_internal(ctx, obj, flags);
    }
    ...
  }
```

So, this changes API does not affect. 

---

`grn_obj_remove_flags()` is used in `grn_obj_remove_dependent()`.
However, the return value of `grn_obj_remove_dependent()` uses no one.

```
% grep -r grn_obj_remove_dependent ./**/*.c
./lib/db.c:grn_obj_remove_dependent(grn_ctx *ctx, grn_obj *obj)
```

---

`grn_obj_remove_flags()` is used in `grn_ctx_remove()`.
However, `grn_obj_remove_flags()` is not called when `obj` is `NULL` as below.

```c
  grn_obj *obj = grn_ctx_get(ctx, name, name_size);
  if (obj) {
    grn_rc rc = grn_obj_remove_flags(ctx, obj, flags);
    if (rc == GRN_SUCCESS) {
      GRN_API_RETURN(rc);
    }
    if (!(flags & GRN_OBJ_REMOVE_ENSURE)) {
      GRN_API_RETURN(rc);
    }
  } ...
```

So, this changes API does not affect. 

---

`grn_obj_remove_flags()` is used in `grn_ctx_remove_by_id_internal()`
However, `grn_obj_remove_flags()` is not called when `obj` is `NULL` as below.

```c
  grn_obj *obj = grn_ctx_at(ctx, id);
  if (obj) {
    grn_rc rc;
    if (is_top_level) {
      rc = grn_obj_remove_flags(ctx, obj, flags);
    } else {
      rc = grn_obj_remove_internal(ctx, obj, flags);
    }
```

So, this changes API does not affect. 