### PR TITLE
doc reference/command/object_inspect: fix duplicated label

### DIFF
--- a/doc/source/reference/commands/object_inspect.rst
+++ b/doc/source/reference/commands/object_inspect.rst
@@ -658,7 +658,7 @@ or not. The value is ``true`` if ``WEIGHT_BFLOAT16`` was specified,
 
 .. seealso:: :ref:`column-create-flags`
 
-.. _object-inspect-return-value-vector-column-value-weight_bfloat16:
+.. _object-inspect-return-value-generated-column-value-generator:
 
 ``GENERATED_COLUMN_VALUE_GENERATOR``
 """"""""""""""""""""""""""""""""""""


### PR DESCRIPTION
This change resolves a warning during documentation generation as follow. It is raised because there is a duplicated label. So we just rename the label to fix it.

```console
$ cmake \
    -S .
    -B ../groonga.doc
    --preset=doc && \
  cmake
    --build ../groonga.doc
...
/home/otegami/work/c/groonga/doc/source/reference/commands/object_inspect.rst:661: WARNING: Duplicate explicit target name: "object-inspect-return-value-vector-column-value-weight_bfloat16". [docutils]
...
```