### PR TITLE
docs: api/grn_db: move grn_db_unmap() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_db.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_db.po
@@ -128,12 +128,3 @@ msgstr "復旧対象のデータベース。"
 
 msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
 msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
-msgid "This is a thread unsafe API. You can't touch the database while this API is running."
-msgstr ""
-
-msgid "Unmaps all opened tables and columns in the passed database. Resources used by these opened tables and columns are freed."
-msgstr ""
-
-msgid "Normally, this API isn't useless. Because resources used by opened tables and columns are managed by OS automatically."
-msgstr ""

--- a/doc/source/reference/api/grn_db.rst
+++ b/doc/source/reference/api/grn_db.rst
@@ -107,26 +107,3 @@ TODO...
 
    :param db: The database to be recovered.
    :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
-.. c:function:: grn_rc grn_db_unmap(grn_ctx *ctx, grn_obj *db)
-
-   .. note::
-
-      This is an experimental API.
-
-   .. note::
-
-      This is a thread unsafe API. You can't touch the database while
-      this API is running.
-
-   .. versionadded:: 5.0.7
-
-   Unmaps all opened tables and columns in the passed
-   database. Resources used by these opened tables and columns are
-   freed.
-
-   Normally, this API isn't useless. Because resources used by opened
-   tables and columns are managed by OS automatically.
-
-   :param db: The database to be recovered.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.

--- a/include/groonga/db.h
+++ b/include/groonga/db.h
@@ -48,8 +48,6 @@ grn_db_recover(grn_ctx *ctx, grn_obj *db);
  *        Normally, this API is needless. Because resources used by opened
  *        tables and columns are managed by OS automatically.
  *
- * \note This is an experimental API.
- *
  * \attention This is a thread unsafe API. You can't touch the database while
  *            this API is running.
  *

--- a/include/groonga/db.h
+++ b/include/groonga/db.h
@@ -42,6 +42,24 @@ GRN_API void
 grn_db_touch(grn_ctx *ctx, grn_obj *db);
 GRN_API grn_rc
 grn_db_recover(grn_ctx *ctx, grn_obj *db);
+/**
+ * \brief Unmaps all opened tables and columns in the passed database.
+ *        Resources used by these opened tables and columns are freed.
+ *        Normally, this API isn't useless. Because resources used by opened
+ *        tables and columns are managed by OS automatically.
+ *
+ * \note This is an experimental API.
+ *
+ * \attention This is a thread unsafe API. You can't touch the database while
+ *             this API is running.
+ *
+ * \since 5.0.7
+ *
+ * \param ctx The context object.
+ * \param db The database to be recovered.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_db_unmap(grn_ctx *ctx, grn_obj *db);
 GRN_API uint32_t

--- a/include/groonga/db.h
+++ b/include/groonga/db.h
@@ -45,13 +45,13 @@ grn_db_recover(grn_ctx *ctx, grn_obj *db);
 /**
  * \brief Unmaps all opened tables and columns in the passed database.
  *        Resources used by these opened tables and columns are freed.
- *        Normally, this API isn't useless. Because resources used by opened
+ *        Normally, this API is needless. Because resources used by opened
  *        tables and columns are managed by OS automatically.
  *
  * \note This is an experimental API.
  *
  * \attention This is a thread unsafe API. You can't touch the database while
- *             this API is running.
+ *            this API is running.
  *
  * \since 5.0.7
  *


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.