### PR TITLE
docs: api/grn_column: move grn_column_find_index_data reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_column.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_column.po
@@ -36,24 +36,6 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "columnに張られているindexのうち、opの操作を実行可能なものの数を返します。またそれらのidを、buf_sizeに指定された個数を上限としてindexbufに返します。"
-msgstr ""
-
-msgid "対象のcolumnを指定します。"
-msgstr ""
-
-msgid "indexで実行したい操作を指定します。"
-msgstr ""
-
-msgid "indexを格納するバッファ（呼出側で準備する）を指定します。"
-msgstr ""
-
-msgid "indexbufのサイズ（byte長）を指定します。"
-msgstr ""
-
-msgid "section番号を格納するint長バッファ（呼出側で準備する）を指定します。"
-msgstr ""
-
 msgid "This is a dangerous API. You must not use this API when other thread or process accesses the target column. If you use this API against shared column, the process that accesses the column may be broken and the column may be broken."
 msgstr ""
 

--- a/doc/source/reference/api/grn_column.rst
+++ b/doc/source/reference/api/grn_column.rst
@@ -18,16 +18,6 @@ TODO...
 Reference
 ---------
 
-.. c:function:: int grn_column_index(grn_ctx *ctx, grn_obj *column, grn_operator op, grn_obj **indexbuf, int buf_size, int *section)
-
-   columnに張られているindexのうち、opの操作を実行可能なものの数を返します。またそれらのidを、buf_sizeに指定された個数を上限としてindexbufに返します。
-
-   :param column: 対象のcolumnを指定します。
-   :param op: indexで実行したい操作を指定します。
-   :param indexbuf: indexを格納するバッファ（呼出側で準備する）を指定します。
-   :param buf_size: indexbufのサイズ（byte長）を指定します。
-   :param section: section番号を格納するint長バッファ（呼出側で準備する）を指定します。
-
 .. c:function:: grn_rc grn_column_truncate(grn_ctx *ctx, grn_obj *column)
 
    .. note::

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1935,7 +1935,9 @@ grn_obj_open(grn_ctx *ctx,
              grn_obj_flags flags,
              grn_id domain);
 
-/* Deprecated since 5.0.1. Use grn_column_find_index_data() instead. */
+/**
+ * \deprecated Since 5.0.1. Use \ref grn_column_find_index_data instead.
+ */
 GRN_API int
 grn_column_index(grn_ctx *ctx,
                  grn_obj *column,

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1950,7 +1950,28 @@ typedef struct _grn_index_datum {
   unsigned int section;
 } grn_index_datum;
 
-/* @since 5.0.1. */
+/**
+ * \brief Return indexes that can perform a specified operation by storing it in
+ *        `index_data`.
+ *
+ * \note This function replaces the deprecated \ref grn_column_index function.
+ *
+ * \since 5.0.1
+ *
+ * \param ctx The context object.
+ * \param column The target column to search for associated indexes.
+ * \param op The operator that the indexes should support.
+ *           (e.g., \ref GRN_OP_EQUAL, GRN_OP_PREFIX, GRN_OP_LESS, and so on.).
+ * \param index_data An array to store information about the found indexes.
+ *                   Each element is a \ref grn_index_datum structure containing
+ *                   details about an index. The caller must allocate this array
+ *                   with at least `n_index_data` elements.
+ * \param n_index_data The maximum number of entries to store in `index_data`.
+ *
+ * \return The total number of indexes found that support the specified
+ *         operation. If more indexes are found than `n_index_data`, only the
+ *         first `n_index_data` entries are filled in `index_data`.
+ */
 GRN_API unsigned int
 grn_column_find_index_data(grn_ctx *ctx,
                            grn_obj *column,

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1963,7 +1963,8 @@ typedef struct _grn_index_datum {
  * \param ctx The context object.
  * \param column The target column to search for associated indexes.
  * \param op The operator that the indexes should support.
- *           (e.g., \ref GRN_OP_EQUAL, GRN_OP_PREFIX, GRN_OP_LESS, and so on.).
+ *           (e.g., \ref GRN_OP_EQUAL, \ref GRN_OP_PREFIX, \ref GRN_OP_LESS, and
+ *           so on.).
  * \param index_data An array to store information about the found indexes.
  *                   Each element is a \ref grn_index_datum structure containing
  *                   details about an index. The caller must allocate this array

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1971,7 +1971,7 @@ typedef struct _grn_index_datum {
  *                   with at least `n_index_data` elements.
  * \param n_index_data The maximum number of entries to store in `index_data`.
  *
- * \return The total number of indexes found that support the specified
+ * \return The total number of found indexes that support the specified
  *         operation. If more indexes are found than `n_index_data`, only the
  *         first `n_index_data` entries are filled in `index_data`.
  */


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.