### PR TITLE
output: grn_output_table_records: Separate open and content

### DIFF
--- a/lib/output.c
+++ b/lib/output.c
@@ -2600,6 +2600,17 @@ grn_output_table_records(grn_ctx *ctx,
 }
 
 static void
+grn_output_table_records_close_v1(grn_ctx *ctx,
+                                  grn_obj *outbuf,
+                                  grn_content_type output_type,
+                                  grn_obj_format *format)
+{
+  if (format) {
+    grn_output_table_records_close(ctx, outbuf, output_type);
+  }
+}
+
+static void
 grn_output_table_records_content_v1(grn_ctx *ctx,
                                     grn_obj *outbuf,
                                     grn_content_type output_type,
@@ -2607,9 +2618,7 @@ grn_output_table_records_content_v1(grn_ctx *ctx,
                                     grn_obj_format *format)
 {
   grn_output_table_records_content(ctx, outbuf, output_type, table, format);
-  if (format) {
-    grn_output_table_records_close(ctx, outbuf, output_type);
-  }
+  grn_output_table_records_close_v1(ctx, outbuf, output_type, format);
 }
 
 static void
@@ -2655,6 +2664,19 @@ grn_output_result_set_close_v1(grn_ctx *ctx,
 }
 
 static void
+grn_output_table_records_close_v3(grn_ctx *ctx,
+                                  grn_obj *outbuf,
+                                  grn_content_type output_type,
+                                  grn_obj_format *format)
+{
+  if (format) {
+    grn_output_table_records_close(ctx, outbuf, output_type);
+  } else {
+    grn_output_array_close(ctx, outbuf, output_type);
+  }
+}
+
+static void
 grn_output_table_records_content_v3(grn_ctx *ctx,
                                     grn_obj *outbuf,
                                     grn_content_type output_type,
@@ -2662,11 +2684,7 @@ grn_output_table_records_content_v3(grn_ctx *ctx,
                                     grn_obj_format *format)
 {
   grn_output_table_records_content(ctx, outbuf, output_type, table, format);
-  if (format) {
-    grn_output_table_records_close(ctx, outbuf, output_type);
-  } else {
-    grn_output_array_close(ctx, outbuf, output_type);
-  }
+  grn_output_table_records_close_v3(ctx, outbuf, output_type, format);
 }
 
 static void


### PR DESCRIPTION
GitHub: Related: GH-2031, GH-2043

Prepare to fix the output of `records`.

Added grn_output_table_records_content_v1().
Also added grn_output_table_records_content_v3().

The closing process is still included in content() because it is still being separated, but we plan to separate the closing process later.
The process of executing content() in open() will also be separated.