### PR TITLE
docs: api/grn_ctx: move grn_ctx_use() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
@@ -108,15 +108,6 @@ msgstr ""
 msgid "``ctx`` を破棄するときに呼ばれる関数を指定します。"
 msgstr ""
 
-msgid "ctxが操作対象とするdbを指定します。NULLを指定した場合は、dbを操作しない状態(init直後の状態)になります。"
-msgstr ""
-
-msgid "Don't use it with :c:type:`grn_ctx` that has ``GRN_CTX_PER_DB`` flag."
-msgstr "``GRN_CTX_PER_DB`` フラグを指定した :c:type:`grn_ctx` と一緒に使ってはいけません。"
-
-msgid "ctxが使用するdbを指定します。"
-msgstr ""
-
 msgid "ctxが使用するdbからnameに対応するオブジェクトを検索して返す。nameに一致するオブジェクトが存在しなければNULLを返す。"
 msgstr ""
 

--- a/doc/source/reference/api/grn_ctx.rst
+++ b/doc/source/reference/api/grn_ctx.rst
@@ -83,14 +83,6 @@ Reference
    :param func: ``ctx`` を破棄するときに呼ばれる関数を指定します。
    :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
 
-.. c:function:: grn_rc grn_ctx_use(grn_ctx *ctx, grn_obj *db)
-
-   ctxが操作対象とするdbを指定します。NULLを指定した場合は、dbを操作しない状態(init直後の状態)になります。
-
-   Don't use it with :c:type:`grn_ctx` that has ``GRN_CTX_PER_DB`` flag.
-
-   :param db: ctxが使用するdbを指定します。
-
 .. c:function:: grn_obj *grn_ctx_get(grn_ctx *ctx, const char *name, int name_size)
 
    ctxが使用するdbからnameに対応するオブジェクトを検索して返す。nameに一致するオブジェクトが存在しなければNULLを返す。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -809,6 +809,8 @@ struct _grn_obj {
  *
  * You can initialize it if you specify `NULL` for the parameter `db`.
  *
+ * \attention Don't use it with context that has \ref GRN_CTX_PER_DB flag.
+ *
  * \param ctx The context object.
  * \param db The database object.
  *

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -804,14 +804,24 @@ struct _grn_obj {
 
 #define GRN_OBJ_FIN(ctx, obj) (grn_obj_close((ctx), (obj)))
 
+/**
+ * \brief Set the database that the context is using.
+ *
+ * You can initialize it if you specify `NULL` for the parameter `db`.
+ *
+ * \param ctx The context object.
+ * \param db The database object.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_ctx_use(grn_ctx *ctx, grn_obj *db);
 /**
- * \brief Retrieve the DB that the context is using.
+ * \brief Retrieve the database that the context is using.
  *
  * \param ctx The context object.
  *
- * \return The DB object in use, `NULL` if DB is not in use.
+ * \return The database object in use, `NULL` if database is not in use.
  */
 GRN_API grn_obj *
 grn_ctx_db(grn_ctx *ctx);


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.

Unify "DB" with "database" for related grn_ctx_db(). Followed other documents.