### PR TITLE
output: Add grn_output_result_set_open_metadata()

### DIFF
--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -205,10 +205,10 @@ grn_ctx_output_bool(grn_ctx *ctx, bool value);
 GRN_API void
 grn_ctx_output_obj(grn_ctx *ctx, grn_obj *value, grn_obj_format *format);
 GRN_API void
-grn_ctx_output_result_set_header(grn_ctx *ctx,
-                                 grn_obj *result_set,
-                                 grn_obj_format *format,
-                                 uint32_t n_additional_elements);
+grn_ctx_output_result_set_open_metadata(grn_ctx *ctx,
+                                        grn_obj *result_set,
+                                        grn_obj_format *format,
+                                        uint32_t n_additional_elements);
 GRN_API void
 grn_ctx_output_result_set_open(grn_ctx *ctx,
                                grn_obj *result_set,

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -205,6 +205,11 @@ grn_ctx_output_bool(grn_ctx *ctx, bool value);
 GRN_API void
 grn_ctx_output_obj(grn_ctx *ctx, grn_obj *value, grn_obj_format *format);
 GRN_API void
+grn_ctx_output_result_set_header(grn_ctx *ctx,
+                                 grn_obj *result_set,
+                                 grn_obj_format *format,
+                                 uint32_t n_additional_elements);
+GRN_API void
 grn_ctx_output_result_set_open(grn_ctx *ctx,
                                grn_obj *result_set,
                                grn_obj_format *format,

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2751,17 +2751,17 @@ grn_ctx_output_obj(grn_ctx *ctx, grn_obj *value, grn_obj_format *format)
 }
 
 void
-grn_ctx_output_result_set_header(grn_ctx *ctx,
-                                 grn_obj *result_set,
-                                 grn_obj_format *format,
-                                 uint32_t n_additional_elements)
+grn_ctx_output_result_set_open_metadata(grn_ctx *ctx,
+                                        grn_obj *result_set,
+                                        grn_obj_format *format,
+                                        uint32_t n_additional_elements)
 {
-  grn_output_result_set_header(ctx,
-                               ctx->impl->output.buf,
-                               ctx->impl->output.type,
-                               result_set,
-                               format,
-                               n_additional_elements);
+  grn_output_result_set_open_metadata(ctx,
+                                      ctx->impl->output.buf,
+                                      ctx->impl->output.type,
+                                      result_set,
+                                      format,
+                                      n_additional_elements);
 }
 
 void

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2751,6 +2751,20 @@ grn_ctx_output_obj(grn_ctx *ctx, grn_obj *value, grn_obj_format *format)
 }
 
 void
+grn_ctx_output_result_set_header(grn_ctx *ctx,
+                                 grn_obj *result_set,
+                                 grn_obj_format *format,
+                                 uint32_t n_additional_elements)
+{
+  grn_output_result_set_header(ctx,
+                               ctx->impl->output.buf,
+                               ctx->impl->output.type,
+                               result_set,
+                               format,
+                               n_additional_elements);
+}
+
+void
 grn_ctx_output_result_set_open(grn_ctx *ctx,
                                grn_obj *result_set,
                                grn_obj_format *format,

--- a/lib/grn_output.h
+++ b/lib/grn_output.h
@@ -29,6 +29,13 @@ void
 grn_output_init_from_env(void);
 
 GRN_API void
+grn_output_result_set_header(grn_ctx *ctx,
+                             grn_obj *outbuf,
+                             grn_content_type output_type,
+                             grn_obj *result_set,
+                             grn_obj_format *format,
+                             uint32_t n_additional_elements);
+GRN_API void
 grn_output_result_set_open(grn_ctx *ctx,
                            grn_obj *outbuf,
                            grn_content_type output_type,
@@ -99,6 +106,13 @@ grn_obj_format_set_columns(grn_ctx *ctx,
   (grn_ctx_output_str(ctx, value, value_len))
 #define GRN_OUTPUT_BOOL(value)      (grn_ctx_output_bool(ctx, value))
 #define GRN_OUTPUT_OBJ(obj, format) (grn_ctx_output_obj(ctx, obj, format))
+#define GRN_OUTPUT_RESULT_SET_HEADER(result_set,                               \
+                                     format,                                   \
+                                     n_additional_elements)                    \
+  (grn_ctx_output_result_set_header(ctx,                                       \
+                                    result_set,                                \
+                                    format,                                    \
+                                    n_additional_elements))
 #define GRN_OUTPUT_RESULT_SET_OPEN(result_set, format, n_additional_elements)  \
   (grn_ctx_output_result_set_open(ctx,                                         \
                                   result_set,                                  \

--- a/lib/grn_output.h
+++ b/lib/grn_output.h
@@ -29,12 +29,12 @@ void
 grn_output_init_from_env(void);
 
 GRN_API void
-grn_output_result_set_header(grn_ctx *ctx,
-                             grn_obj *outbuf,
-                             grn_content_type output_type,
-                             grn_obj *result_set,
-                             grn_obj_format *format,
-                             uint32_t n_additional_elements);
+grn_output_result_set_open_metadata(grn_ctx *ctx,
+                                    grn_obj *outbuf,
+                                    grn_content_type output_type,
+                                    grn_obj *result_set,
+                                    grn_obj_format *format,
+                                    uint32_t n_additional_elements);
 GRN_API void
 grn_output_result_set_open(grn_ctx *ctx,
                            grn_obj *outbuf,
@@ -106,13 +106,13 @@ grn_obj_format_set_columns(grn_ctx *ctx,
   (grn_ctx_output_str(ctx, value, value_len))
 #define GRN_OUTPUT_BOOL(value)      (grn_ctx_output_bool(ctx, value))
 #define GRN_OUTPUT_OBJ(obj, format) (grn_ctx_output_obj(ctx, obj, format))
-#define GRN_OUTPUT_RESULT_SET_HEADER(result_set,                               \
-                                     format,                                   \
-                                     n_additional_elements)                    \
-  (grn_ctx_output_result_set_header(ctx,                                       \
-                                    result_set,                                \
-                                    format,                                    \
-                                    n_additional_elements))
+#define GRN_OUTPUT_RESULT_SET_OPEN_METADATA(result_set,                        \
+                                            format,                            \
+                                            n_additional_elements)             \
+  (grn_ctx_output_result_set_open_metadata(ctx,                                \
+                                           result_set,                         \
+                                           format,                             \
+                                           n_additional_elements))
 #define GRN_OUTPUT_RESULT_SET_OPEN(result_set, format, n_additional_elements)  \
   (grn_ctx_output_result_set_open(ctx,                                         \
                                   result_set,                                  \

--- a/lib/output.c
+++ b/lib/output.c
@@ -2602,12 +2602,12 @@ grn_output_table_records(grn_ctx *ctx,
 }
 
 static void
-grn_output_result_set_header_v1(grn_ctx *ctx,
-                                grn_obj *outbuf,
-                                grn_content_type output_type,
-                                grn_obj *table,
-                                grn_obj_format *format,
-                                uint32_t n_additional_elements)
+grn_output_result_set_open_metadata_v1(grn_ctx *ctx,
+                                       grn_obj *outbuf,
+                                       grn_content_type output_type,
+                                       grn_obj *table,
+                                       grn_obj_format *format,
+                                       uint32_t n_additional_elements)
 {
   if (format) {
     int resultset_size = 1;
@@ -2642,12 +2642,12 @@ grn_output_result_set_close_v1(grn_ctx *ctx,
 }
 
 static void
-grn_output_result_set_header_v3(grn_ctx *ctx,
-                                grn_obj *outbuf,
-                                grn_content_type output_type,
-                                grn_obj *result_set,
-                                grn_obj_format *format,
-                                uint32_t n_additional_elements)
+grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
+                                       grn_obj *outbuf,
+                                       grn_content_type output_type,
+                                       grn_obj *result_set,
+                                       grn_obj_format *format,
+                                       uint32_t n_additional_elements)
 {
   if (format) {
     int n_elements = 2;
@@ -2681,27 +2681,27 @@ grn_output_result_set_close_v3(grn_ctx *ctx,
 }
 
 void
-grn_output_result_set_header(grn_ctx *ctx,
-                             grn_obj *outbuf,
-                             grn_content_type output_type,
-                             grn_obj *result_set,
-                             grn_obj_format *format,
-                             uint32_t n_additional_elements)
+grn_output_result_set_open_metadata(grn_ctx *ctx,
+                                    grn_obj *outbuf,
+                                    grn_content_type output_type,
+                                    grn_obj *result_set,
+                                    grn_obj_format *format,
+                                    uint32_t n_additional_elements)
 {
   if (grn_ctx_get_command_version(ctx) < GRN_COMMAND_VERSION_3) {
-    grn_output_result_set_header_v1(ctx,
-                                    outbuf,
-                                    output_type,
-                                    result_set,
-                                    format,
-                                    n_additional_elements);
+    grn_output_result_set_open_metadata_v1(ctx,
+                                           outbuf,
+                                           output_type,
+                                           result_set,
+                                           format,
+                                           n_additional_elements);
   } else {
-    grn_output_result_set_header_v3(ctx,
-                                    outbuf,
-                                    output_type,
-                                    result_set,
-                                    format,
-                                    n_additional_elements);
+    grn_output_result_set_open_metadata_v3(ctx,
+                                           outbuf,
+                                           output_type,
+                                           result_set,
+                                           format,
+                                           n_additional_elements);
   }
 }
 
@@ -2721,12 +2721,12 @@ grn_output_result_set_open(grn_ctx *ctx,
       grn_arrow_stream_writer_open(ctx, outbuf);
   }
 
-  grn_output_result_set_header(ctx,
-                               outbuf,
-                               output_type,
-                               result_set,
-                               format,
-                               n_additional_elements);
+  grn_output_result_set_open_metadata(ctx,
+                                      outbuf,
+                                      output_type,
+                                      result_set,
+                                      format,
+                                      n_additional_elements);
   grn_output_table_records(ctx, outbuf, output_type, result_set, format);
 }
 

--- a/lib/output.c
+++ b/lib/output.c
@@ -2517,6 +2517,22 @@ grn_output_table_records_open(grn_ctx *ctx,
 }
 
 void
+grn_output_table_keys_open(grn_ctx *ctx,
+                           grn_obj *outbuf,
+                           grn_content_type output_type,
+                           int n_records)
+{
+  if (output_type == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
+
+  if (grn_ctx_get_command_version(ctx) >= GRN_COMMAND_VERSION_3) {
+    grn_output_cstr(ctx, outbuf, output_type, "keys");
+    grn_output_array_open(ctx, outbuf, output_type, "keys", n_records);
+  }
+}
+
+void
 grn_output_table_records_close(grn_ctx *ctx,
                                grn_obj *outbuf,
                                grn_content_type output_type)
@@ -2596,6 +2612,9 @@ grn_output_table_records(grn_ctx *ctx,
 {
   if (format) {
     grn_output_table_records_open(ctx, outbuf, output_type, format->limit);
+  } else {
+    unsigned int n_records = grn_table_size(ctx, table);
+    grn_output_table_keys_open(ctx, outbuf, output_type, (int)n_records);
   }
   grn_output_table_records_content(ctx, outbuf, output_type, table, format);
   grn_output_table_records_close(ctx, outbuf, output_type);
@@ -2664,9 +2683,6 @@ grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
   } else {
     int n_elements = 1 + (int)n_additional_elements;
     grn_output_map_open(ctx, outbuf, output_type, "result_set", n_elements);
-    unsigned int n_records = grn_table_size(ctx, result_set);
-    grn_output_cstr(ctx, outbuf, output_type, "keys");
-    grn_output_array_open(ctx, outbuf, output_type, "keys", (int)n_records);
   }
 }
 

--- a/lib/output.c
+++ b/lib/output.c
@@ -2668,20 +2668,19 @@ grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
                                        grn_obj_format *format,
                                        uint32_t n_additional_elements)
 {
+  int n_elements = (int)n_additional_elements;
   if (format) {
-    int n_elements = 2;
     /* result_set: {"n_hits": N, ("columns": COLUMNS,) */
     if (format->flags & GRN_OBJ_FORMAT_WITH_COLUMN_NAMES) {
       n_elements++;
     }
-    n_elements += (int)n_additional_elements;
+    n_elements++;
     grn_output_map_open(ctx, outbuf, output_type, "result_set", n_elements);
     grn_output_result_set_n_hits(ctx, outbuf, output_type, format);
     if (format->flags & GRN_OBJ_FORMAT_WITH_COLUMN_NAMES) {
       grn_output_table_columns(ctx, outbuf, output_type, result_set, format);
     }
   } else {
-    int n_elements = 1 + (int)n_additional_elements;
     grn_output_map_open(ctx, outbuf, output_type, "result_set", n_elements);
   }
 }

--- a/lib/output.c
+++ b/lib/output.c
@@ -2671,10 +2671,10 @@ grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
   int n_elements = (int)n_additional_elements;
   if (format) {
     /* result_set: {"n_hits": N, ("columns": COLUMNS,) */
+    n_elements++;
     if (format->flags & GRN_OBJ_FORMAT_WITH_COLUMN_NAMES) {
       n_elements++;
     }
-    n_elements++;
     grn_output_map_open(ctx, outbuf, output_type, "result_set", n_elements);
     grn_output_result_set_n_hits(ctx, outbuf, output_type, format);
     if (format->flags & GRN_OBJ_FORMAT_WITH_COLUMN_NAMES) {

--- a/lib/output.c
+++ b/lib/output.c
@@ -2516,7 +2516,7 @@ grn_output_table_records_open(grn_ctx *ctx,
   }
 }
 
-void
+static void
 grn_output_table_keys_open(grn_ctx *ctx,
                            grn_obj *outbuf,
                            grn_content_type output_type,

--- a/lib/output.c
+++ b/lib/output.c
@@ -2741,7 +2741,7 @@ grn_output_result_set_open(grn_ctx *ctx,
                                       output_type,
                                       result_set,
                                       format,
-                                      n_additional_elements);
+                                      n_additional_elements + 1);
   grn_output_table_records(ctx, outbuf, output_type, result_set, format);
 }
 


### PR DESCRIPTION
GitHub: Related: GH-2031

Prepare to fix the output of `records`.

Add grn_output_result_set_open_metadata()  to output only the metadata part.

Added `grn_output_table_records_close_v*` but removed it because it was already abstracted and unnecessary. `grn_output_table_records_content_v*` was removed since it is common in v1 and v3.