### PR TITLE
logical_range_filter: Fix two records keys in response of command v3

### DIFF
--- a/lib/mrb/mrb_writer.c
+++ b/lib/mrb/mrb_writer.c
@@ -134,7 +134,7 @@ writer_close_map(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
-writer_open_result_set(mrb_state *mrb, mrb_value self)
+writer_open_result_set_internal(mrb_state *mrb, mrb_value self, bool with_records)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
   mrb_value mrb_table;
@@ -164,10 +164,26 @@ writer_open_result_set(mrb_state *mrb, mrb_value self)
       grn_mrb_ctx_check(mrb);
     }
   }
-  GRN_OUTPUT_RESULT_SET_OPEN(table, &format, (uint32_t)n_additional_elements);
+  if (with_records) {
+    GRN_OUTPUT_RESULT_SET_OPEN(table, &format, (uint32_t)n_additional_elements);
+  } else {
+    GRN_OUTPUT_RESULT_SET_OPEN_METADATA(table, &format, (uint32_t)n_additional_elements);
+  }
   grn_obj_format_fin(ctx, &format);
 
   return mrb_nil_value();
+}
+
+static mrb_value
+writer_open_result_set(mrb_state *mrb, mrb_value self)
+{
+  return writer_open_result_set_internal(mrb, self, true);
+}
+
+static mrb_value
+writer_open_result_set_metadata(mrb_state *mrb, mrb_value self)
+{
+  return writer_open_result_set_internal(mrb, self, false);
 }
 
 static mrb_value
@@ -321,6 +337,8 @@ grn_mrb_writer_init(grn_ctx *ctx)
 
   mrb_define_method(mrb, klass, "open_result_set",
                     writer_open_result_set, MRB_ARGS_ARG(3, 1));
+  mrb_define_method(mrb, klass, "open_result_set_metadata",
+                    writer_open_result_set_metadata, MRB_ARGS_ARG(3, 1));
   mrb_define_method(mrb, klass, "close_result_set",
                     writer_close_result_set, MRB_ARGS_NONE());
   mrb_define_method(mrb, klass, "open_table_records",

--- a/lib/output.c
+++ b/lib/output.c
@@ -2736,7 +2736,6 @@ grn_output_result_set_open(grn_ctx *ctx,
                            grn_obj_format *format,
                            uint32_t n_additional_elements)
 {
-  /* grn_output_result_set_open_metadata() to set `arrow_stream_writer`. */
   grn_output_result_set_open_metadata(ctx,
                                       outbuf,
                                       output_type,

--- a/lib/output.c
+++ b/lib/output.c
@@ -2703,6 +2703,14 @@ grn_output_result_set_open_metadata(grn_ctx *ctx,
                                     grn_obj_format *format,
                                     uint32_t n_additional_elements)
 {
+  if (output_type == GRN_CONTENT_APACHE_ARROW) {
+    if (ctx->impl->output.arrow_stream_writer) {
+      grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
+    }
+    ctx->impl->output.arrow_stream_writer =
+      grn_arrow_stream_writer_open(ctx, outbuf);
+  }
+
   if (grn_ctx_get_command_version(ctx) < GRN_COMMAND_VERSION_3) {
     grn_output_result_set_open_metadata_v1(ctx,
                                            outbuf,
@@ -2728,14 +2736,7 @@ grn_output_result_set_open(grn_ctx *ctx,
                            grn_obj_format *format,
                            uint32_t n_additional_elements)
 {
-  if (output_type == GRN_CONTENT_APACHE_ARROW) {
-    if (ctx->impl->output.arrow_stream_writer) {
-      grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
-    }
-    ctx->impl->output.arrow_stream_writer =
-      grn_arrow_stream_writer_open(ctx, outbuf);
-  }
-
+  /* grn_output_result_set_open_metadata() to set `arrow_stream_writer`. */
   grn_output_result_set_open_metadata(ctx,
                                       outbuf,
                                       output_type,

--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -40,7 +40,7 @@ module Groonga
               n_elements += result_set.size
 
               if is_first
-                writer.open_result_set_metadata(result_set, output_columns, -1)
+                writer.open_result_set_metadata(result_set, output_columns, -1, 1)
                 writer.open_table_records(-1)
                 is_first = false
               end

--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -40,7 +40,7 @@ module Groonga
               n_elements += result_set.size
 
               if is_first
-                writer.open_result_set(result_set, output_columns, -1)
+                writer.open_result_set_metadata(result_set, output_columns, -1)
                 writer.open_table_records(-1)
                 is_first = false
               end


### PR DESCRIPTION
GitHub: fixes GH-2026

Example of invalid JSON:

```
...
    "records": [],
    "records": [
      ...
    ],
...
```

An empty array of `records` is output first.

`GRN_OUTPUT_RESULT_SET_OPEN` would output up to `records`, resulting in two `records`, so use `GRN_OUTPUT_RESULT_SET_OPEN_METADATA` instead.