### PR TITLE
output: Add grn_output_result_set_content()

### DIFF
--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2762,6 +2762,11 @@ grn_ctx_output_result_set_open(grn_ctx *ctx,
                              result_set,
                              format,
                              n_additional_elements);
+  grn_output_result_set_content(ctx,
+                                ctx->impl->output.buf,
+                                ctx->impl->output.type,
+                                result_set,
+                                format);
 }
 
 void

--- a/lib/grn_output.h
+++ b/lib/grn_output.h
@@ -36,6 +36,12 @@ grn_output_result_set_open(grn_ctx *ctx,
                            grn_obj_format *format,
                            uint32_t n_additional_elements);
 GRN_API void
+grn_output_result_set_content(grn_ctx *ctx,
+                              grn_obj *outbuf,
+                              grn_content_type output_type,
+                              grn_obj *result_set,
+                              grn_obj_format *format);
+GRN_API void
 grn_output_result_set_close(grn_ctx *ctx,
                             grn_obj *outbuf,
                             grn_content_type output_type,

--- a/lib/output.c
+++ b/lib/output.c
@@ -2600,28 +2600,6 @@ grn_output_table_records(grn_ctx *ctx,
 }
 
 static void
-grn_output_table_records_close_v1(grn_ctx *ctx,
-                                  grn_obj *outbuf,
-                                  grn_content_type output_type,
-                                  grn_obj_format *format)
-{
-  if (format) {
-    grn_output_table_records_close(ctx, outbuf, output_type);
-  }
-}
-
-static void
-grn_output_table_records_content_v1(grn_ctx *ctx,
-                                    grn_obj *outbuf,
-                                    grn_content_type output_type,
-                                    grn_obj *table,
-                                    grn_obj_format *format)
-{
-  grn_output_table_records_content(ctx, outbuf, output_type, table, format);
-  grn_output_table_records_close_v1(ctx, outbuf, output_type, format);
-}
-
-static void
 grn_output_result_set_open_v1(grn_ctx *ctx,
                               grn_obj *outbuf,
                               grn_content_type output_type,
@@ -2650,7 +2628,6 @@ grn_output_result_set_open_v1(grn_ctx *ctx,
   } else {
     grn_output_array_open(ctx, outbuf, output_type, "HIT", -1);
   }
-  grn_output_table_records_content_v1(ctx, outbuf, output_type, table, format);
 }
 
 static void
@@ -2664,30 +2641,6 @@ grn_output_result_set_close_v1(grn_ctx *ctx,
 }
 
 static void
-grn_output_table_records_close_v3(grn_ctx *ctx,
-                                  grn_obj *outbuf,
-                                  grn_content_type output_type,
-                                  grn_obj_format *format)
-{
-  if (format) {
-    grn_output_table_records_close(ctx, outbuf, output_type);
-  } else {
-    grn_output_array_close(ctx, outbuf, output_type);
-  }
-}
-
-static void
-grn_output_table_records_content_v3(grn_ctx *ctx,
-                                    grn_obj *outbuf,
-                                    grn_content_type output_type,
-                                    grn_obj *table,
-                                    grn_obj_format *format)
-{
-  grn_output_table_records_content(ctx, outbuf, output_type, table, format);
-  grn_output_table_records_close_v3(ctx, outbuf, output_type, format);
-}
-
-static void
 grn_output_result_set_open_v3(grn_ctx *ctx,
                               grn_obj *outbuf,
                               grn_content_type output_type,
@@ -2697,7 +2650,7 @@ grn_output_result_set_open_v3(grn_ctx *ctx,
 {
   if (format) {
     int n_elements = 2;
-    /* result_set: {"n_hits": N, ("columns": COLUMNS,) "records": records} */
+    /* result_set: {"n_hits": N, ("columns": COLUMNS,) "records": */
     if (format->flags & GRN_OBJ_FORMAT_WITH_COLUMN_NAMES) {
       n_elements++;
     }
@@ -2715,11 +2668,6 @@ grn_output_result_set_open_v3(grn_ctx *ctx,
     grn_output_cstr(ctx, outbuf, output_type, "keys");
     grn_output_array_open(ctx, outbuf, output_type, "keys", (int)n_records);
   }
-  grn_output_table_records_content_v3(ctx,
-                                      outbuf,
-                                      output_type,
-                                      result_set,
-                                      format);
 }
 
 static void
@@ -2766,6 +2714,21 @@ grn_output_result_set_open(grn_ctx *ctx,
 }
 
 void
+grn_output_result_set_content(grn_ctx *ctx,
+                              grn_obj *outbuf,
+                              grn_content_type output_type,
+                              grn_obj *result_set,
+                              grn_obj_format *format)
+{
+  grn_output_table_records_content(ctx,
+                                   outbuf,
+                                   output_type,
+                                   result_set,
+                                   format);
+  grn_output_table_records_close(ctx, outbuf, output_type);
+}
+
+void
 grn_output_result_set_close(grn_ctx *ctx,
                             grn_obj *outbuf,
                             grn_content_type output_type,
@@ -2809,6 +2772,7 @@ grn_output_result_set(grn_ctx *ctx,
                              result_set,
                              format,
                              n_additional_elements);
+  grn_output_result_set_content(ctx, outbuf, output_type, result_set, format);
   grn_output_result_set_close(ctx, outbuf, output_type, result_set, format);
 }
 


### PR DESCRIPTION
GitHub: Related: GH-2031

Prepare to fix the output of `records`.

Add grn_output_result_set_content() to output `[...]` of `records`.

Added `grn_output_table_records_close_v*` but removed it because it was already abstracted and unnecessary.
`grn_output_table_records_content_v*` was removed since it is common in v1 and v3.