### PR TITLE
docs: api/grn_hook: move grn_obj_get_hook() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
@@ -68,15 +68,3 @@ msgstr ""
 
 msgid "hook固有情報を指定します。"
 msgstr ""
-
-msgid "objに定義されているhookの手続き（proc）を返します。hook固有情報が定義されている場合は、その内容をdataにコピーして返します。"
-msgstr ""
-
-msgid "hookタイプを指定します。"
-msgstr ""
-
-msgid "実行順位を指定します。"
-msgstr ""
-
-msgid "hook固有情報格納バッファを指定します。"
-msgstr ""

--- a/doc/source/reference/api/grn_hook.rst
+++ b/doc/source/reference/api/grn_hook.rst
@@ -39,12 +39,3 @@ Reference
       objectに複数のhookが定義されている場合は順位の順に呼び出されます。
    :param proc: 手続きを指定します。
    :param data: hook固有情報を指定します。
-
-.. c:function:: grn_obj *grn_obj_get_hook(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset, grn_obj *data)
-
-   objに定義されているhookの手続き（proc）を返します。hook固有情報が定義されている場合は、その内容をdataにコピーして返します。
-
-   :param obj: 対象objectを指定します。
-   :param entry: hookタイプを指定します。
-   :param offset: 実行順位を指定します。
-   :param data: hook固有情報格納バッファを指定します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1727,7 +1727,7 @@ grn_obj_get_nhooks(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry);
  * \param offset The offset of execution order.
  * \param data The buffer to store hook data.
  *
- * \return The procedure if the hook is set, `NULL` otherwise.
+ * \return The procedure object if the hook is set, `NULL` otherwise.
  */
 GRN_API grn_obj *
 grn_obj_get_hook(

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1717,6 +1717,18 @@ grn_obj_add_hook(grn_ctx *ctx,
  */
 GRN_API int
 grn_obj_get_nhooks(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry);
+/**
+ * \brief Get the hook set on the object. If hook data is set, it is stored in
+ *        `data`.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param entry The type of hook.
+ * \param offset The offset of execution order.
+ * \param data The buffer to store hook data.
+ *
+ * \return The procedure if the hook is set, `NULL` otherwise.
+ */
 GRN_API grn_obj *
 grn_obj_get_hook(
   grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset, grn_obj *data);


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.