### PR TITLE
docs: unify_middle_dot: Add usage

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -94,8 +94,8 @@ msgstr "以下は、 :ref:`normalizer-nfkc150-unify-hyphen-and-prolonged-sound-m
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option. This option enables normalize middle dot to \"·\" (U+00B7 MIDDLE DOT) as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-middle-dot` オプションの使用例です。このオプションは、中点を\"·\" (U+00B7 MIDDLE DOT)に正規化します。"
 
-msgid "You can use it with ``remove_symbol`` to remove the middle dot."
-msgstr "``remove_symbol`` と一緒に使うと中点を削除できます。"
+msgid "You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters."
+msgstr ":ref:`normalizer-nfkc150-remove-symbol` と一緒に使うと中点を削除できます。"
 
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-v-sounds` option. This option enables normalize \"ヴァヴィヴヴェヴォ\" to \"バビブベボ\" as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-v-sounds` オプションの使用例です。このオプションは、以下のように、\"ヴァヴィヴヴェヴォ\"を\"バビブベボ\"に正規化します。"

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -94,7 +94,7 @@ msgstr "以下は、 :ref:`normalizer-nfkc150-unify-hyphen-and-prolonged-sound-m
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option. This option enables normalize middle dot to \"·\" (U+00B7 MIDDLE DOT) as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-middle-dot` オプションの使用例です。このオプションは、中点を\"·\" (U+00B7 MIDDLE DOT)に正規化します。"
 
-msgid "You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters."
+msgid "You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all characters like middle dot."
 msgstr ":ref:`normalizer-nfkc150-remove-symbol` と一緒に使うと中点を削除できます。"
 
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-v-sounds` option. This option enables normalize \"ヴァヴィヴヴェヴォ\" to \"バビブベボ\" as below."

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -95,7 +95,7 @@ msgid "Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option. 
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-middle-dot` オプションの使用例です。このオプションは、中点を\"·\" (U+00B7 MIDDLE DOT)に正規化します。"
 
 msgid "You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all characters like middle dot."
-msgstr ":ref:`normalizer-nfkc150-remove-symbol` と一緒に使うと中点を削除できます。"
+msgstr ":ref:`normalizer-nfkc150-remove-symbol` と一緒に使うと中点のような文字をすべて削除できます。"
 
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-v-sounds` option. This option enables normalize \"ヴァヴィヴヴェヴォ\" to \"バビブベボ\" as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-v-sounds` オプションの使用例です。このオプションは、以下のように、\"ヴァヴィヴヴェヴォ\"を\"バビブベボ\"に正規化します。"

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -94,6 +94,9 @@ msgstr "以下は、 :ref:`normalizer-nfkc150-unify-hyphen-and-prolonged-sound-m
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option. This option enables normalize middle dot to \"·\" (U+00B7 MIDDLE DOT) as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-middle-dot` オプションの使用例です。このオプションは、中点を\"·\" (U+00B7 MIDDLE DOT)に正規化します。"
 
+msgid "You can use it with ``remove_symbol`` to remove the middle dot."
+msgstr "``remove_symbol`` と一緒に使うと中点を削除できます。"
+
 msgid "Here is an example of :ref:`normalizer-nfkc150-unify-katakana-v-sounds` option. This option enables normalize \"ヴァヴィヴヴェヴォ\" to \"バビブベボ\" as below."
 msgstr "以下は、 :ref:`normalizer-nfkc150-unify-katakana-v-sounds` オプションの使用例です。このオプションは、以下のように、\"ヴァヴィヴヴェヴォ\"を\"バビブベボ\"に正規化します。"
 

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -159,7 +159,7 @@ This option enables normalize hyphen and prolonged sound to "-" (U+002D HYPHEN-M
 Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option.
 This option enables normalize middle dot to "·" (U+00B7 MIDDLE DOT) as below.
 
-You can use it with ``remove_symbol`` to remove the middle dot.
+You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters.
 
 .. groonga-command
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log
@@ -438,7 +438,7 @@ Middle dot of the target of normalizing is as below.
 * "・" (U+30FB KATAKANA MIDDLE DOT)
 * "･" (U+FF65 HALFWIDTH KATAKANA MIDDLE DOT)
 
-You can use it with ``remove_symbol`` to remove the middle dot.
+You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters.
 
 .. _normalizer-nfkc150-unify-katakana-v-sounds:
 

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -159,7 +159,7 @@ This option enables normalize hyphen and prolonged sound to "-" (U+002D HYPHEN-M
 Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option.
 This option enables normalize middle dot to "·" (U+00B7 MIDDLE DOT) as below.
 
-You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters.
+You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all characters like middle dot.
 
 .. groonga-command
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log
@@ -438,7 +438,7 @@ Middle dot of the target of normalizing is as below.
 * "・" (U+30FB KATAKANA MIDDLE DOT)
 * "･" (U+FF65 HALFWIDTH KATAKANA MIDDLE DOT)
 
-You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all middle dot like characters.
+You can use it with :ref:`normalizer-nfkc150-remove-symbol` to remove all characters like middle dot.
 
 .. _normalizer-nfkc150-unify-katakana-v-sounds:
 

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -159,6 +159,8 @@ This option enables normalize hyphen and prolonged sound to "-" (U+002D HYPHEN-M
 Here is an example of :ref:`normalizer-nfkc150-unify-middle-dot` option.
 This option enables normalize middle dot to "·" (U+00B7 MIDDLE DOT) as below.
 
+You can use it with ``remove_symbol`` to remove the middle dot.
+
 .. groonga-command
 .. include:: ../../example/reference/normalizers/normalizer-nfkc150-unify-middle-dot.log
 .. normalize   'NormalizerNFKC150("unify_middle_dot", true)'   "·ᐧ•∙⋅⸱・･"   WITH_TYPES
@@ -435,6 +437,8 @@ Middle dot of the target of normalizing is as below.
 * "⸱" (U+2E31 WORD SEPARATOR MIDDLE DOT)
 * "・" (U+30FB KATAKANA MIDDLE DOT)
 * "･" (U+FF65 HALFWIDTH KATAKANA MIDDLE DOT)
+
+You can use it with ``remove_symbol`` to remove the middle dot.
 
 .. _normalizer-nfkc150-unify-katakana-v-sounds:
 


### PR DESCRIPTION
GitHub: GH-2080

You can remove the middle dot when used with `remove_symbol`.