### PR TITLE
ci macos: temporarily disable mruby test on macos-latest

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -415,22 +415,24 @@ jobs:
           USE_SYSTEM=yes test/mruby/run-test.rb
       - name: "Test: stdio"
         run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite
+          DYLD_LIBRARY_PATH=/usr/local/lib \
+            grntest \
+              --base-dir test/command \
+              --n-retries=2 \
+              --read-timeout=30 \
+              --reporter=mark \
+              test/command/suite
       - name: "Test: HTTP: load: Apache Arrow"
         run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            --input-type=apache-arrow \
-            --interface=http \
-            test/command/suite
+          DYLD_LIBRARY_PATH=/usr/local/lib \
+            grntest \
+              --base-dir test/command \
+              --n-retries=2 \
+              --read-timeout=30 \
+              --reporter=mark \
+              --input-type=apache-arrow \
+              --interface=http \
+              test/command/suite
 
   windows-mingw:
     name: Windows MinGW

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -409,6 +409,8 @@ jobs:
             --groonga-install-prefix=/usr/local \
             -v
       - name: "Test: mruby"
+        # TODO: Disabled temporarily as a workaround for the rpath issue in Rroonga.
+        if: false
         run: |
           USE_SYSTEM=yes test/mruby/run-test.rb
       - name: "Test: stdio"


### PR DESCRIPTION
Because there is a rpath issue in Rroonga.
Once resolved, we should enable mruby test on macos-latest.