### PR TITLE
docs: api/grn_obj: move grn_obj_lock() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -42,13 +42,10 @@ msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 msgid "objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
-msgid "objをlockします。timeout（秒）経過してもlockを取得できない場合は ``GRN_RESOURCE_DEADLOCK_AVOIDED`` を返します。"
+msgid "objをunlockします。"
 msgstr ""
 
 msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "objをunlockします。"
 msgstr ""
 
 msgid "強制的にロックをクリアします。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -27,12 +27,6 @@ Reference
 
    objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。
 
-.. c:function:: grn_rc grn_obj_lock(grn_ctx *ctx, grn_obj *obj, grn_id id, int timeout)
-
-   objをlockします。timeout（秒）経過してもlockを取得できない場合は ``GRN_RESOURCE_DEADLOCK_AVOIDED`` を返します。
-
-   :param obj: 対象objectを指定します。
-
 .. c:function:: grn_rc grn_obj_unlock(grn_ctx *ctx, grn_obj *obj, grn_id id)
 
    objをunlockします。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1308,6 +1308,18 @@ grn_obj_expire(grn_ctx *ctx, grn_obj *obj, int threshold);
  */
 GRN_API int
 grn_obj_check(grn_ctx *ctx, grn_obj *obj);
+/**
+ * \brief Lock an object with a specified timeout.
+ *
+ * \param ctx The context object.
+ * \param obj The target object to lock.
+ * \param id The ID of the target object.
+ * \param timeout The maximum time to wait for the lock, in seconds.
+ *
+ * \return \ref GRN_SUCCESS on success. the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_RESOURCE_DEADLOCK_AVOIDED is returned if the
+ *         lock could not be acquired within the specified timeout.
+ */
 GRN_API grn_rc
 grn_obj_lock(grn_ctx *ctx, grn_obj *obj, grn_id id, int timeout);
 GRN_API grn_rc


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.