### PR TITLE
docs: api/grn_table: move grn_table_get_key() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -45,21 +45,6 @@ msgstr ""
 msgid "検索keyを指定します。"
 msgstr ""
 
-msgid "tableのIDに対応するレコードのkeyを取得します。"
-msgstr ""
-
-msgid "対応するレコードが存在する場合はkey長を返します。見つからない場合は0を返します。対応するキーの検索に成功し、またbuf_sizeの長さがkey長以上であった場合は、keybufに該当するkeyをコピーします。"
-msgstr ""
-
-msgid "対象レコードのIDを指定します。"
-msgstr ""
-
-msgid "keyを格納するバッファ(呼出側で準備する)を指定します。"
-msgstr ""
-
-msgid "keybufのサイズ(byte長)を指定します。"
-msgstr ""
-
 msgid "tableのレコードを特定の条件でグループ化します。"
 msgstr ""
 

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -25,17 +25,6 @@ Reference
    :param table: 対象tableを指定します。
    :param key: 検索keyを指定します。
 
-.. c:function:: int grn_table_get_key(grn_ctx *ctx, grn_obj *table, grn_id id, void *keybuf, int buf_size)
-
-   tableのIDに対応するレコードのkeyを取得します。
-
-   対応するレコードが存在する場合はkey長を返します。見つからない場合は0を返します。対応するキーの検索に成功し、またbuf_sizeの長さがkey長以上であった場合は、keybufに該当するkeyをコピーします。
-
-   :param table: 対象tableを指定します。
-   :param id: 対象レコードのIDを指定します。
-   :param keybuf: keyを格納するバッファ(呼出側で準備する)を指定します。
-   :param buf_size: keybufのサイズ(byte長)を指定します。
-
 .. c:type:: grn_table_sort_key
 
    TODO...

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -145,6 +145,19 @@ grn_table_lcp_search(grn_ctx *ctx,
                      grn_obj *table,
                      const void *key,
                      unsigned int key_size);
+/**
+ * \brief Get the key assigned to the ID.
+ *        If the size of the key found is larger than `buf_size`, it is not
+ *        stored in `keybuf`.
+ *
+ * \param ctx The context object
+ * \param table The table
+ * \param id: The ID to be found
+ * \param keybuf: Buffer to store the record key.
+ * \param buf_size: Size of `keybuf` in bytes.
+ *
+ * \return key size of the record on success, `0` on not existed.
+ */
 GRN_API int
 grn_table_get_key(
   grn_ctx *ctx, grn_obj *table, grn_id id, void *keybuf, int buf_size);

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -150,13 +150,13 @@ grn_table_lcp_search(grn_ctx *ctx,
  *        If the size of the key found is larger than `buf_size`, it is not
  *        stored in `keybuf`.
  *
- * \param ctx The context object
- * \param table The table
- * \param id: The ID to be found
- * \param keybuf: Buffer to store the record key.
- * \param buf_size: Size of `keybuf` in bytes.
+ * \param ctx The context object.
+ * \param table The table.
+ * \param id The ID to be found.
+ * \param keybuf Buffer to store the record key.
+ * \param buf_size Size of `keybuf` in bytes.
  *
- * \return key size of the record on success, `0` on not existed.
+ * \return Key size of the record on success, `0` on not existed.
  */
 GRN_API int
 grn_table_get_key(


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.