### PR TITLE
docs: Add unify_latin_alphabet_with option to NormalizerNFKC150

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -720,6 +720,7 @@ absolute_source_files = \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-v-sounds.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-wo-sound.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-zu-small-sounds.log \
+	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log \
@@ -2039,6 +2040,7 @@ source_files_relative_from_doc_dir = \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-v-sounds.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-wo-sound.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-katakana-zu-small-sounds.log \
+	source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log \

--- a/doc/files.cmake
+++ b/doc/files.cmake
@@ -720,6 +720,7 @@ set(GRN_DOC_SOURCES
     example/reference/normalizers/normalizer-nfkc150-unify-katakana-v-sounds.log
     example/reference/normalizers/normalizer-nfkc150-unify-katakana-wo-sound.log
     example/reference/normalizers/normalizer-nfkc150-unify-katakana-zu-small-sounds.log
+    example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log
     example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log
     example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log
     example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -139,6 +139,12 @@ msgstr "以下は :ref:`normalizer-nfkc150-unify-kana-hyphen` オプションの
 msgid "If a previous kana letter is \"ん\" , \"-\" is normalized to \"ん\", And a previous kana letter is \"ン\" , \"-\" is normalized to \"ン\"."
 msgstr "もし、一文字前の文字が\"ん\"であれば、\"-\"は\"ん\"に正規化されます。また、一文字前の文字が\"ン\"であれば、\"-\"は\"ン\"に正規化されます。"
 
+msgid "Here is an example of :ref:`normalizer-nfkc150-unify-latin-alphabet-with` option. This option enables that alphabets with diacritical mark and alphabets without diacritical mark regarded as the same character as below."
+msgstr "以下は :ref:`normalizer-nfkc150-unify-latin-alphabet-with` オプションの使用例です。このオプションは、以下のように発音記号付きの文字と発音記号なしの文字を同じ文字とみなすことができます。"
+
+msgid "However, this feature focus on only LATIN (SMALL|CAPITAL) LETTER X WITH XXX. It doesn't support LATIN (SMALL|CAPITAL) LETTER X + COMBINING XXX characters."
+msgstr "ただし、この機能は LATIN (SMALL|CAPITAL) LETTER X WITH XXX にのみフォーカスしています。 LATIN (SMALL|CAPITAL) LETTER X + COMBINING XXX はサポートしていません。"
+
 msgid "Advanced usage"
 msgstr "高度な使い方"
 
@@ -408,6 +414,12 @@ msgstr ""
 
 msgid "This option enables to normalize \"-\" (U+002D HYPHEN-MINUS) to a vowel of a previous kana letter."
 msgstr "このオプションは、\"-\" (U+002D HYPHEN-MINUS) を一文字前のひらがな・カタカナの母音に正規化します。"
+
+msgid "``unify_latin_alphabet_with``"
+msgstr ""
+
+msgid "This option enables that alphabets with diacritical mark and alphabets without diacritical mark regarded as the same character as below."
+msgstr "このオプションは、以下のように発音記号付きの文字と発音記号なしの文字を同じ文字とみなすことができます。"
 
 msgid "See also"
 msgstr "参考"

--- a/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log
+++ b/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log
@@ -1,0 +1,24 @@
+Execution example::
+
+  normalize   'NormalizerNFKC150("unify_latin_alphabet_with", true)'   "ngoằn"   WITH_TYPES
+  # [
+  #   [
+  #     0,
+  #     1337566253.89858,
+  #     0.000355720520019531
+  #   ],
+  #   {
+  #     "normalized": "ngoan",
+  #     "types": [
+  #       "alpha",
+  #       "alpha",
+  #       "alpha",
+  #       "alpha",
+  #       "alpha",
+  #       "null"
+  #     ],
+  #     "checks": [
+  # 
+  #     ]
+  #   }
+  # ]

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -70,6 +70,12 @@ Specify option::
 
   NormalizerNFKC150("unify_kana_hyphen", true)
 
+  NormalizerNFKC150("unify_latin_alphabet_with", true)
+
+.. versionadded:: 14.0.7
+
+  :ref:`normalizer-nfkc150-unify-latin-alphabet-with` is added.
+
 .. versionadded:: 13.0.1
 
   :ref:`normalizer-nfkc150-unify-kana-prolonged-sound-mark` is added.
@@ -252,6 +258,15 @@ And a previous kana letter is "ン" , "-" is normalized to "ン".
 .. groonga-command
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-kana-hyphen.log
 .. normalize   'NormalizerNFKC150("unify_kana_hyphen", true)'   "カ-キ-ク-ケ-コ-"   WITH_TYPES
+
+Here is an example of :ref:`normalizer-nfkc150-unify-latin-alphabet-with` option.
+This option enables that alphabets with diacritical mark and alphabets without diacritical mark regarded as the same character as below.
+
+However, this feature focus on only LATIN (SMALL|CAPITAL) LETTER X WITH XXX. It doesn't support LATIN (SMALL|CAPITAL) LETTER X + COMBINING XXX characters.
+
+.. groonga-command
+.. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log
+.. normalize   'NormalizerNFKC150("unify_latin_alphabet_with", true)'   "ngoằn"   WITH_TYPES
 
 Advanced usage
 ^^^^^^^^^^^^^^
@@ -602,6 +617,17 @@ And a previous kana letter is "ン" , "-" is normalized to "ン".
    よ- -> よお, ろ- -> ろお, を- -> をお
    
    ん- -> んん
+
+.. _normalizer-nfkc150-unify-latin-alphabet-with:
+
+``unify_latin_alphabet_with``
+"""""""""""""""""""""""""""""
+
+.. versionadded:: 14.0.7
+
+This option enables that alphabets with diacritical mark and alphabets without diacritical mark regarded as the same character as below.
+
+However, this feature focus on only LATIN (SMALL|CAPITAL) LETTER X WITH XXX. It doesn't support LATIN (SMALL|CAPITAL) LETTER X + COMBINING XXX characters.
 
 See also
 ----------


### PR DESCRIPTION
To improve maintainability, we have plans to change the structure of the documentation.
That plan will consolidate the options into one page.
So I have only added it to NormalizerNFKC150 in this commit.