### PR TITLE
docs: api/grn_index_cursor: move grn_index_cursor_open() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_index_cursor.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_index_cursor.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_index_cursor``"
 msgstr ""
 
@@ -33,23 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid ":c:type:`grn_table_cursor` から取得できるそれぞれのレコードについて、 ``GRN_OBJ_COLUMN_INDEX`` 型のカラムの値を順番に取り出すためのカーソルを生成して返します。"
-msgstr ""
-
-msgid "rid_min, rid_maxを指定して取得するレコードidの値を制限することができます。"
-msgstr ""
-
-msgid "戻り値であるgrn_index_cursorは :c:func:`grn_obj_close()` を使って解放します。"
-msgstr ""
-
-msgid "対象cursorを指定します。"
-msgstr ""
-
-msgid "対象インデックスカラムを指定します。"
-msgstr ""
-
-msgid "出力するレコードidの下限を指定します。"
-msgstr ""
-
-msgid "出力するレコードidの上限を指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_index_cursor.rst
+++ b/doc/source/reference/api/grn_index_cursor.rst
@@ -16,15 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:function:: grn_obj *grn_index_cursor_open(grn_ctx *ctx, grn_table_cursor *tc, grn_obj *index, grn_id rid_min, grn_id rid_max, int flags)
- 
-   :c:type:`grn_table_cursor` から取得できるそれぞれのレコードについて、 ``GRN_OBJ_COLUMN_INDEX`` 型のカラムの値を順番に取り出すためのカーソルを生成して返します。
-
-   rid_min, rid_maxを指定して取得するレコードidの値を制限することができます。
-
-   戻り値であるgrn_index_cursorは :c:func:`grn_obj_close()` を使って解放します。
-
-   :param tc: 対象cursorを指定します。
-   :param index: 対象インデックスカラムを指定します。
-   :param rid_min: 出力するレコードidの下限を指定します。
-   :param rid_max: 出力するレコードidの上限を指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -466,6 +466,26 @@ grn_table_cursor_get_max_n_records(grn_ctx *ctx, grn_table_cursor *cursor);
 GRN_API grn_obj *
 grn_table_cursor_table(grn_ctx *ctx, grn_table_cursor *tc);
 
+/**
+ * \brief Create index cursor.
+ *
+ * For each record in `tc`, create a cursor to retrieve the record in `index`.
+ * You can specify `rid_min` and `rid_max` to limit the records to be retrieved.
+ *
+ * If you specify `NULL` for `tc`, you must specify the target `term_id` with
+ * \ref grn_index_cursor_set_term_id.
+ *
+ * \param ctx The context object
+ * \param tc The table cursor.
+ * \param index The index column (Object in \ref GRN_OBJ_COLUMN_INDEX).
+ * \param rid_min Minimum record ID of index column.
+ * \param rid_max Maximum record ID of index column.
+ * \param flags `0` or \ref GRN_OBJ_WITH_POSITION.
+ *
+ * \return The index cursor on success, `NULL` on error.
+ *         `NULL` if memory allocation fails.
+ *         You must free the return index cursor with \ref grn_obj_close.
+ */
 GRN_API grn_obj *
 grn_index_cursor_open(grn_ctx *ctx,
                       grn_table_cursor *tc,

--- a/include/groonga/table.h
+++ b/include/groonga/table.h
@@ -467,23 +467,26 @@ GRN_API grn_obj *
 grn_table_cursor_table(grn_ctx *ctx, grn_table_cursor *tc);
 
 /**
- * \brief Create index cursor.
+ * \brief Create a cursor that returns postings in \ref GRN_OBJ_COLUMN_INDEX.
  *
- * For each record in `tc`, create a cursor to retrieve the record in `index`.
- * You can specify `rid_min` and `rid_max` to limit the records to be retrieved.
+ * If you specify a valid \ref grn_table_cursor as `tc`, the created cursor
+ * returns all postings for records that are retrieved by `tc`.
  *
- * If you specify `NULL` for `tc`, you must specify the target `term_id` with
+ * If you specify `NULL` as `tc`, the create cursor returns all postings only
+ * for the specified term ID. You must set the term ID by
  * \ref grn_index_cursor_set_term_id.
+ *
+ * You can specify `rid_min` and `rid_max` to limit the postings to be
+ * retrieved.
  *
  * \param ctx The context object
  * \param tc The table cursor.
  * \param index The index column (Object in \ref GRN_OBJ_COLUMN_INDEX).
- * \param rid_min Minimum record ID of index column.
- * \param rid_max Maximum record ID of index column.
+ * \param rid_min Minimum record ID of posting.
+ * \param rid_max Maximum record ID of posting.
  * \param flags `0` or \ref GRN_OBJ_WITH_POSITION.
  *
  * \return The index cursor on success, `NULL` on error.
- *         `NULL` if memory allocation fails.
  *         You must free the return index cursor with \ref grn_obj_close.
  */
 GRN_API grn_obj *


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.