### PR TITLE
doc conf: suppress `'include': Has content` warnings in .md

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,11 +11,17 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import docutils.parsers.rst.directives.misc
 import re
 import sphinx
 import sys, os
 import gettext
 from datetime import datetime
+
+# Hack to allow include directives to contain content.
+# This modification is necessary to embed Groonga execution commands
+# within include blocks. It prevents warnings during documentation generation.
+docutils.parsers.rst.directives.misc.Include.has_content = True
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,9 +18,36 @@ import sys, os
 import gettext
 from datetime import datetime
 
-# Hack to allow include directives to contain content.
-# This modification is necessary to embed Groonga execution commands
-# within include blocks. It prevents warnings during documentation generation.
+# Workaround to allow the include directive to contain content when using
+# Markdown (MyST-Parser).
+#
+# This is necessary only when using Markdown through the MyST-Parser. If we
+# stop using Markdown or switch to a different parser in the future, this
+# workaround could be removed.
+#
+# Without this change, we encounter warnings during documentation generation
+# when using include directives with content. For example:
+#
+# ```{include} filename.md
+# plugin_register functions/language_model
+# ```
+#
+# This results in the warning:
+#   WARNING: include: Has content, but none permitted [myst.directive_parse]
+#
+# We considered the following approaches but chose this workaround for ease of
+# maintenance:
+# - Implementing a new directive in Python that allows content:
+#   - This would be increasing maintenance costs since our team primarily uses
+#     Ruby or C, not Python.
+# - Modifying the Ruby script that updates execution examples:
+#   - This could be hard to figure out how to do and increase maintenance costs
+#     because it might be a complex approach.
+#
+# This workaround functions by setting `Include.has_content = True`, which
+# modifies the default behavior of the include directive to accept content. This
+# suppresses the warnings and allows us to embed Groonga execution commands
+# within include blocks as needed.
 docutils.parsers.rst.directives.misc.Include.has_content = True
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
We want to embed the results of executing Groonga commands within documents for easy to understand. We preprocess our document sources by `doc/update-execution-example.rb` and generate execution results.

We're using the following syntax for the preprocess in `.md`:

````md
<!-- groonga-command -->

```{include} output-path.md
table_create ...
select ...
```
````

But this causes the following warnings:

```console
$ cmake \
    -S .
    -B ../groonga.doc
    --preset=doc && \
  cmake
    --build ../groonga.doc
...
/home/otegami/work/c/groonga/doc/source/reference/functions/language_model_vectorize.md.rst:61: WARNING: 'include': Has content, but none permitted [myst.directive_parse]
...
```

We can use other syntax for `.md` because `doc/update-execution-example.rb` is maintained by us. We can just implement a logic for other syntax in `doc/update-execution-example.rb`.

FYI: We're using the following syntax in `.rst`:

```rst
.. groonga-command
.. include:: output-path.log
.. table_create ...
.. select ...
```

For example, `.rst` uses comment (`.. ` is a comment syntax in `.rst`) for Groonga commands. We may be able to use `% table_create ...` in `.md` but we don't have a good idea for new syntax for now. 

This change suppresses the warning by changing the `include` directive's property. MyST-Parser generates the warning for no content directives such as the `include` directive. This changes the `include` directive to a have content directive.