### PR TITLE
index_column_diff: increase timeout for too_many_token's tests on Windows

### DIFF
--- a/test/command/suite/index_column_diff/too_many_tokens/int64_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/int64_vector.test
@@ -4,7 +4,7 @@ column_create PostingLists deltas COLUMN_VECTOR Int64
 table_create Deltas TABLE_PAT_KEY Int64
 column_create Deltas index COLUMN_INDEX|WITH_POSITION PostingLists deltas
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 PostingLists '{"deltas" => [1] * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/reference_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/reference_vector.test
@@ -5,7 +5,7 @@ column_create Memos tags COLUMN_VECTOR Tags
 
 column_create Tags memos_tags COLUMN_INDEX|WITH_POSITION Memos tags
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 Memos '{"tags" => ["tag"] * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text.test
@@ -4,7 +4,7 @@ column_create Diaries content COLUMN_SCALAR LongText
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenDelimit
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries content
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 Diaries '{"content" => "a " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_multi_sources.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_multi_sources.test
@@ -7,7 +7,7 @@ column_create Terms index \
   COLUMN_INDEX|WITH_POSITION|WITH_SECTION \
   Diaries title,content
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 Diaries '{"title" => "a", "content" => "a " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_multi_tokens.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_multi_tokens.test
@@ -4,7 +4,7 @@ column_create Diaries content COLUMN_SCALAR LongText
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenDelimit
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries content
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 Diaries '{"content" => "a b " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_vector.test
@@ -4,7 +4,7 @@ column_create Diaries contents COLUMN_VECTOR Text
 table_create Terms TABLE_PAT_KEY ShortText
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries contents
 
-#@timeout 60
+#@timeout 120
 #@disable-logging
 #@generate-series 1 1 Diaries '{"contents" => ["a"] * (0x1ffff + 1)}'
 #@enable-logging


### PR DESCRIPTION
In CI, `Test: HTTP: reference count: Apache Arrow: chunked` step for Windows failed as follows.
These tests are unstable using the current timeout time.

```
...
--- (expected)
+++ (actual)
@@ -6,6 +6,5 @@
 [[0,0.0,0.0],true]
 column_create Deltas index COLUMN_INDEX|WITH_POSITION PostingLists deltas
 [[0,0.0,0.0],true]
-#|w| [ii][update][one] too many postings: <Deltas.index>: <1>(1): record:<PostingLists>(1:1), n-postings:<131072>, n-discarded-postings:<1>
 index_column_diff Deltas index
 [[0,0.0,0.0],[]]

===============================================================================
[2] index_column_diff/too_many_tokens
  int64_vector                                                56.2620s [failed]
===============================================================================
===============================================================================
...
```

So we will try to extend the timeout from 60 seconds to 120 seconds for these too_many_token's tests.