### PR TITLE
docs: api/grn_obj: add usage to `grn_obj_column` for handling the accessor

### DIFF
--- a/include/groonga/column.h
+++ b/include/groonga/column.h
@@ -36,17 +36,7 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  *
- * Here is an example to use \ref grn_obj_column with \ref GRN_COLUMN_NAME_ID
- * and \ref GRN_COLUMN_NAME_ID_LEN to retrieve the `_id` column object:
- *
- * ```c
- * grn_obj *id_accessor = grn_obj_column(ctx,
- *                                       table,
- *                                       GRN_COLUMN_NAME_ID,
- *                                       GRN_COLUMN_NAME_ID_LEN);
- * // ...
- * grn_obj_unlink(ctx, id_accessor);
- * ```
+ * For usage examples, see \ref grn_obj_column.
  */
 #define GRN_COLUMN_NAME_ID "_id"
 /**
@@ -68,17 +58,7 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  *
- * Here is an example of using \ref grn_obj_column with \ref GRN_COLUMN_NAME_KEY
- * and \ref GRN_COLUMN_NAME_KEY_LEN to retrieve the `_key` column object:
- *
- * ```c
- * grn_obj *key_accessor = grn_obj_column(ctx,
- *                                        table,
- *                                        GRN_COLUMN_NAME_KEY,
- *                                        GRN_COLUMN_NAME_KEY_LEN);
- * // ...
- * grn_obj_unlink(ctx, key_accessor);
- * ```
+ * For usage examples, see \ref grn_obj_column.
  */
 #define GRN_COLUMN_NAME_KEY "_key"
 /**
@@ -99,18 +79,7 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  *
- * Here is an example of using \ref grn_obj_column with \ref
- * GRN_COLUMN_NAME_VALUE and \ref GRN_COLUMN_NAME_VALUE_LEN to retrieve the
- * `_value` column object:
- *
- * ```c
- * grn_obj *value_accessor = grn_obj_column(ctx,
- *                                          table,
- *                                          GRN_COLUMN_NAME_VALUE,
- *                                          GRN_COLUMN_NAME_VALUE_LEN);
- * // ...
- * grn_obj_unlink(ctx, value_accessor);
- * ```
+ * For usage examples, see \ref grn_obj_column.
  */
 #define GRN_COLUMN_NAME_VALUE "_value"
 /**
@@ -132,18 +101,7 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  *
- * Here is an example of using \ref grn_obj_column with \ref
- * GRN_COLUMN_NAME_SCORE and \ref GRN_COLUMN_NAME_SCORE_LEN to retrieve the
- * `_score` column object:
- *
- * ```c
- * grn_obj *score_accessor = grn_obj_column(ctx,
- *                                          table,
- *                                          GRN_COLUMN_NAME_SCORE,
- *                                          GRN_COLUMN_NAME_SCORE_LEN);
- * // ...
- * grn_obj_unlink(ctx, score_accessor);
- * ```
+ * For usage examples, see \ref grn_obj_column.
  */
 #define GRN_COLUMN_NAME_SCORE "_score"
 /**
@@ -167,18 +125,7 @@ typedef struct _grn_column_cache grn_column_cache;
  *
  * \since 3.1.1
  *
- * Here is an example of using \ref grn_obj_column with \ref
- * GRN_COLUMN_NAME_NSUBRECS and \ref GRN_COLUMN_NAME_NSUBRECS_LEN to retrieve
- * the `_nsubrecs` column object:
- *
- * ```c
- * grn_obj *nsubrecs_accessor = grn_obj_column(ctx,
- *                                             table,
- *                                             GRN_COLUMN_NAME_NSUBRECS,
- *                                             GRN_COLUMN_NAME_NSUBRECS_LEN);
- * // ...
- * grn_obj_unlink(ctx, nsubrecs_accessor);
- * ```
+ * For usage examples, see \ref grn_obj_column.
  */
 #define GRN_COLUMN_NAME_NSUBRECS "_nsubrecs"
 /**

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -941,7 +941,7 @@ typedef enum {
  *
  *        To illustrate its usage, here is an example to use \ref grn_obj_column
  *        with pseudo column like \ref GRN_COLUMN_NAME_ID and
- *        \ref GRN_COLUMN_NAME_ID_LEN to retrieve the `_id` column object
+ *        \ref GRN_COLUMN_NAME_ID_LEN to retrieve the accessor object for `_id`.
  *
  *        ```c
  *        grn_obj *id_accessor = grn_obj_column(ctx,

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -939,6 +939,19 @@ typedef enum {
  *        with it when it's no longer needed. You can use
  *        `grn_obj_is_accessor()` to detect whether it's an accessor or not.
  *
+ *        To illustrate its usage, here is an example to use \ref grn_obj_column
+ *        with pseudo column like \ref GRN_COLUMN_NAME_ID and
+ *        \ref GRN_COLUMN_NAME_ID_LEN to retrieve the `_id` column object
+ *
+ *        ```c
+ *        grn_obj *id_accessor = grn_obj_column(ctx,
+ *                                              table,
+ *                                              GRN_COLUMN_NAME_ID,
+ *                                              GRN_COLUMN_NAME_ID_LEN);
+ *        // ...
+ *        grn_obj_unlink(ctx, id_accessor);
+ *        ```
+ *
  * \param ctx The context object
  * \param table The target table or accessor from which the column or accessor
  *              is retrieved.


### PR DESCRIPTION
fix: https://github.com/groonga/groonga/pull/2062#discussion_r1828971015

This changes add the usage to `grn_obj_column` for handling the accessor with pseudo columns.
It also removes the duplicated the examples from pseudo columns' usages.