### PR TITLE
docs: api/grn_table: move grn_table_group() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_table.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_table``"
 msgstr ""
 
@@ -33,20 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "tableのレコードを特定の条件でグループ化します。"
-msgstr ""
-
-msgid "対象tableを指定します。"
-msgstr ""
-
-msgid "group化キー構造体の配列へのポインタを指定します。"
-msgstr ""
-
-msgid "group化キー構造体の配列のサイズを指定します。"
-msgstr ""
-
-msgid "group化の結果を格納する構造体の配列へのポインタを指定します。"
-msgstr ""
-
-msgid "group化の結果を格納する構造体の配列のサイズを指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_table.rst
+++ b/doc/source/reference/api/grn_table.rst
@@ -16,28 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_table_sort_key
-
-   TODO...
-
-.. c:type:: grn_table_sort_flags
-
-   TODO...
-
-.. c:type:: grn_table_group_result
-
-   TODO...
-
-.. c:type:: grn_table_group_flags
-
-   TODO...
-
-.. c:function:: grn_rc grn_table_group(grn_ctx *ctx, grn_obj *table, grn_table_sort_key *keys, int n_keys, grn_table_group_result *results, int n_results)
-
-   tableのレコードを特定の条件でグループ化します。
-
-   :param table: 対象tableを指定します。
-   :param keys: group化キー構造体の配列へのポインタを指定します。
-   :param n_keys: group化キー構造体の配列のサイズを指定します。
-   :param results: group化の結果を格納する構造体の配列へのポインタを指定します。
-   :param n_results: group化の結果を格納する構造体の配列のサイズを指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -749,6 +749,20 @@ struct _grn_table_group_result {
   uint32_t n_aggregators;
 };
 
+/**
+ * \brief Group the records in the table.
+ *
+ * \param ctx The context object.
+ * \param table The table.
+ * \param keys Array of keys for grouping.
+ * \param n_keys Number of elements in `keys` array.
+ * \param results Array to store the results of grouping.
+ * \param n_results Number of elements in `results` array.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_INVALID_ARGUMENT is returned if `table` is
+ *         `NULL`.
+ */
 GRN_API grn_rc
 grn_table_group(grn_ctx *ctx,
                 grn_obj *table,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.