### PR TITLE
docs: api/grn_info: move grn_obj_(get|set)_element_info reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_info.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_info.po
@@ -50,18 +50,3 @@ msgstr ""
 
 msgid "設定する情報の種類を指定します。"
 msgstr ""
-
-msgid "objのidに対応するレコードの、typeに対応する情報をvaluebufに格納します。呼出側ではtypeに応じて十分なサイズのバッファを確保しなければいけません。"
-msgstr ""
-
-msgid "対象IDを指定します。"
-msgstr ""
-
-msgid "objのidに対応するレコードのtypeに対応する情報をvalueの内容に更新します。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "設定しようとする値を指定します。"
-msgstr ""

--- a/doc/source/reference/api/grn_info.rst
+++ b/doc/source/reference/api/grn_info.rst
@@ -34,21 +34,3 @@ Reference
 
    :param obj: 対象objを指定します。
    :param type: 設定する情報の種類を指定します。
-
-.. c:function:: grn_obj *grn_obj_get_element_info(grn_ctx *ctx, grn_obj *obj, grn_id id, grn_info_type type, grn_obj *value)
-
-   objのidに対応するレコードの、typeに対応する情報をvaluebufに格納します。呼出側ではtypeに応じて十分なサイズのバッファを確保しなければいけません。
-
-   :param obj: 対象objを指定します。
-   :param id: 対象IDを指定します。
-   :param type: 取得する情報の種類を指定します。
-   :param value: 値を格納するバッファ（呼出側で準備）を指定します。
-
-.. c:function:: grn_rc grn_obj_set_element_info(grn_ctx *ctx, grn_obj *obj, grn_id id, grn_info_type type, grn_obj *value)
-
-   objのidに対応するレコードのtypeに対応する情報をvalueの内容に更新します。
-
-   :param obj: 対象objectを指定します。
-   :param id: 対象IDを指定します。
-   :param type: 設定する情報の種類を指定します。
-   :param value: 設定しようとする値を指定します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -947,9 +947,36 @@ grn_obj_set_info(grn_ctx *ctx,
                  grn_obj *obj,
                  grn_info_type type,
                  grn_obj *value);
+/**
+ * \brief Get information on the record with the ID in the object.
+ *
+ * \note This function is not implemented yet.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param id The target ID.
+ * \param type The type of information.
+ * \param valuebuf The buffer to store the retrieved value (must be prepared by
+ *                 the caller).
+ *
+ * \return `valuebuf`.
+ */
 GRN_API grn_obj *
 grn_obj_get_element_info(
-  grn_ctx *ctx, grn_obj *obj, grn_id id, grn_info_type type, grn_obj *value);
+  grn_ctx *ctx, grn_obj *obj, grn_id id, grn_info_type type, grn_obj *valuebuf);
+/**
+ * \brief Set information on the record with the ID in the object.
+ *
+ * \note This function is not implemented yet.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param id The target ID.
+ * \param type The type of information.
+ * \param value The value to set.
+ *
+ * \return \ref GRN_SUCCESS.
+ */
 GRN_API grn_rc
 grn_obj_set_element_info(
   grn_ctx *ctx, grn_obj *obj, grn_id id, grn_info_type type, grn_obj *value);


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.