### PR TITLE
docs: api/grn_obj: move grn_obj_expire() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -42,13 +42,10 @@ msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 msgid "objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
-msgid "objの占有するメモリのうち、可能な領域をthresholdを指標として解放します。"
+msgid "objに対応するファイルの整合性を検査します。"
 msgstr ""
 
 msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "objに対応するファイルの整合性を検査します。"
 msgstr ""
 
 msgid "objをlockします。timeout（秒）経過してもlockを取得できない場合は ``GRN_RESOURCE_DEADLOCK_AVOIDED`` を返します。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -27,12 +27,6 @@ Reference
 
    objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。
 
-.. c:function:: int grn_obj_expire(grn_ctx *ctx, grn_obj *obj, int threshold)
-
-   objの占有するメモリのうち、可能な領域をthresholdを指標として解放します。
-
-   :param obj: 対象objectを指定します。
-
 .. c:function:: int grn_obj_check(grn_ctx *ctx, grn_obj *obj)
 
    objに対応するファイルの整合性を検査します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1285,7 +1285,7 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
  *
  * \note This function is not implemented yet.
  *       The \ref grn_obj_expire function is intended to serve as a
- *       generic version of grn_ii_expire and grn_io_expire.
+ *       generic version of grn_ii_expire() and grn_io_expire().
  *
  * \param ctx The context object.
  * \param obj The target object whose memory is to be managed.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1287,9 +1287,9 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
  *        be released, ensuring efficient memory management and preventing
  *        excessive memory usage.
  *
- *        \note This function is not implemented yet.
- *              The \ref grn_obj_expire function is intended to serve as a
- *              generic version of \ref grn_ii_expire and \ref grn_io_expire.
+ * \note This function is not implemented yet.
+ *       The \ref grn_obj_expire function is intended to serve as a
+ *       generic version of grn_ii_expire and grn_io_expire.
  *
  * \param ctx The context object.
  * \param obj The target object whose memory is to be managed.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1281,7 +1281,7 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
   ((obj)->header.type == GRN_TABLE_NO_KEY ? GRN_ID_NIL : (obj)->header.domain)
 
 /**
- * @brief Free allocatable memory occupied by an object based on a threshold.
+ * \brief Free allocatable memory occupied by an object based on a threshold.
  *
  *        The `threshold` acts as a benchmark to decide how much memory should
  *        be released, ensuring efficient memory management and preventing
@@ -1291,12 +1291,12 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
  *              The \ref grn_obj_expire function is intended to serve as a
  *              generic version of \ref grn_ii_expire and \ref grn_io_expire.
  *
- * @param ctx The context object.
- * @param obj The target object whose memory is to be managed.
- * @param threshold The threshold value used as a benchmark for freeing memory
+ * \param ctx The context object.
+ * \param obj The target object whose memory is to be managed.
+ * \param threshold The threshold value used as a benchmark for freeing memory
  *                  spaces.
  *
- * @return Returns `0`.
+ * \return \ref GRN_SUCCESS on success.
  */
 GRN_API int
 grn_obj_expire(grn_ctx *ctx, grn_obj *obj, int threshold);

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1283,10 +1283,6 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
 /**
  * \brief Free allocatable memory occupied by an object based on a threshold.
  *
- *        The `threshold` acts as a benchmark to decide how much memory should
- *        be released, ensuring efficient memory management and preventing
- *        excessive memory usage.
- *
  * \note This function is not implemented yet.
  *       The \ref grn_obj_expire function is intended to serve as a
  *       generic version of grn_ii_expire and grn_io_expire.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1280,6 +1280,24 @@ grn_obj_get_range(grn_ctx *ctx, grn_obj *obj);
 #define GRN_OBJ_GET_DOMAIN(obj)                                                \
   ((obj)->header.type == GRN_TABLE_NO_KEY ? GRN_ID_NIL : (obj)->header.domain)
 
+/**
+ * @brief Free allocatable memory occupied by an object based on a threshold.
+ *
+ *        The `threshold` acts as a benchmark to decide how much memory should
+ *        be released, ensuring efficient memory management and preventing
+ *        excessive memory usage.
+ *
+ *        \note This function is not implemented yet.
+ *              The \ref grn_obj_expire function is intended to serve as a
+ *              generic version of \ref grn_ii_expire and \ref grn_io_expire.
+ *
+ * @param ctx The context object.
+ * @param obj The target object whose memory is to be managed.
+ * @param threshold The threshold value used as a benchmark for freeing memory
+ *                  spaces.
+ *
+ * @return Returns `0`.
+ */
 GRN_API int
 grn_obj_expire(grn_ctx *ctx, grn_obj *obj, int threshold);
 GRN_API int


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.