### PR TITLE
docs: api/grn_obj: move grn_obj_name() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -42,22 +42,10 @@ msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 msgid "objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
-msgid "objの名前の長さを返します。無名objectなら0を返します。"
-msgstr ""
-
-msgid "名前付きのobjectであり、buf_sizeの長さが名前の長以上であった場合は、namebufに該当する名前をコピーします。"
+msgid "objパラメータのとる値の範囲を表わしているオブジェクトのIDを返します。例えば、:c:type:`grn_builtin_type` にある ``GRN_DB_INT`` などを返します。"
 msgstr ""
 
 msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "名前を格納するバッファ（呼出側で準備する）を指定します。"
-msgstr ""
-
-msgid "namebufのサイズ（byte長）を指定します。"
-msgstr ""
-
-msgid "objパラメータのとる値の範囲を表わしているオブジェクトのIDを返します。例えば、:c:type:`grn_builtin_type` にある ``GRN_DB_INT`` などを返します。"
 msgstr ""
 
 msgid "objの占有するメモリのうち、可能な領域をthresholdを指標として解放します。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -27,16 +27,6 @@ Reference
 
    objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。
 
-.. c:function:: int grn_obj_name(grn_ctx *ctx, grn_obj *obj, char *namebuf, int buf_size)
-
-   objの名前の長さを返します。無名objectなら0を返します。
-
-   名前付きのobjectであり、buf_sizeの長さが名前の長以上であった場合は、namebufに該当する名前をコピーします。
-
-   :param obj: 対象objectを指定します。
-   :param namebuf: 名前を格納するバッファ（呼出側で準備する）を指定します。
-   :param buf_size: namebufのサイズ（byte長）を指定します。
-
 .. c:function:: grn_id grn_obj_get_range(grn_ctx *ctx, grn_obj *obj)
 
    objパラメータのとる値の範囲を表わしているオブジェクトのIDを返します。例えば、:c:type:`grn_builtin_type` にある ``GRN_DB_INT`` などを返します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1197,7 +1197,7 @@ grn_obj_set_finalizer(grn_ctx *ctx, grn_obj *obj, grn_proc_func *func);
 GRN_API const char *
 grn_obj_path(grn_ctx *ctx, grn_obj *obj);
 /**
- * \brief Return the length of an object's name.
+ * \brief Return an object's name by storing it in `namebuf`.
  *
  *        If the object has a name and `buf_size` is greater than or equal to
  *        the length of the name, the name is copied into `namebuf`.
@@ -1210,8 +1210,7 @@ grn_obj_path(grn_ctx *ctx, grn_obj *obj);
  *
  * \param ctx The context object.
  * \param obj The object whose name is to be retrieved.
- * \param namebuf A buffer to store the object's name. This buffer must be
- *                allocated by the caller.
+ * \param namebuf A buffer allocated by the caller to store the object's name.
  * \param buf_size The size of `namebuf` in bytes.
  *
  * \return The length of the object's name. Returns `0` if the object is unnamed

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1196,6 +1196,27 @@ grn_obj_set_finalizer(grn_ctx *ctx, grn_obj *obj, grn_proc_func *func);
  */
 GRN_API const char *
 grn_obj_path(grn_ctx *ctx, grn_obj *obj);
+/**
+ * \brief Return the length of an object's name.
+ *
+ *        If the object has a name and `buf_size` is greater than or equal to
+ *        the length of the name, the name is copied into `namebuf`.
+ *
+ *        If the length of the name exceeds `buf_size`, the name is not copied
+ *        into `namebuf`, but the length of the name is still returned.
+ *
+ *        The maximum possible length of the name is limited by
+ *        \ref GRN_TABLE_MAX_KEY_SIZE.
+ *
+ * \param ctx The context object.
+ * \param obj The object whose name is to be retrieved.
+ * \param namebuf A buffer to store the object's name. This buffer must be
+ *                allocated by the caller.
+ * \param buf_size The size of `namebuf` in bytes.
+ *
+ * \return The length of the object's name. Returns `0` if the object is unnamed
+ *         or `NULL`.
+ */
 GRN_API int
 grn_obj_name(grn_ctx *ctx, grn_obj *obj, char *namebuf, int buf_size);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.