### PR TITLE
docs: api/grn_obj: move grn_obj_path() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -42,16 +42,13 @@ msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 msgid "objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
-msgid "objに対応するファイルパスを返します。一時objectならNULLを返します。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
-
 msgid "objの名前の長さを返します。無名objectなら0を返します。"
 msgstr ""
 
 msgid "名前付きのobjectであり、buf_sizeの長さが名前の長以上であった場合は、namebufに該当する名前をコピーします。"
+msgstr ""
+
+msgid "対象objectを指定します。"
 msgstr ""
 
 msgid "名前を格納するバッファ（呼出側で準備する）を指定します。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -27,12 +27,6 @@ Reference
 
    objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。
 
-.. c:function:: const char *grn_obj_path(grn_ctx *ctx, grn_obj *obj)
-
-   objに対応するファイルパスを返します。一時objectならNULLを返します。
-
-   :param obj: 対象objectを指定します。
-
 .. c:function:: int grn_obj_name(grn_ctx *ctx, grn_obj *obj, char *namebuf, int buf_size)
 
    objの名前の長さを返します。無名objectなら0を返します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1190,14 +1190,12 @@ grn_obj_set_finalizer(grn_ctx *ctx, grn_obj *obj, grn_proc_func *func);
  * \brief Return the file path associated with an object.
  *
  *        Return the file path associated with the specified object (`obj`).
- *        If the object is temporary or has no associated file path,
- *        it returns `NULL`.
+ *        If the object is temporary, it returns `NULL`.
  *
  * \param ctx The context object.
  * \param obj The object whose file path is to be retrieved.
  *
- * \return The file path on success, `NULL` if the object
- *         is temporary or has no associated file path.
+ * \return The file path on success, `NULL` if the object is temporary.
  */
 GRN_API const char *
 grn_obj_path(grn_ctx *ctx, grn_obj *obj);

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1189,9 +1189,6 @@ grn_obj_set_finalizer(grn_ctx *ctx, grn_obj *obj, grn_proc_func *func);
 /**
  * \brief Return the file path associated with an object.
  *
- *        Return the file path associated with the specified object (`obj`).
- *        If the object is temporary, it returns `NULL`.
- *
  * \param ctx The context object.
  * \param obj The object whose file path is to be retrieved.
  *

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1186,7 +1186,19 @@ grn_obj_user_data(grn_ctx *ctx, grn_obj *obj);
 
 GRN_API grn_rc
 grn_obj_set_finalizer(grn_ctx *ctx, grn_obj *obj, grn_proc_func *func);
-
+/**
+ * \brief Return the file path associated with an object.
+ *
+ *        Return the file path associated with the specified object (`obj`).
+ *        If the object is temporary or has no associated file path,
+ *        it returns `NULL`.
+ *
+ * \param ctx The context object.
+ * \param obj The object whose file path is to be retrieved.
+ *
+ * \return The file path on success, `NULL` if the object
+ *         is temporary or has no associated file path.
+ */
 GRN_API const char *
 grn_obj_path(grn_ctx *ctx, grn_obj *obj);
 GRN_API int


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.