### PR TITLE
docs: api/grn_hook: move grn_obj_get_nhooks() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
@@ -69,13 +69,10 @@ msgstr ""
 msgid "hook固有情報を指定します。"
 msgstr ""
 
-msgid "objに定義されているhookの数を返します。"
+msgid "objに定義されているhookの手続き（proc）を返します。hook固有情報が定義されている場合は、その内容をdataにコピーして返します。"
 msgstr ""
 
 msgid "hookタイプを指定します。"
-msgstr ""
-
-msgid "objに定義されているhookの手続き（proc）を返します。hook固有情報が定義されている場合は、その内容をdataにコピーして返します。"
 msgstr ""
 
 msgid "実行順位を指定します。"

--- a/doc/source/reference/api/grn_hook.rst
+++ b/doc/source/reference/api/grn_hook.rst
@@ -40,13 +40,6 @@ Reference
    :param proc: 手続きを指定します。
    :param data: hook固有情報を指定します。
 
-.. c:function:: int grn_obj_get_nhooks(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry)
-
-   objに定義されているhookの数を返します。
-
-   :param obj: 対象objectを指定します。
-   :param entry: hookタイプを指定します。
-
 .. c:function:: grn_obj *grn_obj_get_hook(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset, grn_obj *data)
 
    objに定義されているhookの手続き（proc）を返します。hook固有情報が定義されている場合は、その内容をdataにコピーして返します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1706,6 +1706,15 @@ grn_obj_add_hook(grn_ctx *ctx,
                  int offset,
                  grn_obj *proc,
                  grn_obj *data);
+/**
+ * \brief Get the number of hooks set on the object.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param entry The type of hook.
+ *
+ * \return The number of hooks set on the object.
+ */
 GRN_API int
 grn_obj_get_nhooks(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry);
 GRN_API grn_obj *


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.