### PR TITLE
clang-format: add include/groonga/cast.h

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,11 +23,11 @@ repos:
           ?benchmark/bench-distance\.c|
           ?include/groonga/applier\.h|
           ?include/groonga/bulk\.hpp|
+          ?include/groonga/cast\.h|
           ?include/groonga/column\.h|
           ?include/groonga/command_arguments\.hpp|
           ?include/groonga/dat\.h|
           ?include/groonga/db\.h|
-          ?include/groonga/cast\.h|
           ?include/groonga/distance\.h|
           ?include/groonga/error\.h|
           ?include/groonga/expr\.h|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
           ?include/groonga/command_arguments\.hpp|
           ?include/groonga/dat\.h|
           ?include/groonga/db\.h|
+          ?include/groonga/cast\.h|
           ?include/groonga/distance\.h|
           ?include/groonga/error\.h|
           ?include/groonga/expr\.h|

--- a/include/groonga/cast.h
+++ b/include/groonga/cast.h
@@ -21,7 +21,7 @@
 
 #include <groonga/option.h>
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -32,12 +32,13 @@ typedef struct {
   grn_obj *target;
 } grn_caster;
 
-GRN_API grn_rc grn_caster_cast(grn_ctx *ctx,
-                               grn_caster *caster);
-GRN_API grn_rc grn_obj_cast(grn_ctx *ctx,
-                            grn_obj *src,
-                            grn_obj *dest,
-                            grn_bool add_record_if_not_exist);
+GRN_API grn_rc
+grn_caster_cast(grn_ctx *ctx, grn_caster *caster);
+GRN_API grn_rc
+grn_obj_cast(grn_ctx *ctx,
+             grn_obj *src,
+             grn_obj *dest,
+             grn_bool add_record_if_not_exist);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
GitHub: GH-2024

We will add the documentation to the header of grn_obj_cast().
Therefore, we want to include this file in the formatting targets.