### PR TITLE
docs: Replace others.rst with cmake.rst

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/centos.po
+++ b/doc/locale/ja/LC_MESSAGES/install/centos.po
@@ -25,5 +25,5 @@ msgstr "CentOS 7がEOLになったのでGroonga 14.0.5以降はCentOS 7用パッ
 msgid "Groonga supports AlmaLinux. So you can continue using Groonga by switching from CentOS 7 to AlmaLinux."
 msgstr "Groongaは、AlmaLinuxをサポートしているので、CentOS 7からAlmaLinuxにOSを切り替えることで引続きGroongaを利用できます。"
 
-msgid "See also :doc:`/install/almalinux`."
-msgstr ":doc:`/install/almalinux`を参照してください。"
+msgid "See also :doc:`/install/almalinux` ."
+msgstr ":doc:`/install/almalinux` を参照してください。"

--- a/doc/locale/ja/LC_MESSAGES/install/cmake.po
+++ b/doc/locale/ja/LC_MESSAGES/install/cmake.po
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "How to build Groonga with CMake"
-msgstr "CMakeを使ってGroongaをビルドする方法"
+msgid "Others: Build with CMake"
+msgstr "その他: CMakeを使ってビルド"
 
 msgid "This document describes how to build Groonga from source with CMake."
 msgstr "このドキュメントはCMakeを使ってソースコードからGroongaをビルドする方法を説明します。"

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -20,8 +20,7 @@ size data.
    install/mac_os_x
    install/debian
    install/ubuntu
-   install/centos
    install/almalinux
    install/amazon_linux
    install/docker
-   install/others
+   install/cmake

--- a/doc/source/install/centos.rst
+++ b/doc/source/install/centos.rst
@@ -1,5 +1,7 @@
 .. -*- rst -*-
 
+:orphan:
+
 CentOS
 ======
 
@@ -7,4 +9,4 @@ Support for Groonga has ended from version 14.0.5 because of CentOS 7’s EOL.
 
 Groonga supports AlmaLinux. So you can continue using Groonga by switching from CentOS 7 to AlmaLinux.
 
-See also :doc:`/install/almalinux`.
+See also :doc:`/install/almalinux` .

--- a/doc/source/install/cmake.rst
+++ b/doc/source/install/cmake.rst
@@ -1,7 +1,5 @@
-:orphan:
-
-How to build Groonga with CMake
-===============================
+Others: Build with CMake
+========================
 
 This document describes how to build Groonga from source with CMake.
 

--- a/doc/source/install/others.rst
+++ b/doc/source/install/others.rst
@@ -1,5 +1,7 @@
 .. -*- rst -*-
 
+:orphan:
+
 Others
 ======
 


### PR DESCRIPTION
GitHub: GH-2007

Since there was already a cmake.rst, replace "Others" with it.

The installation documentation for each OS refers to `others.rst`, which should be changed separately. We will also add a separate note on the necessary CMake options.