### PR TITLE
docs: Add unify_to_katakana option to NormalizerNFKC150

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -723,6 +723,7 @@ absolute_source_files = \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log \
+	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji.log \
 	$(top_srcdir)/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-voiced-sound-mark-hiragana.log \
@@ -2043,6 +2044,7 @@ source_files_relative_from_doc_dir = \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log \
+	source/example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-to-romaji.log \
 	source/example/reference/normalizers/normalizer-nfkc150-unify-voiced-sound-mark-hiragana.log \

--- a/doc/files.cmake
+++ b/doc/files.cmake
@@ -723,6 +723,7 @@ set(GRN_DOC_SOURCES
     example/reference/normalizers/normalizer-nfkc150-unify-latin-alphabet-with.log
     example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log
     example/reference/normalizers/normalizer-nfkc150-unify-prolonged-sound-mark.log
+    example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log
     example/reference/normalizers/normalizer-nfkc150-unify-to-romaji-complex.log
     example/reference/normalizers/normalizer-nfkc150-unify-to-romaji.log
     example/reference/normalizers/normalizer-nfkc150-unify-voiced-sound-mark-hiragana.log

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -100,6 +100,9 @@ msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-v-sounds` オプシ
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-bu-sounds` option. This option enables normalize \"ヴァヴィヴゥヴェヴォ\" to \"ブ\" as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-bu-sounds` オプションの使用例です。このオプションは、以下のように、\"ヴァヴィヴゥヴェヴォ\"を\"ブ\"に正規化します。"
 
+msgid "Here is an example of :ref:`normalizer-nfkc150-unify-to-katakana` option. This option normalize hiragana to katakana."
+msgstr "以下は、 :ref:`normalizer-nfkc150-unify-to-katakana` オプションの使用例です。このオプションは、以下のように、ひらがなをカタカナに正規化します。"
+
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-to-romaji` option. This option enables normalize hiragana and katakana to romaji as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-to-romaji` オプションの使用例です。このオプションは、以下のように、ひらがなとカタカナをローマ字に正規化します。"
 
@@ -148,6 +151,9 @@ msgstr "ただし、この機能は LATIN (SMALL|CAPITAL) LETTER X WITH XXX に�
 msgid "Advanced usage"
 msgstr "高度な使い方"
 
+msgid "With ``TokenMecab``"
+msgstr "``TokenMecab`` と使う"
+
 msgid "You can output romaji of specific a part of speech with using to combine ``TokenMecab`` and ``NormalizerNFKC150`` as below."
 msgstr "``TokenMecab`` と ``NormalizerNFKC150`` を組み合わせて使うことで、特定の品詞の読みをローマ字で出力できます。"
 
@@ -156,6 +162,51 @@ msgstr "まずはじめに、 ``TokenMecab`` の ``target_class`` オプショ�
 
 msgid "Next, you normalize reading of the noun that extracted with ``unify_to_romaji`` option of ``NormalizerNFKC150``."
 msgstr "次に、抽出した名詞の読みを ``NormalizerNFKC130`` の ``unify_to_romaji`` を使って正規化します。"
+
+msgid "Use ``unify_to_katakana`` with other options"
+msgstr "``unify_to_katakana`` を他のオプションと使う"
+
+msgid ":ref:`normalizer-nfkc150-unify-to-katakana` can be combined with the following options to equate special katakana with general katakana."
+msgstr ":ref:`normalizer-nfkc150-unify-to-katakana` は以下に列挙するオプションと組み合わせることで、特殊なカタカナを一般的なカタカナと同一視します。"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-v-sounds`"
+msgstr ""
+
+msgid "Equivalent: \"ゔぁゔぃゔゔぇゔぉ\", \"ばびぶべぼ\", \"ヴァヴィヴヴェヴォ\" and \"バビブベボ\""
+msgstr "\"ゔぁゔぃゔゔぇゔぉ\"、\"ばびぶべぼ\"、\"ヴァヴィヴヴェヴォ\"、\"バビブベボ\"を同一視します"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-gu-small-sounds`"
+msgstr ""
+
+msgid "Equivalent: \"ぐぁぐぃぐぇぐぉ\", \"がぎげご\", \"グァグィグェグォ\" and \"ガギゲゴ\""
+msgstr "\"ぐぁぐぃぐぇぐぉ\"、\"がぎげご\"、\"グァグィグェグォ\"、\"ガギゲゴ\"を同一視します"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-zu-small-sounds`"
+msgstr ""
+
+msgid "Equivalent: \"ずぁずぃずぇずぉ\", \"ざじぜぞ\", \"ズァズィズェズォ\" and \"ザジゼゾ\""
+msgstr "\"ずぁずぃずぇずぉ\"、\"ざじぜぞ\"、\"ズァズィズェズォ\"、\"ザジゼゾ\"を同一視します"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-wo-sound`"
+msgstr ""
+
+msgid "Equivalent: \"お\", \"を\", \"オ\" and \"ヲ\""
+msgstr "\"お\"、\"を\"、\"オ\"、\"ヲ\"を同一視します"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-di-sound`"
+msgstr ""
+
+msgid "Equivalent: \"じ\", \"ぢ\", \"ジ\" and \"ヂ\""
+msgstr "\"じ\"、\"ぢ\"、\"ジ\"、\"ヂ\"を同一視します"
+
+msgid ":ref:`normalizer-nfkc150-unify-katakana-du-sound`"
+msgstr ""
+
+msgid "Equivalent: \"ず\", \"づ\", \"ズ\" and \"ヅ\""
+msgstr "\"ず\"、\"づ\"、\"ズ\"、\"ヅ\"を同一視します"
+
+msgid "For example, using ``unify_to_katakana`` and ``unify_katakana_v_sounds`` together, you can search \"バイオリン\", \"ヴァイオリン\", \"ばいおりん\" and \"ゔぁいおりん\" with \"ばいおりん\"."
+msgstr "例えば、 ``unify_to_katakana`` と ``unify_katakana_v_sounds`` を使うと、\"\"ばいおりん\"で\"バイオリン\"、\"ヴァイオリン\"、\"ばいおりん\"、\"ゔぁいおりん\"が検索できます。"
 
 msgid "Parameters"
 msgstr "引数"
@@ -297,6 +348,12 @@ msgstr ""
 
 msgid "This option enables normalize \"ヴァヴィヴゥヴェヴォ\" to \"ブ\"."
 msgstr "このオプションは、\"ヴァヴィヴゥヴェヴォ\"を\"ブ\"に正規化します。"
+
+msgid "``unify_to_katakana``"
+msgstr ""
+
+msgid "This option normalize hiragana to katakana."
+msgstr "このオプションは、ひらがなをカタカナに正規化します。"
 
 msgid "``unify_to_romaji``"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -100,7 +100,7 @@ msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-v-sounds` オプシ
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-bu-sounds` option. This option enables normalize \"ヴァヴィヴゥヴェヴォ\" to \"ブ\" as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-bu-sounds` オプションの使用例です。このオプションは、以下のように、\"ヴァヴィヴゥヴェヴォ\"を\"ブ\"に正規化します。"
 
-msgid "Here is an example of :ref:`normalizer-nfkc150-unify-to-katakana` option. This option normalize hiragana to katakana."
+msgid "Here is an example of :ref:`normalizer-nfkc150-unify-to-katakana` option. This option normalizes hiragana to katakana."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-to-katakana` オプションの使用例です。このオプションは、以下のように、ひらがなをカタカナに正規化します。"
 
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-to-romaji` option. This option enables normalize hiragana and katakana to romaji as below."
@@ -352,7 +352,7 @@ msgstr "このオプションは、\"ヴァヴィヴゥヴェヴォ\"を\"ブ\"�
 msgid "``unify_to_katakana``"
 msgstr ""
 
-msgid "This option normalize hiragana to katakana."
+msgid "This option normalizes hiragana to katakana."
 msgstr "このオプションは、ひらがなをカタカナに正規化します。"
 
 msgid "``unify_to_romaji``"

--- a/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log
+++ b/doc/source/example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log
@@ -1,0 +1,28 @@
+Execution example::
+
+  normalize   'NormalizerNFKC150("unify_to_katakana", true)'   "ゔぁゔぃゔゔぇゔぉ"   WITH_TYPES
+  # [
+  #   [
+  #     0,
+  #     1337566253.89858,
+  #     0.000355720520019531
+  #   ],
+  #   {
+  #     "normalized": "ヴァヴィヴヴェヴォ",
+  #     "types": [
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "katakana",
+  #       "null"
+  #     ],
+  #     "checks": [
+  # 
+  #     ]
+  #   }
+  # ]

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -178,7 +178,7 @@ This option enables normalize "ヴァヴィヴゥヴェヴォ" to "ブ" as below
 .. normalize   'NormalizerNFKC150("unify_katakana_bu_sound", true)'   "ヴァヴィヴヴェヴォヴ"   WITH_TYPES
 
 Here is an example of :ref:`normalizer-nfkc150-unify-to-katakana` option.
-This option normalize hiragana to katakana.
+This option normalizes hiragana to katakana.
 
 .. groonga-command
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log
@@ -455,7 +455,7 @@ This option enables normalize "ヴァヴィヴゥヴェヴォ" to "ブ".
 ``unify_to_katakana``
 """""""""""""""""""""
 
-This option normalize hiragana to katakana.
+This option normalizes hiragana to katakana.
 
 .. _normalizer-nfkc150-unify-to-romaji:
 

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -48,6 +48,8 @@ Specify option::
 
   NormalizerNFKC150("unify_katakana_bu_sound", true)
 
+  NormalizerNFKC150("unify_to_katakana", true)
+
   NormalizerNFKC150("unify_to_romaji", true)
 
   NormalizerNFKC150("remove_symbol", true)
@@ -175,6 +177,13 @@ This option enables normalize "ヴァヴィヴゥヴェヴォ" to "ブ" as below
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-katakana-bu-sounds.log
 .. normalize   'NormalizerNFKC150("unify_katakana_bu_sound", true)'   "ヴァヴィヴヴェヴォヴ"   WITH_TYPES
 
+Here is an example of :ref:`normalizer-nfkc150-unify-to-katakana` option.
+This option normalize hiragana to katakana.
+
+.. groonga-command
+.. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-to-katakana.log
+.. normalize   'NormalizerNFKC150("unify_to_katakana", true)'   "ゔぁゔぃゔゔぇゔぉ"   WITH_TYPES
+
 Here is an example of :ref:`normalizer-nfkc150-unify-to-romaji` option.
 This option enables normalize hiragana and katakana to romaji as below.
 
@@ -271,6 +280,9 @@ However, this feature focus on only LATIN (SMALL|CAPITAL) LETTER X WITH XXX. It 
 Advanced usage
 ^^^^^^^^^^^^^^
 
+With ``TokenMecab``
+"""""""""""""""""""
+
 You can output romaji of specific a part of speech with using to combine
 ``TokenMecab`` and ``NormalizerNFKC150`` as below.
 
@@ -284,6 +296,37 @@ Next, you normalize reading of the noun that extracted with ``unify_to_romaji`` 
 .. normalize   'NormalizerNFKC150("unify_to_romaji", true)'   "カレ"   WITH_TYPES
 .. normalize   'NormalizerNFKC150("unify_to_romaji", true)'   "ナマエ"   WITH_TYPES
 .. normalize   'NormalizerNFKC150("unify_to_romaji", true)'   "ヤマダ"   WITH_TYPES
+
+Use ``unify_to_katakana`` with other options
+""""""""""""""""""""""""""""""""""""""""""""
+
+:ref:`normalizer-nfkc150-unify-to-katakana` can be combined with the following options to equate special katakana with general katakana.
+
+* :ref:`normalizer-nfkc150-unify-katakana-v-sounds`
+
+  * Equivalent: "ゔぁゔぃゔゔぇゔぉ", "ばびぶべぼ", "ヴァヴィヴヴェヴォ" and "バビブベボ"
+
+* :ref:`normalizer-nfkc150-unify-katakana-gu-small-sounds`
+
+  * Equivalent: "ぐぁぐぃぐぇぐぉ", "がぎげご", "グァグィグェグォ" and "ガギゲゴ"
+
+* :ref:`normalizer-nfkc150-unify-katakana-zu-small-sounds`
+
+  * Equivalent: "ずぁずぃずぇずぉ", "ざじぜぞ", "ズァズィズェズォ" and "ザジゼゾ"
+
+* :ref:`normalizer-nfkc150-unify-katakana-wo-sound`
+
+  * Equivalent: "お", "を", "オ" and "ヲ"
+
+* :ref:`normalizer-nfkc150-unify-katakana-di-sound`
+
+  * Equivalent: "じ", "ぢ", "ジ" and "ヂ"
+
+* :ref:`normalizer-nfkc150-unify-katakana-du-sound`
+
+  * Equivalent: "ず", "づ", "ズ" and "ヅ"
+
+For example, using ``unify_to_katakana`` and ``unify_katakana_v_sounds`` together, you can search "バイオリン", "ヴァイオリン", "ばいおりん" and "ゔぁいおりん" with "ばいおりん".
 
 Parameters
 ----------
@@ -406,6 +449,13 @@ This option enables normalize "ヴァヴィヴヴェヴォ" to "バビブベボ"
 """""""""""""""""""""""""""
 
 This option enables normalize "ヴァヴィヴゥヴェヴォ" to "ブ".
+
+.. _normalizer-nfkc150-unify-to-katakana:
+
+``unify_to_katakana``
+"""""""""""""""""""""
+
+This option normalize hiragana to katakana.
 
 .. _normalizer-nfkc150-unify-to-romaji:
 


### PR DESCRIPTION
To improve maintainability, we have plans to change the structure of the documentation.
That plan will consolidate the options into one page.
So I have only added it to NormalizerNFKC150 in this commit.