### PR TITLE
docs: api/grn_hook: move grn_obj_add_hook() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_hook.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_hook``"
 msgstr ""
 
@@ -33,38 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "objに対してhookを追加します。"
-msgstr ""
-
-msgid "対象objectを指定します。"
-msgstr ""
-
-msgid "``GRN_HOOK_GET`` は、objectの参照時に呼び出されるhookを定義します。  ``GRN_HOOK_SET`` は、objectの更新時に呼び出されるhookを定義します。  ``GRN_HOOK_SELECT`` は、検索処理の実行中に適時呼び出され、処理の実行状況を調べたり、実行の中断を指示することができます。"
-msgstr ""
-
-msgid "``GRN_HOOK_GET`` は、objectの参照時に呼び出されるhookを定義します。"
-msgstr ""
-
-msgid "``GRN_HOOK_SET`` は、objectの更新時に呼び出されるhookを定義します。"
-msgstr ""
-
-msgid "``GRN_HOOK_SELECT`` は、検索処理の実行中に適時呼び出され、処理の実行状況を調べたり、実行の中断を指示することができます。"
-msgstr ""
-
-msgid "hookの実行順位。offsetに対応するhookの直前に新たなhookを挿入します。  0を指定した場合は先頭に挿入されます。-1を指定した場合は末尾に挿入されます。  objectに複数のhookが定義されている場合は順位の順に呼び出されます。"
-msgstr ""
-
-msgid "hookの実行順位。offsetに対応するhookの直前に新たなhookを挿入します。"
-msgstr ""
-
-msgid "0を指定した場合は先頭に挿入されます。-1を指定した場合は末尾に挿入されます。"
-msgstr ""
-
-msgid "objectに複数のhookが定義されている場合は順位の順に呼び出されます。"
-msgstr ""
-
-msgid "手続きを指定します。"
-msgstr ""
-
-msgid "hook固有情報を指定します。"
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_hook.rst
+++ b/doc/source/reference/api/grn_hook.rst
@@ -16,26 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_hook_entry
-
-   TODO...
-
-.. c:function:: grn_rc grn_obj_add_hook(grn_ctx *ctx, grn_obj *obj, grn_hook_entry entry, int offset, grn_obj *proc, grn_obj *data)
-
-   objに対してhookを追加します。
-
-   :param obj: 対象objectを指定します。
-   :param entry:
-      ``GRN_HOOK_GET`` は、objectの参照時に呼び出されるhookを定義します。
-
-      ``GRN_HOOK_SET`` は、objectの更新時に呼び出されるhookを定義します。
-
-      ``GRN_HOOK_SELECT`` は、検索処理の実行中に適時呼び出され、処理の実行状況を調べたり、実行の中断を指示することができます。
-   :param offset:
-      hookの実行順位。offsetに対応するhookの直前に新たなhookを挿入します。
-
-      0を指定した場合は先頭に挿入されます。-1を指定した場合は末尾に挿入されます。
-
-      objectに複数のhookが定義されている場合は順位の順に呼び出されます。
-   :param proc: 手続きを指定します。
-   :param data: hook固有情報を指定します。
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1687,10 +1687,16 @@ GRN_API void *
 grn_proc_get_hook_local_data(grn_ctx *ctx, grn_obj *exec_info);
 
 typedef enum {
+  /// Hooked on update.
   GRN_HOOK_SET = 0,
+  /// Hooked on getting
   GRN_HOOK_GET,
+  /// Hooked on insertion.
   GRN_HOOK_INSERT,
+  /// Hooked on deletion.
   GRN_HOOK_DELETE,
+  /// Hooked during the search process. You can use it to check the status of a
+  /// process or to terminate a process.
   GRN_HOOK_SELECT
 } grn_hook_entry;
 
@@ -1699,6 +1705,20 @@ typedef enum {
 GRN_API const char *
 grn_hook_entry_to_string(grn_hook_entry entry);
 
+/**
+ * \brief Add a hook to the object. If multiple hooks are set for the object,
+ *        they are called in order.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ * \param entry The type of hook.
+ * \param offset The offset of execution order. Add to the beginning if `0` is
+ *               specified. Add to the end if `-1` is specified.
+ * \param proc The procedure object.
+ * \param data The hook data.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_obj_add_hook(grn_ctx *ctx,
                  grn_obj *obj,

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1707,7 +1707,7 @@ grn_hook_entry_to_string(grn_hook_entry entry);
 
 /**
  * \brief Add a hook to the object. If multiple hooks are set for the object,
- *        they are called in order.
+ *        they are called in the order they are registered in the hook list.
  *
  * \param ctx The context object.
  * \param obj The target object.


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.