### PR TITLE
request_cancel: Fix a bug that canceled request may return an invalid response

### DIFF
--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2188,7 +2188,7 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
       have_buffer = true;
     }
 
-    *flags |= GRN_CTX_QUIT;
+    *flags = GRN_CTX_QUIT;
     if (!have_buffer) {
       *str = NULL;
       *str_len = 0;
@@ -2209,10 +2209,10 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
         *str_len = (unsigned int)GRN_BULK_VSIZE(ctx->impl->output.buf);
         if (header.flags & GRN_CTX_QUIT) {
           ctx->stat = GRN_CTX_QUIT;
-          *flags |= GRN_CTX_QUIT;
+          *flags = GRN_CTX_QUIT;
         } else {
           if (!(header.flags & GRN_CTX_TAIL)) {
-            *flags |= GRN_CTX_MORE;
+            *flags = GRN_CTX_MORE;
           }
         }
         ctx->impl->output.type = static_cast<grn_content_type>(header.qtype);
@@ -2225,7 +2225,7 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
         if (ctx->rc == GRN_CANCEL) {
           *str = NULL;
           *str_len = 0;
-          *flags |= GRN_CTX_QUIT;
+          *flags = GRN_CTX_QUIT;
         }
       }
       goto exit;
@@ -2233,7 +2233,7 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
       if (ctx->rc == GRN_CANCEL) {
         *str = NULL;
         *str_len = 0;
-        *flags |= GRN_CTX_QUIT;
+        *flags = GRN_CTX_QUIT;
       } else {
         grn_obj *buf = ctx->impl->output.buf;
         *str = GRN_BULK_HEAD(buf);

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2180,16 +2180,6 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
 
   *flags = 0;
 
-  // In case of GRN_CANCEL, empty the result and quit the process.
-  // When cancelled, the result may be incomplete.
-  // Also, the cancelled means that the result should not be necessary.
-  if (ctx->rc == GRN_CANCEL) {
-    *str = NULL;
-    *str_len = 0;
-    ctx->stat = GRN_CTX_QUIT;
-    *flags |= GRN_CTX_QUIT;
-    return GRN_SUCCESS;
-  }
   if (ctx->stat == GRN_CTX_QUIT) {
     bool have_buffer = false;
 
@@ -2232,14 +2222,23 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
         ctx->errline = 0;
         ctx->errfile = NULL;
         ctx->errfunc = NULL;
+        if (ctx->rc == GRN_CANCEL) {
+          *str = NULL;
+          *str_len = 0;
+          *flags |= GRN_CTX_QUIT;
+        }
       }
       goto exit;
     } else {
-      grn_obj *buf = ctx->impl->output.buf;
-      size_t head = 0;
-      size_t tail = GRN_BULK_VSIZE(buf);
-      *str = GRN_BULK_HEAD(buf) + head;
-      *str_len = (unsigned int)(tail - head);
+      if (ctx->rc == GRN_CANCEL) {
+        *str = NULL;
+        *str_len = 0;
+        *flags |= GRN_CTX_QUIT;
+      } else {
+        grn_obj *buf = ctx->impl->output.buf;
+        *str = GRN_BULK_HEAD(buf);
+        *str_len = (unsigned int)GRN_BULK_VSIZE(buf);
+      }
       GRN_BULK_REWIND(ctx->impl->output.buf);
       goto exit;
     }

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2180,6 +2180,16 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
 
   *flags = 0;
 
+  // In case of GRN_CANCEL, empty the result and quit the process.
+  // When cancelled, the result may be incomplete.
+  // Also, the cancelled means that the result should not be necessary.
+  if (ctx->rc == GRN_CANCEL) {
+    *str = NULL;
+    *str_len = 0;
+    ctx->stat = GRN_CTX_QUIT;
+    *flags |= GRN_CTX_QUIT;
+    return GRN_SUCCESS;
+  }
   if (ctx->stat == GRN_CTX_QUIT) {
     bool have_buffer = false;
 


### PR DESCRIPTION
Sometimes the following response is received when canceling.

Example of command version 3 (Incomplete JSON) (`...` is the omission of an element):

```
{
  "body": {
  "columns":[...],
  "records":[
    [...],
    "header":{
      "return_code":-77,
      ...
    }
  }
```

If `ctx->rc` is `GRN_CANCEL`, we force using an empty result. Because creating result may be incomplete.
We can do it because the cancelled response must not be used.