### PR TITLE
packages: Remove `php-devel` from the Dockerfile in yum

### DIFF
--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -27,7 +27,6 @@ RUN \
     mecab-devel \
     msgpack-devel \
     openssl-devel \
-    php-devel \
     pkgconfig \
     python2-devel \
     rapidjson-devel \

--- a/packages/yum/almalinux-9/Dockerfile
+++ b/packages/yum/almalinux-9/Dockerfile
@@ -31,7 +31,6 @@ RUN \
     lz4-devel \
     msgpack-devel \
     openssl-devel \
-    php-devel \
     pkgconfig \
     ruby \
     simdjson-devel \

--- a/packages/yum/amazon-linux-2023/Dockerfile
+++ b/packages/yum/amazon-linux-2023/Dockerfile
@@ -20,7 +20,6 @@ RUN \
     libzstd-devel \
     lz4-devel \
     openssl-devel \
-    php-devel \
     pkgconfig \
     ruby \
     tar \


### PR DESCRIPTION
Not necessary since Groonga is not build for PHP.

Target files:
```
$ grep -ir php packages
packages/yum/almalinux-9/Dockerfile:    php-devel \
packages/yum/almalinux-8/Dockerfile:    php-devel \
packages/yum/amazon-linux-2023/Dockerfile:    php-devel \
```