### PR TITLE
docs: api/grn_db: move grn_obj_db() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_db.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_db.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_db``"
 msgstr ""
 
@@ -33,8 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "objの属するdbを返します。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_db.rst
+++ b/doc/source/reference/api/grn_db.rst
@@ -16,10 +16,5 @@ TODO...
 Reference
 ---------
 
-TODO...
-
-.. c:function:: grn_obj *grn_obj_db(grn_ctx *ctx, grn_obj *obj)
-
-   objの属するdbを返します。
-
-   :param obj: 対象objectを指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1354,8 +1354,8 @@ grn_obj_defrag(grn_ctx *ctx, grn_obj *obj, int threshold);
  * \param ctx The context object.
  * \param obj Target object.
  *
- * \return The database object to which `obj` belongs if `obj` is the database
- *         object, `NULL` otherwise.
+ * \return The database object to which `obj` belongs, `NULL` if `obj` doesn't
+ *         belong to any database.
  */
 GRN_API grn_obj *
 grn_obj_db(grn_ctx *ctx, grn_obj *obj);

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1348,6 +1348,15 @@ grn_obj_flush_only_opened(grn_ctx *ctx, grn_obj *obj);
 GRN_API int
 grn_obj_defrag(grn_ctx *ctx, grn_obj *obj, int threshold);
 
+/**
+ * \brief Return the database to which `obj` belongs.
+ *
+ * \param ctx The context object.
+ * \param obj Target object.
+ *
+ * \return The database object to which `obj` belongs if `obj` is the database
+ *         object, `NULL` otherwise.
+ */
 GRN_API grn_obj *
 grn_obj_db(grn_ctx *ctx, grn_obj *obj);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.