### PR TITLE
docs: api/grn_info: move grn_obj_(get|set)_info reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_info.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_info.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_info``"
 msgstr ""
 
@@ -33,20 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "objのtypeに対応する情報をvaluebufに格納します。"
-msgstr ""
-
-msgid "対象objを指定します。"
-msgstr ""
-
-msgid "取得する情報の種類を指定します。"
-msgstr ""
-
-msgid "値を格納するバッファ（呼出側で準備）を指定します。"
-msgstr ""
-
-msgid "objのtypeに対応する情報をvalueの内容に更新します。"
-msgstr ""
-
-msgid "設定する情報の種類を指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_info.rst
+++ b/doc/source/reference/api/grn_info.rst
@@ -16,21 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_info_type
-
-   TODO...
-
-.. c:function:: grn_obj *grn_obj_get_info(grn_ctx *ctx, grn_obj *obj, grn_info_type type, grn_obj *valuebuf)
-
-   objのtypeに対応する情報をvaluebufに格納します。
-
-   :param obj: 対象objを指定します。
-   :param type: 取得する情報の種類を指定します。
-   :param valuebuf: 値を格納するバッファ（呼出側で準備）を指定します。
-
-.. c:function:: grn_rc grn_obj_set_info(grn_ctx *ctx, grn_obj *obj, grn_info_type type, grn_obj *value)
-
-   objのtypeに対応する情報をvalueの内容に更新します。
-
-   :param obj: 対象objを指定します。
-   :param type: 設定する情報の種類を指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -937,11 +937,34 @@ typedef enum {
   GRN_INFO_NORMALIZERS,
 } grn_info_type;
 
+/**
+ * \brief Get information on the object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param type The type of information.
+ * \param valuebuf The buffer to store the retrieved value (must be prepared by
+ *                 the caller).
+ *
+ * \return `valuebuf`.
+ */
 GRN_API grn_obj *
 grn_obj_get_info(grn_ctx *ctx,
                  grn_obj *obj,
                  grn_info_type type,
                  grn_obj *valuebuf);
+/**
+ * \brief Set information on the object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param type The type of information.
+ * \param value The value to set.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_INVALID_ARGUMENT is returned if `obj` is
+ *         `NULL`.
+ */
 GRN_API grn_rc
 grn_obj_set_info(grn_ctx *ctx,
                  grn_obj *obj,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.