### PR TITLE
docs: api/grn_obj: move grn_obj_unlock() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_obj.po
@@ -42,13 +42,10 @@ msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 msgid "objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。"
 msgstr ""
 
-msgid "objをunlockします。"
+msgid "強制的にロックをクリアします。"
 msgstr ""
 
 msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "強制的にロックをクリアします。"
 msgstr ""
 
 msgid "objが現在lockされていれば0以外の値を返します。"

--- a/doc/source/reference/api/grn_obj.rst
+++ b/doc/source/reference/api/grn_obj.rst
@@ -27,12 +27,6 @@ Reference
 
    objをメモリから解放します。objに属するobjectも再帰的にメモリから解放されます。
 
-.. c:function:: grn_rc grn_obj_unlock(grn_ctx *ctx, grn_obj *obj, grn_id id)
-
-   objをunlockします。
-
-   :param obj: 対象objectを指定します。
-
 .. c:function:: grn_rc grn_obj_clear_lock(grn_ctx *ctx, grn_obj *obj)
 
    強制的にロックをクリアします。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1322,6 +1322,15 @@ grn_obj_check(grn_ctx *ctx, grn_obj *obj);
  */
 GRN_API grn_rc
 grn_obj_lock(grn_ctx *ctx, grn_obj *obj, grn_id id, int timeout);
+/**
+ * \brief Unlock an object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object to unlock.
+ * \param id The ID of the target object.
+ *
+ * \return \ref GRN_SUCCESS on success.
+ */
 GRN_API grn_rc
 grn_obj_unlock(grn_ctx *ctx, grn_obj *obj, grn_id id);
 GRN_API grn_rc

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1316,7 +1316,7 @@ grn_obj_check(grn_ctx *ctx, grn_obj *obj);
  * \param id The ID of the target object.
  * \param timeout The maximum time to wait for the lock, in seconds.
  *
- * \return \ref GRN_SUCCESS on success. the appropriate \ref grn_rc on error.
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  *         For example, \ref GRN_RESOURCE_DEADLOCK_AVOIDED is returned if the
  *         lock could not be acquired within the specified timeout.
  */


### PR DESCRIPTION
GitHub: https://github.com/groonga/groonga/issues/1817

Prepare to switch to documents automatically generated by Doxygen.