### PR TITLE
ci: use the latest Apache Arrow when we build packages

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -594,7 +594,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: apache-arrow
-          ref: apache-arrow-16.1.0
+          ref: apache-arrow-18.0.0
           repository: apache/arrow
           submodules: recursive
       # Use CMake 3.27 not 3.26.


### PR DESCRIPTION
We get Apache Arrow version in "detect_target_apache_arrow_version()" of packages/Rakefile when we build packages.

"detect_target_apache_arrow_version()" refer to .github/workflows/cmake.yml. So, we need to update Apache Arrow version in .github/workflows/cmake.yml.