### PR TITLE
request_cancel: Fix a bug that canceled request may return an invalid response

### DIFF
--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2222,23 +2222,12 @@ grn_ctx_recv(grn_ctx *ctx, char **str, unsigned int *str_len, int *flags)
         ctx->errline = 0;
         ctx->errfile = NULL;
         ctx->errfunc = NULL;
-        if (ctx->rc == GRN_CANCEL) {
-          *str = NULL;
-          *str_len = 0;
-          *flags = GRN_CTX_QUIT;
-        }
       }
       goto exit;
     } else {
-      if (ctx->rc == GRN_CANCEL) {
-        *str = NULL;
-        *str_len = 0;
-        *flags = GRN_CTX_QUIT;
-      } else {
-        grn_obj *buf = ctx->impl->output.buf;
-        *str = GRN_BULK_HEAD(buf);
-        *str_len = (unsigned int)GRN_BULK_VSIZE(buf);
-      }
+      grn_obj *buf = ctx->impl->output.buf;
+      *str = GRN_BULK_HEAD(buf);
+      *str_len = (unsigned int)GRN_BULK_VSIZE(buf);
       GRN_BULK_REWIND(ctx->impl->output.buf);
       goto exit;
     }

--- a/plugins/sharding/logical_range_filter.rb
+++ b/plugins/sharding/logical_range_filter.rb
@@ -61,6 +61,11 @@ module Groonga
             writer.close_result_set
           end
           query_logger.log(:size, ":", "output(#{n_elements})")
+        rescue Groonga::Cancel
+          unless is_first
+            writer.close_table_records
+            writer.close_result_set
+          end
         ensure
           context.close
         end


### PR DESCRIPTION
Sometimes the following response is received when canceling. Example of command version 3 (Incomplete JSON) (`...` is the omission of an element):

```
{
  "body": {
  "columns":[...],
  "records":[
    [...],
    "header":{
      "return_code":-77,
      ...
    }
  }
```

I found that the e5400b36db0820c8baf37bacafa7d70b67129bb9 approach did not fix it.
Bugs with invalid JSON occur during the streaming process.

In particular, `logical_range_filter` may raise an exception and not output all if `request_cancel`.
Fix `logical_range_filter` to output closing brackets in case of exception due to cancellation, so that it becomes normal JSON.