### PR TITLE
ci macos: use macos-13 temporary

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -180,7 +180,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -347,7 +347,7 @@ jobs:
 
   macos:
     name: macOS
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -410,7 +410,9 @@ jobs:
             -v
       - name: "Test: mruby"
         run: |
-          USE_SYSTEM=yes test/mruby/run-test.rb
+          DYLD_LIBRARY_PATH=/usr/local/lib \
+            USE_SYSTEM=yes \
+            test/mruby/run-test.rb
       - name: "Test: stdio"
         run: |
           grntest \


### PR DESCRIPTION
This serves as a workaround while awaiting a fix for the rpath problem in Rroonga.
Once resolved, we should revert to using macos-latest.