### PR TITLE
docs: api/grn_ctx: move grn_ctx_(init|fin) reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
@@ -66,31 +66,13 @@ msgstr "TODO..."
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "ctxを初期化します。"
-msgstr ""
-
-msgid "初期化するctx構造体へのポインタを指定します。"
-msgstr ""
-
-msgid "初期化する ``ctx`` のオプションを指定します。"
-msgstr ""
-
-msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
-msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
-msgid "ctxの管理するメモリを解放し、使用を終了します。"
-msgstr ""
-
-msgid "If ``ctx`` is initialized by :c:func:`grn_ctx_open()` not :c:func:`grn_ctx_init()`, you need to use :c:func:`grn_ctx_close()` instead of :c:func:`grn_ctx_fin()`."
-msgstr ":c:func:`grn_ctx_init()` ではなく :c:func:`grn_ctx_open()` で ``ctx`` を初期化した場合、 :c:func:`grn_ctx_fin()` ではなく :c:func:`grn_ctx_close()` を使わなければいけません。"
-
-msgid "解放するctx構造体へのポインタを指定します。"
-msgstr ""
-
 msgid "初期化された :c:type:`grn_ctx` オブジェクトを返します。"
 msgstr ""
 
 msgid ":c:func:`grn_ctx_init()` で初期化された :c:type:`grn_ctx` オブジェクトは構造体の実体をAPIの呼び元で確保するのに対して、 :c:func:`grn_ctx_open()` ではGroongaライブラリの内部で、実体を確保します。 どちらで初期化された :c:type:`grn_ctx` も、 :c:func:`grn_ctx_fin()` で解放できます。 :c:func:`grn_ctx_open()` で確保した :c:type:`grn_ctx` 構造体に関しては、:c:func:`grn_ctx_fin()` で解放した後に、その :c:type:`grn_ctx` で作成した :c:type:`grn_obj` を :c:func:`grn_obj_close()` によって解放しても問題ありません。"
+msgstr ""
+
+msgid "初期化する ``ctx`` のオプションを指定します。"
 msgstr ""
 
 msgid "It calls :c:func:`grn_ctx_fin()` and frees allocated memory for ``ctx`` by :c:func:`grn_ctx_open()`."
@@ -98,6 +80,9 @@ msgstr ":c:func:`grn_ctx_fin()` を呼び出し、その後、 :c:func:`grn_ctx_
 
 msgid "no longer needed :c:type:`grn_ctx`."
 msgstr "もう使わない :c:type:`grn_ctx` 。"
+
+msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
+msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
 
 msgid "ctxを破棄するときに呼ばれる関数を設定します。"
 msgstr ""

--- a/doc/source/reference/api/grn_ctx.rst
+++ b/doc/source/reference/api/grn_ctx.rst
@@ -38,25 +38,6 @@ Reference
 
    TODO...
 
-.. c:function:: grn_rc grn_ctx_init(grn_ctx *ctx, int flags)
-
-   ctxを初期化します。
-
-   :param ctx: 初期化するctx構造体へのポインタを指定します。
-   :param flags: 初期化する ``ctx`` のオプションを指定します。
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
-.. c:function:: grn_rc grn_ctx_fin(grn_ctx *ctx)
-
-   ctxの管理するメモリを解放し、使用を終了します。
-
-   If ``ctx`` is initialized by :c:func:`grn_ctx_open()` not
-   :c:func:`grn_ctx_init()`, you need to use
-   :c:func:`grn_ctx_close()` instead of :c:func:`grn_ctx_fin()`.
-
-   :param ctx: 解放するctx構造体へのポインタを指定します。
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
 .. c:function:: grn_ctx *grn_ctx_open(int flags)
 
    初期化された :c:type:`grn_ctx` オブジェクトを返します。

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -336,7 +336,7 @@ struct _grn_ctx {
 /**
  * \brief Initialize the context.
  *
- * \param ctx The context object.
+ * \param ctx The context object allocated by the caller.
  * \param flags Initialization options.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
@@ -352,7 +352,7 @@ grn_ctx_init(grn_ctx *ctx, int flags);
  *            \ref grn_ctx_init. If the context is opened with
  *            \ref grn_ctx_open, it need to be closed with \ref grn_ctx_close.
  *
- * \param ctx The context object.
+ * \param ctx The context object initialized by \ref grn_ctx_init.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  */

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -333,8 +333,29 @@ struct _grn_ctx {
 #define GRN_CTX_BATCH_MODE (0x04)
 #define GRN_CTX_PER_DB     (0x08)
 
+/**
+ * \brief Initialize the context.
+ *
+ * \param ctx The context object.
+ * \param flags Initialization options.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_ctx_init(grn_ctx *ctx, int flags);
+/**
+ * \brief Finish the context.
+ *
+ * This function releases memory that was managed by the context and finishes.
+ *
+ * \attention This function finishes the context initialized by
+ *            \ref grn_ctx_init. If the context is opened with
+ *            \ref grn_ctx_open, it need to be closed with \ref grn_ctx_close.
+ *
+ * \param ctx The context object.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_ctx_fin(grn_ctx *ctx);
 GRN_API grn_ctx *


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.