### PR TITLE
docs: api/grn_column: move GRN_COLUMN_NAME_KEY{,_LEN} reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_column.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_column.po
@@ -36,23 +36,14 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "It returns the name of :doc:`/reference/columns/pseudo` ``_key``."
-msgstr ""
-
-msgid "It is useful to use with :c:macro:`GRN_COLUMN_NAME_KEY_LEN` like the following::"
-msgstr ""
-
-msgid "Since 3.1.1."
-msgstr "3.1.1から。"
-
-msgid "It returns the byte size of :c:macro:`GRN_COLUMN_NAME_KEY`."
-msgstr ""
-
 msgid "It returns the name of :doc:`/reference/columns/pseudo` ``_value``."
 msgstr ""
 
 msgid "It is useful to use with :c:macro:`GRN_COLUMN_NAME_VALUE_LEN` like the following::"
 msgstr ""
+
+msgid "Since 3.1.1."
+msgstr "3.1.1から。"
 
 msgid "It returns the byte size of :c:macro:`GRN_COLUMN_NAME_VALUE`."
 msgstr ""

--- a/doc/source/reference/api/grn_column.rst
+++ b/doc/source/reference/api/grn_column.rst
@@ -18,24 +18,6 @@ TODO...
 Reference
 ---------
 
-.. c:macro:: GRN_COLUMN_NAME_KEY
-
-   It returns the name of :doc:`/reference/columns/pseudo` ``_key``.
-
-   It is useful to use with :c:macro:`GRN_COLUMN_NAME_KEY_LEN` like
-   the following::
-
-     grn_obj *key_column;
-     key_column = grn_ctx_get(ctx, GRN_COLUMN_NAME_KEY, GRN_COLUMN_NAME_KEY_LEN);
-
-   Since 3.1.1.
-
-.. c:macro:: GRN_COLUMN_NAME_KEY_LEN
-
-   It returns the byte size of :c:macro:`GRN_COLUMN_NAME_KEY`.
-
-   Since 3.1.1.
-
 .. c:macro:: GRN_COLUMN_NAME_VALUE
 
    It returns the name of :doc:`/reference/columns/pseudo` ``_value``.

--- a/include/groonga/column.h
+++ b/include/groonga/column.h
@@ -57,8 +57,37 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  */
-#define GRN_COLUMN_NAME_ID_LEN       (sizeof(GRN_COLUMN_NAME_ID) - 1)
-#define GRN_COLUMN_NAME_KEY          "_key"
+#define GRN_COLUMN_NAME_ID_LEN (sizeof(GRN_COLUMN_NAME_ID) - 1)
+/**
+ * \brief Name of the pseudo column `_key`.
+ *
+ * The `_key` pseudo column represents the primary key value of a record in a
+ * Groonga table. It is defined only for tables that have a primary key. The
+ * primary key value is unique within the table and is immutable.
+ *
+ * \since 3.1.1
+ *
+ * Here is an example of using \ref grn_obj_column with \ref GRN_COLUMN_NAME_KEY
+ * and \ref GRN_COLUMN_NAME_KEY_LEN to retrieve the `_key` column object:
+ *
+ * ```c
+ * grn_obj *key_accessor = grn_obj_column(ctx,
+ *                                       table,
+ *                                       GRN_COLUMN_NAME_KEY,
+ *                                       GRN_COLUMN_NAME_KEY_LEN);
+ * // ...
+ * grn_obj_unlink(ctx, key_accessor);
+ * ```
+ */
+#define GRN_COLUMN_NAME_KEY "_key"
+/**
+ * \brief Length of the pseudo `_key` column name.
+ *
+ * The \ref GRN_COLUMN_NAME_KEY_LEN macro returns the byte size of the
+ * \ref GRN_COLUMN_NAME_KEY, excluding the null terminator.
+ *
+ * \since 3.1.1
+ */
 #define GRN_COLUMN_NAME_KEY_LEN      (sizeof(GRN_COLUMN_NAME_KEY) - 1)
 #define GRN_COLUMN_NAME_VALUE        "_value"
 #define GRN_COLUMN_NAME_VALUE_LEN    (sizeof(GRN_COLUMN_NAME_VALUE) - 1)

--- a/include/groonga/column.h
+++ b/include/groonga/column.h
@@ -63,7 +63,8 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * The `_key` pseudo column represents the primary key value of a record in a
  * Groonga table. It is defined only for tables that have a primary key. The
- * primary key value is unique within the table and is immutable.
+ * primary key value is unique within the table. It is also immutable except
+ * \ref GRN_TABLE_DAT_KEY.
  *
  * \since 3.1.1
  *

--- a/include/groonga/column.h
+++ b/include/groonga/column.h
@@ -73,9 +73,9 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * ```c
  * grn_obj *key_accessor = grn_obj_column(ctx,
- *                                       table,
- *                                       GRN_COLUMN_NAME_KEY,
- *                                       GRN_COLUMN_NAME_KEY_LEN);
+ *                                        table,
+ *                                        GRN_COLUMN_NAME_KEY,
+ *                                        GRN_COLUMN_NAME_KEY_LEN);
  * // ...
  * grn_obj_unlink(ctx, key_accessor);
  * ```


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.