### PR TITLE
tool: add a new tool for generating blog from release note

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -259,6 +259,17 @@ namespace :release do
         end
       end
     end
+    namespace :blog do
+      desc "Generate Blog from release note"
+      task :generate do
+        groonga_org_path = File.expand_path(env_var("GROONGA_ORG_DIR"))
+
+        ruby("tools/generate-blog-entry-from-release-note.rb",
+             groonga_org_path,
+             package,
+             version.chomp)
+      end
+    end
   end
 
   desc "Tag"

--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@
 
 require "open-uri"
 require "tmpdir"
+require_relative "groonga-blog-task"
 
 def sh_capture_output(*command_line)
   IO.pipe do |read, write|
@@ -259,17 +260,8 @@ namespace :release do
         end
       end
     end
-    namespace :blog do
-      desc "Generate Blog from release note"
-      task :generate do
-        groonga_org_path = File.expand_path(env_var("GROONGA_ORG_DIR"))
-
-        ruby("tools/generate-blog-entry-from-release-note.rb",
-             groonga_org_path,
-             package,
-             version.chomp)
-      end
-    end
+    groonga_blog_task = GroongaBlogTask.new
+    groonga_blog_task.define
   end
 
   desc "Tag"

--- a/blog-task.rb
+++ b/blog-task.rb
@@ -1,0 +1,111 @@
+# Copyright(C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class BlogTask
+  include Rake::DSL
+
+  def initialize(package)
+    @package = package
+    @version = detect_version
+  end
+
+  def define
+    define_blog_task
+  end
+
+  private
+  def env_var(name, default=nil)
+    value = ENV[name] || default
+    raise "${#{name}} is missing" if value.nil?
+    value
+  end
+
+  def document_repository_path
+    raise NotImplementedError
+  end
+
+  def detect_version
+    raise NotImplementedError
+  end
+
+  def define_blog_task
+    namespace :document do
+      namespace :blog do
+        desc "Generate Blog from release note"
+        task :generate do
+          blog_file_name = "#{Time.now.strftime("%F")}-#{package}-#{version}.md"
+          File.open("#{document_repository_path}/ja/_posts/#{blog_file_name}", "w") do |blog_ja|
+            blog_ja.write(contents_ja(@package.capitalize, @version))
+          end
+
+          File.open("#{document_repository_path}/en/_posts/#{blog_file_name}", "w") do |blog_en|
+            blog_en.write(contents_en(@package.capitalize, @version))
+          end
+        end
+      end
+    end
+  end
+
+  def contents_ja(package, version)
+    major_version = version.split('.')[0];
+
+    contents = <<CONTENTS
+---
+layout: post.ja
+title: #{package} #{version}リリース
+description: #{package} #{version}をリリースしました！
+---
+
+## #{package} #{version}リリース
+
+#{package} #{version}をリリースしました！
+
+それぞれの環境毎のインストール方法: [インストール](/ja/docs/install.html)
+
+### 変更内容
+
+主な変更点は以下のリンクを参照してください。
+
+[#{package} #{version} release-note](/ja/docs/news/#{major_version}.html#release-#{version.gsub(".", "-")})
+
+CONTENTS
+  end
+
+  def contents_en(package, version)
+    major_version = version.split('.')[0];
+
+    contents = <<CONTENTS
+---
+layout: post.en
+title: #{package} #{version} has been released
+description: #{package} #{version} has been released!
+---
+
+## #{package} #{version} has been released
+
+#{package} #{version} has been released!
+
+How to install: [Install](/docs/install.html)
+
+### Changes
+
+Please refer the following link.
+
+[#{package} #{version} release-note](/docs/news/#{major_version}.html#release-#{version.gsub(".", "-")})
+
+CONTENTS
+  end
+end

--- a/groonga-blog-task.rb
+++ b/groonga-blog-task.rb
@@ -1,0 +1,36 @@
+# Copyright(C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require_relative "blog-task"
+
+class GroongaBlogTask < BlogTask
+  def initialize
+    super("groonga")
+  end
+
+  def document_repository_path
+    env_var("GROONGA_ORG_DIR")
+  end
+
+  def detect_version
+    version_env = ENV["VERSION"]
+    return version_env if version_env
+
+    base_version_file = File.join(__dir__,
+                                  "base_version")
+    version = File.read(base_version_file).chomp
+  end
+end

--- a/groonga-blog-task.rb
+++ b/groonga-blog-task.rb
@@ -21,6 +21,7 @@ class GroongaBlogTask < BlogTask
     super("groonga")
   end
 
+  private
   def document_repository_path
     env_var("GROONGA_ORG_DIR")
   end

--- a/tools/generate-blog-entry-from-release-note.rb
+++ b/tools/generate-blog-entry-from-release-note.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+groonga_org_repository_path = ENV['GROONGA_ORG_PATH']
+if groonga_org_repository_path.nil?
+  puts("Usage: GROONGA_ORG_PATH=xxx ruby generate-blog-entry-from-release-note.rb")
+  return
+end
+
+base_version_file = File.join(__dir__,
+                              "..",
+                              "base_version")
+groonga_version = File.read(base_version_file).chomp
+
+def contents_ja(groonga_version)
+  groonga_major_version = groonga_version.split('.')[0];
+
+  contents = <<CONTENTS
+---
+layout: post.ja
+title: Groonga #{groonga_version}リリース
+description: Groonga #{groonga_version}をリリースしました！
+---
+
+## Groonga #{groonga_version}リリース
+
+Groonga #{groonga_version}をリリースしました！
+
+それぞれの環境毎のインストール方法: [インストール](/ja/docs/install.html)
+
+### 変更内容
+
+主な変更点は以下のリンクを参照してください。
+
+[Groonga #{groonga_version} release-note](/ja/docs/news/#{groonga_major_version}.html#release-#{groonga_version})
+
+CONTENTS
+end
+
+def contents_en(groonga_version)
+  groonga_major_version = groonga_version.split('.')[0];
+
+  contents = <<CONTENTS
+---
+layout: post.en
+title: Groonga #{groonga_version} has been released
+description: Groonga #{groonga_version} has been released!
+---
+
+## Groonga #{groonga_version} has been released
+
+Groonga #{groonga_version} has been released!
+
+How to install: [Install](/docs/install.html)
+
+### Changes
+
+Please refer the following link.
+
+[Groonga #{groonga_version} release-note](/docs/news/#{groonga_major_version}.html#release-#{groonga_version})
+
+CONTENTS
+end
+
+groonga_blog_file_name = "#{Time.now.strftime("%F")}-groonga-#{groonga_version}.md"
+File.open("#{groonga_org_repository_path}/ja/_posts/#{groonga_blog_file_name}", "w") do |blog_ja|
+  blog_ja.write(contents_ja(groonga_version))
+end
+
+File.open("#{groonga_org_repository_path}/en/_posts/#{groonga_blog_file_name}", "w") do |blog_en|
+  blog_en.write(contents_en(groonga_version))
+end

--- a/tools/generate-blog-entry-from-release-note.rb
+++ b/tools/generate-blog-entry-from-release-note.rb
@@ -1,29 +1,34 @@
 #!/usr/bin/env ruby
 
-groonga_org_repository_path = ENV['GROONGA_ORG_PATH']
-if groonga_org_repository_path.nil?
-  puts("Usage: GROONGA_ORG_PATH=xxx ruby generate-blog-entry-from-release-note.rb")
+document_repository_path = ARGV[0]
+if document_repository_path.nil?
   return
 end
 
-base_version_file = File.join(__dir__,
-                              "..",
-                              "base_version")
-groonga_version = File.read(base_version_file).chomp
+package = ARGV[1]
+if package.nil?
+  return
+end
 
-def contents_ja(groonga_version)
-  groonga_major_version = groonga_version.split('.')[0];
+version = ARGV[2]
+if version.nil?
+  return
+end
+
+
+def contents_ja(package, version)
+  major_version = version.split('.')[0];
 
   contents = <<CONTENTS
 ---
 layout: post.ja
-title: Groonga #{groonga_version}リリース
-description: Groonga #{groonga_version}をリリースしました！
+title: #{package} #{version}リリース
+description: #{package} #{version}をリリースしました！
 ---
 
-## Groonga #{groonga_version}リリース
+## #{package} #{version}リリース
 
-Groonga #{groonga_version}をリリースしました！
+#{package} #{version}をリリースしました！
 
 それぞれの環境毎のインストール方法: [インストール](/ja/docs/install.html)
 
@@ -31,24 +36,24 @@ Groonga #{groonga_version}をリリースしました！
 
 主な変更点は以下のリンクを参照してください。
 
-[Groonga #{groonga_version} release-note](/ja/docs/news/#{groonga_major_version}.html#release-#{groonga_version})
+[#{package} #{version} release-note](/ja/docs/news/#{major_version}.html#release-#{version.gsub(".", "-")})
 
 CONTENTS
 end
 
-def contents_en(groonga_version)
-  groonga_major_version = groonga_version.split('.')[0];
+def contents_en(package, version)
+  major_version = version.split('.')[0];
 
   contents = <<CONTENTS
 ---
 layout: post.en
-title: Groonga #{groonga_version} has been released
-description: Groonga #{groonga_version} has been released!
+title: #{package} #{version} has been released
+description: #{package} #{version} has been released!
 ---
 
-## Groonga #{groonga_version} has been released
+## #{package} #{version} has been released
 
-Groonga #{groonga_version} has been released!
+#{package} #{version} has been released!
 
 How to install: [Install](/docs/install.html)
 
@@ -56,16 +61,16 @@ How to install: [Install](/docs/install.html)
 
 Please refer the following link.
 
-[Groonga #{groonga_version} release-note](/docs/news/#{groonga_major_version}.html#release-#{groonga_version})
+[#{package} #{version} release-note](/docs/news/#{major_version}.html#release-#{version.gsub(".", "-")})
 
 CONTENTS
 end
 
-groonga_blog_file_name = "#{Time.now.strftime("%F")}-groonga-#{groonga_version}.md"
-File.open("#{groonga_org_repository_path}/ja/_posts/#{groonga_blog_file_name}", "w") do |blog_ja|
-  blog_ja.write(contents_ja(groonga_version))
+blog_file_name = "#{Time.now.strftime("%F")}-#{package}-#{version}.md"
+File.open("#{document_repository_path}/ja/_posts/#{blog_file_name}", "w") do |blog_ja|
+  blog_ja.write(contents_ja(package.capitalize, version))
 end
 
-File.open("#{groonga_org_repository_path}/en/_posts/#{groonga_blog_file_name}", "w") do |blog_en|
-  blog_en.write(contents_en(groonga_version))
+File.open("#{document_repository_path}/en/_posts/#{blog_file_name}", "w") do |blog_en|
+  blog_en.write(contents_en(package.capitalize, version))
 end


### PR DESCRIPTION
Usage:

```
% rake release:document:blog:generate GROONGA_ORG_DIR=../groonga.org
```