### PR TITLE
docs: api/grn_hook: move grn_obj_delete_hook() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
@@ -83,6 +83,3 @@ msgstr ""
 
 msgid "hook固有情報格納バッファを指定します。"
 msgstr ""
-
-msgid "objに定義されているhookを削除します。"
-msgstr ""

--- a/doc/source/reference/api/grn_hook.rst
+++ b/doc/source/reference/api/grn_hook.rst
@@ -55,11 +55,3 @@ Reference
    :param entry: hookタイプを指定します。
    :param offset: 実行順位を指定します。
    :param data: hook固有情報格納バッファを指定します。
-
-.. c:function:: grn_rc grn_obj_delete_hook(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset)
-
-   objに定義されているhookを削除します。
-
-   :param obj: 対象objectを指定します。
-   :param entry: hookタイプを指定します。
-   :param offset: 実行順位を指定します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1711,6 +1711,18 @@ grn_obj_get_nhooks(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry);
 GRN_API grn_obj *
 grn_obj_get_hook(
   grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset, grn_obj *data);
+/**
+ * \brief Delete the hook set on the object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param entry The type of hook.
+ * \param offset The offset of execution order.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_INVALID_ARGUMENT is returned if there was no
+ *         hook in `offset`.
+ */
 GRN_API grn_rc
 grn_obj_delete_hook(grn_ctx *ctx,
                     grn_obj *obj,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.