### PR TITLE
doc reference object_inspect: fix a typo

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/commands/object_inspect.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/commands/object_inspect.po
@@ -543,7 +543,7 @@ msgstr ""
 msgid "The generator expression in :doc:`../grn_expr/script_syntax`."
 msgstr ":doc:`../grn_expr/script_syntax` の生成式です。"
 
-msgid ":ref:`column-create-generate`"
+msgid ":ref:`column-create-generator`"
 msgstr ""
 
 msgid "``GENERATED_COLUMN_SOURCE_ID``"


### PR DESCRIPTION
Because `column-create-generator` is correct name as below.

```
.. _column-create-generator:

``generator``
"""""""""""""

.. versionadded:: 14.1.0

Specifies a generator expression in :doc:`../grn_expr/script_syntax`
that is used to generate column value automatically.

This option is useful if you want to generate a column value from
other column value automatically.

The default value is none.
```

ref: https://github.com/groonga/groonga/blob/main/doc/source/reference/commands/column_create.rst?plain=1#L1880