### PR TITLE
doc: update the generated file list by Shpinx v8.1.3

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -4539,28 +4539,23 @@ html_files_relative_from_locale_dir = \
 	html/_static/scripts/bootstrap.js \
 	html/_static/scripts/bootstrap.js.LICENSE.txt \
 	html/_static/scripts/bootstrap.js.map \
+	html/_static/scripts/fontawesome.js \
+	html/_static/scripts/fontawesome.js.LICENSE.txt \
+	html/_static/scripts/fontawesome.js.map \
 	html/_static/scripts/pydata-sphinx-theme.js \
 	html/_static/scripts/pydata-sphinx-theme.js.map \
 	html/_static/searchtools.js \
 	html/_static/sphinx_highlight.js \
-	html/_static/styles/bootstrap.css \
-	html/_static/styles/bootstrap.css.map \
 	html/_static/styles/pydata-sphinx-theme.css \
 	html/_static/styles/pydata-sphinx-theme.css.map \
 	html/_static/styles/theme.css \
 	html/_static/switcher.json \
-	html/_static/vendor/fontawesome/6.5.2/LICENSE.txt \
-	html/_static/vendor/fontawesome/6.5.2/css/all.min.css \
-	html/_static/vendor/fontawesome/6.5.2/js/all.min.js \
-	html/_static/vendor/fontawesome/6.5.2/js/all.min.js.LICENSE.txt \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2 \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.ttf \
-	html/_static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-brands-400.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-brands-400.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-regular-400.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-regular-400.woff2 \
+	html/_static/vendor/fontawesome/webfonts/fa-solid-900.ttf \
+	html/_static/vendor/fontawesome/webfonts/fa-solid-900.woff2 \
 	html/_static/webpack-macros.html \
 	html/characteristic.html \
 	html/client.html \

--- a/doc/files.cmake
+++ b/doc/files.cmake
@@ -1337,28 +1337,23 @@ set(GRN_DOC_HTML_FILES
     _static/scripts/bootstrap.js
     _static/scripts/bootstrap.js.LICENSE.txt
     _static/scripts/bootstrap.js.map
+    _static/scripts/fontawesome.js
+    _static/scripts/fontawesome.js.LICENSE.txt
+    _static/scripts/fontawesome.js.map
     _static/scripts/pydata-sphinx-theme.js
     _static/scripts/pydata-sphinx-theme.js.map
     _static/searchtools.js
     _static/sphinx_highlight.js
-    _static/styles/bootstrap.css
-    _static/styles/bootstrap.css.map
     _static/styles/pydata-sphinx-theme.css
     _static/styles/pydata-sphinx-theme.css.map
     _static/styles/theme.css
     _static/switcher.json
-    _static/vendor/fontawesome/6.5.2/LICENSE.txt
-    _static/vendor/fontawesome/6.5.2/css/all.min.css
-    _static/vendor/fontawesome/6.5.2/js/all.min.js
-    _static/vendor/fontawesome/6.5.2/js/all.min.js.LICENSE.txt
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-brands-400.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-regular-400.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-solid-900.woff2
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.ttf
-    _static/vendor/fontawesome/6.5.2/webfonts/fa-v4compatibility.woff2
+    _static/vendor/fontawesome/webfonts/fa-brands-400.ttf
+    _static/vendor/fontawesome/webfonts/fa-brands-400.woff2
+    _static/vendor/fontawesome/webfonts/fa-regular-400.ttf
+    _static/vendor/fontawesome/webfonts/fa-regular-400.woff2
+    _static/vendor/fontawesome/webfonts/fa-solid-900.ttf
+    _static/vendor/fontawesome/webfonts/fa-solid-900.woff2
     _static/webpack-macros.html
     characteristic.html
     client.html


### PR DESCRIPTION
This change fixed the following CI error  because the generated file list has been changed from Sphinx 8.1.3.

```
cp: cannot stat './html/_static/styles/bootstrap.css': No such file or directory
```
ref: https://github.com/groonga/groonga/actions/runs/11470920955/job/31920976581#step:9:18973

## How we updated the file list

We have updated the following commands.

```console
$ rm -rf ../groonga.doc && cmake -S . -B ../groonga.doc --preset=doc && cmake --build ../groonga.doc
$ ninja doc_update_files -C ../groonga.doc
```