### PR TITLE
Remove middle dot, when both `remove_symbol` and `unify_middle_dot` are enabled

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -3949,6 +3949,12 @@ grn_nfkc_normalize_remove_target_non_blank_character_p(
   if (data->options->char_type_func(current) == GRN_CHAR_SYMBOL) {
     return data->options->remove_symbol;
   }
+  /* `unify_middle_dot` is `true` and the unified middle dot is handled as a
+   * symbol. */
+  if (data->options->unify_middle_dot &&
+      grn_nfkc_normalize_is_middle_dot_family(current, current_length)) {
+    return data->options->remove_symbol;
+  }
   return false;
 }
 

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_middle_dot.expected
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_middle_dot.expected
@@ -1,0 +1,37 @@
+normalize   'NormalizerNFKC("remove_symbol", true,                   "unify_middle_dot", true)'   "This ·ᐧ•∙ is ⋅⸱ middle ・･ dots"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "this  is  middle  dots",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "others",
+      "alpha",
+      "alpha",
+      "others",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_middle_dot.test
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_middle_dot.test
@@ -1,0 +1,7 @@
+#@add-substitution /NormalizerNFKC(\d*)/ "NormalizerNFKC#{ENV['NFKC'] || '100'}" "NormalizerNFKC"
+normalize \
+  'NormalizerNFKC("remove_symbol", true, \
+                  "unify_middle_dot", true)' \
+  "This ·ᐧ•∙ is ⋅⸱ middle ・･ dots" \
+  WITH_TYPES
+#@remove-substitution /NormalizerNFKC(\d*)/


### PR DESCRIPTION
GitHub: fixes GH-1538

When `unify_middle_dot` is enabled, the middle dot becomes a symbol and should be removed with `remove_symbol`.