### PR TITLE
docs: api/grn_index_cursor: move grn_index_cursor_next() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_index_cursor.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_index_cursor.po
@@ -53,15 +53,3 @@ msgstr ""
 
 msgid "出力するレコードidの上限を指定します。"
 msgstr ""
-
-msgid "cursorの範囲内のインデックスの値を順番に取り出します。"
-msgstr ""
-
-msgid "tidにNULL以外を指定した場合は、index_cursorを作成するときに指定したtable_cursorの現在の対象レコードのidを返します。"
-msgstr ""
-
-msgid "戻り値である :c:type:`grn_posting` 構造体は解放する必要はありません。"
-msgstr ""
-
-msgid "テーブルレコードIDを指定します。"
-msgstr ""

--- a/doc/source/reference/api/grn_index_cursor.rst
+++ b/doc/source/reference/api/grn_index_cursor.rst
@@ -28,15 +28,3 @@ Reference
    :param index: 対象インデックスカラムを指定します。
    :param rid_min: 出力するレコードidの下限を指定します。
    :param rid_max: 出力するレコードidの上限を指定します。
- 
-.. c:function:: grn_posting *grn_index_cursor_next(grn_ctx *ctx, grn_obj *ic, grn_id *tid)
- 
-   cursorの範囲内のインデックスの値を順番に取り出します。
-
-   tidにNULL以外を指定した場合は、index_cursorを作成するときに指定したtable_cursorの現在の対象レコードのidを返します。
-
-   戻り値である :c:type:`grn_posting` 構造体は解放する必要はありません。
-
-   :param ic: 対象cursorを指定します。
-   :param tid: テーブルレコードIDを指定します。
-

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -501,15 +501,16 @@ grn_index_cursor_reset_start_position(grn_ctx *ctx, grn_obj *index_cursor);
 GRN_API uint32_t
 grn_index_cursor_get_start_position(grn_ctx *ctx, grn_obj *index_cursor);
 /**
- * \brief Retrieve the posting information and move the cursor to the the next.
+ * \brief Retrieve the current posting information and move the cursor to the
+ *        the next.
  *
  * \param ctx The context object.
  * \param index_cursor Target cursor.
  * \param term_id The buffer to store the ID of the current target record of
- *                cursor. If NULL is specified, it will not be stored.
+ *                cursor. If `NULL` is specified, it will not be stored.
  *
- * \return \ref grn_posting if the next posting is found, NULL if not.
- *         Return value \ref grn_posting need not be freed.
+ * \return \ref grn_posting if the next posting is found, `NULL` otherwise.
+ *         You don't need to free the returned \ref grn_posting.
  */
 GRN_API grn_posting *
 grn_index_cursor_next(grn_ctx *ctx, grn_obj *index_cursor, grn_id *term_id);

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -500,6 +500,17 @@ GRN_API grn_rc
 grn_index_cursor_reset_start_position(grn_ctx *ctx, grn_obj *index_cursor);
 GRN_API uint32_t
 grn_index_cursor_get_start_position(grn_ctx *ctx, grn_obj *index_cursor);
+/**
+ * \brief Retrieve the posting information and move the cursor to the the next.
+ *
+ * \param ctx The context object.
+ * \param index_cursor Target cursor.
+ * \param term_id The buffer to store the ID of the current target record of
+ *                cursor. If NULL is specified, it will not be stored.
+ *
+ * \return \ref grn_posting if the next posting is found, NULL if not.
+ *         Return value \ref grn_posting need not be freed.
+ */
 GRN_API grn_posting *
 grn_index_cursor_next(grn_ctx *ctx, grn_obj *index_cursor, grn_id *term_id);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.