### PR TITLE
ci: Fix the order of arguments in build.sh

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -109,6 +109,6 @@ jobs:
           sudo incus launch ${{ matrix.image }} target
           sudo incus config device add target host disk source=$PWD path=/host
           sudo incus exec target -- /host/setup.sh
-          sudo incus exec target -- /host/build.sh /host /tmp/local /tmp/build
+          sudo incus exec target -- /host/build.sh /host /tmp/build /tmp/local
           sudo incus stop target
           sudo incus delete target


### PR DESCRIPTION
```
$ ./build.sh
Usage: ./build.sh SOURCE_DIRECTORY BUILD_DIRECTORY INSTALL_PREFIX
 e.g.: ./build.sh . /tmp/build /tmp/local
```