### PR TITLE
docs: api/grn_search: move grn_obj_search() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_search.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_search.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_search``"
 msgstr ""
 
@@ -33,20 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "objを対象としてqueryにマッチするレコードを検索し、opの指定に従ってresにレコードを追加あるいは削除します。"
-msgstr ""
-
-msgid "検索対象のobjectを指定します。"
-msgstr ""
-
-msgid "検索クエリを指定します。"
-msgstr ""
-
-msgid "検索結果を格納するテーブルを指定します。"
-msgstr ""
-
-msgid "``GRN_OP_OR``, ``GRN_OP_AND``, ``GRN_OP_AND_NOT``, ``GRN_OP_ADJUST`` のいずれかを指定します。"
-msgstr ""
-
-msgid "詳細検索条件を指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_search.rst
+++ b/doc/source/reference/api/grn_search.rst
@@ -15,15 +15,6 @@ TODO...
 
 Reference
 ---------
- 
-.. c:type:: grn_search_optarg
 
-.. c:function:: grn_rc grn_obj_search(grn_ctx *ctx, grn_obj *obj, grn_obj *query, grn_obj *res, grn_operator op, grn_search_optarg *optarg)
-
-   objを対象としてqueryにマッチするレコードを検索し、opの指定に従ってresにレコードを追加あるいは削除します。
-
-   :param obj: 検索対象のobjectを指定します。
-   :param query: 検索クエリを指定します。
-   :param res: 検索結果を格納するテーブルを指定します。
-   :param op: ``GRN_OP_OR``, ``GRN_OP_AND``, ``GRN_OP_AND_NOT``, ``GRN_OP_ADJUST`` のいずれかを指定します。
-   :param optarg: 詳細検索条件を指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1319,6 +1319,28 @@ struct _grn_search_optarg {
   grn_id *query_domain;
 };
 
+/**
+ * \brief Search for `obj` in `query`.
+ *
+ * \param ctx The context object.
+ * \param obj The object to be searched.
+ * \param query Search query.
+ * \param res The table to store results.
+ * \param op Logical operation of the table stored in `res` and the table of
+ *           the search result.
+ *           - \ref GRN_OP_OR
+ *           - \ref GRN_OP_AND
+ *           - \ref GRN_OP_AND_NOT
+ *           - \ref GRN_OP_ADJUST
+ * \param optarg Search options. For example, you can specify the search mode in
+ *               \ref grn_search_optarg::mode.
+ *               If \ref GRN_OP_EQUAL is specified for
+ *               \ref grn_search_optarg::mode, it searching for equal record.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_INVALID_ARGUMENT is returned if `obj` is
+ *         `NULL`.
+ */
 GRN_API grn_rc
 grn_obj_search(grn_ctx *ctx,
                grn_obj *obj,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.