### PR TITLE
pat: Fix the calculation for the target segment

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1036,7 +1036,7 @@ key_put(grn_ctx *ctx, grn_pat *pat, const uint8_t *key, uint32_t len)
     return 0;
   }
 
-  ts = (res + len) >> W_OF_KEY_IN_A_SEGMENT;
+  ts = (res + len - 1) >> W_OF_KEY_IN_A_SEGMENT;
   if (res >> W_OF_KEY_IN_A_SEGMENT != ts) {
     res = pat->header->curr_key = ts << W_OF_KEY_IN_A_SEGMENT;
   }

--- a/test/command/suite/load/patricia_trie/bit_less_from_first_segment.expected
+++ b/test/command/suite/load/patricia_trie/bit_less_from_first_segment.expected
@@ -1,0 +1,36 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+[[0,0.0,0.0],true]
+object_inspect Users
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "id": 256,
+    "name": "Users",
+    "type": {
+      "id": 49,
+      "name": "table:pat_key"
+    },
+    "key": {
+      "type": {
+        "id": 14,
+        "name": "ShortText",
+        "type": {
+          "id": 32,
+          "name": "type"
+        },
+        "size": 4096
+      },
+      "total_size": 4194303,
+      "max_total_size": 4294967294
+    },
+    "value": {
+      "type": null
+    },
+    "n_records": 182361,
+    "disk_usage": 0
+  }
+]

--- a/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
@@ -1,0 +1,14 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+
+# About data to load.
+# 4,194,304 bytes per segment.
+# 23 bytes per key.
+# 4,194,304 / 23 = 182,361 with a remainder of 1.
+# The data is a bit less from the first segment.
+#@timeout 30
+#@disable-logging
+#@generate-series 1 182361 Users '{"_key" => "User%019d" % i}'
+#@enable-logging
+#@timeout default
+
+object_inspect Users

--- a/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 23 bytes per key.
 # 4,194,304 / 23 = 182,361 with a remainder of 1.
 # The data is a bit less from the first segment.
-#@timeout 65
+#@timeout 400
 #@disable-logging
 #@generate-series 1 182361 Users '{"_key" => "User%019d" % i}'
 #@enable-logging

--- a/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_less_from_first_segment.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 23 bytes per key.
 # 4,194,304 / 23 = 182,361 with a remainder of 1.
 # The data is a bit less from the first segment.
-#@timeout 30
+#@timeout 65
 #@disable-logging
 #@generate-series 1 182361 Users '{"_key" => "User%019d" % i}'
 #@enable-logging

--- a/test/command/suite/load/patricia_trie/bit_over_from_first_segment.expected
+++ b/test/command/suite/load/patricia_trie/bit_over_from_first_segment.expected
@@ -1,0 +1,36 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+[[0,0.0,0.0],true]
+object_inspect Users
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "id": 256,
+    "name": "Users",
+    "type": {
+      "id": 49,
+      "name": "table:pat_key"
+    },
+    "key": {
+      "type": {
+        "id": 14,
+        "name": "ShortText",
+        "type": {
+          "id": 32,
+          "name": "type"
+        },
+        "size": 4096
+      },
+      "total_size": 4194309,
+      "max_total_size": 4294967294
+    },
+    "value": {
+      "type": null
+    },
+    "n_records": 279621,
+    "disk_usage": 0
+  }
+]

--- a/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 15 bytes per key.
 # 4,194,304 / 15 = 279,620 with a remainder of 4.
 # The data is a bit over from the first segment.
-#@timeout 30
+#@timeout 65
 #@disable-logging
 #@generate-series 1 279620 Users '{"_key" => "User%011d" % i}'
 load --table Users

--- a/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
@@ -1,0 +1,18 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+
+# About data to load.
+# 4,194,304 bytes per segment.
+# 15 bytes per key.
+# 4,194,304 / 15 = 279,620 with a remainder of 4.
+# The data is a bit over from the first segment.
+#@timeout 30
+#@disable-logging
+#@generate-series 1 279620 Users '{"_key" => "User%011d" % i}'
+load --table Users
+[
+{"_key":"ABCDE"}
+]
+#@enable-logging
+#@timeout default
+
+object_inspect Users

--- a/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
+++ b/test/command/suite/load/patricia_trie/bit_over_from_first_segment.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 15 bytes per key.
 # 4,194,304 / 15 = 279,620 with a remainder of 4.
 # The data is a bit over from the first segment.
-#@timeout 65
+#@timeout 400
 #@disable-logging
 #@generate-series 1 279620 Users '{"_key" => "User%011d" % i}'
 load --table Users

--- a/test/command/suite/load/patricia_trie/use_first_segment_in_full.expected
+++ b/test/command/suite/load/patricia_trie/use_first_segment_in_full.expected
@@ -1,0 +1,36 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+[[0,0.0,0.0],true]
+object_inspect Users
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "id": 256,
+    "name": "Users",
+    "type": {
+      "id": 49,
+      "name": "table:pat_key"
+    },
+    "key": {
+      "type": {
+        "id": 14,
+        "name": "ShortText",
+        "type": {
+          "id": 32,
+          "name": "type"
+        },
+        "size": 4096
+      },
+      "total_size": 4194304,
+      "max_total_size": 4294967294
+    },
+    "value": {
+      "type": null
+    },
+    "n_records": 262144,
+    "disk_usage": 0
+  }
+]

--- a/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
+++ b/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
@@ -1,0 +1,14 @@
+table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
+
+# About data to load.
+# 4,194,304 bytes per segment.
+# 16 bytes per key.
+# 4,194,304 / 16 = 262,144.
+# This is data that uses the full segment.
+#@timeout 30
+#@disable-logging
+#@generate-series 1 262144 Users '{"_key" => "User%012d" % i}'
+#@enable-logging
+#@timeout default
+
+object_inspect Users

--- a/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
+++ b/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 16 bytes per key.
 # 4,194,304 / 16 = 262,144.
 # This is data that uses the full segment.
-#@timeout 65
+#@timeout 400
 #@disable-logging
 #@generate-series 1 262144 Users '{"_key" => "User%012d" % i}'
 #@enable-logging

--- a/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
+++ b/test/command/suite/load/patricia_trie/use_first_segment_in_full.test
@@ -5,7 +5,7 @@ table_create --name Users --flags TABLE_PAT_KEY --key_type ShortText
 # 16 bytes per key.
 # 4,194,304 / 16 = 262,144.
 # This is data that uses the full segment.
-#@timeout 30
+#@timeout 65
 #@disable-logging
 #@generate-series 1 262144 Users '{"_key" => "User%012d" % i}'
 #@enable-logging


### PR DESCRIPTION
When the next length to be added equals `GRN_PAT_SEGMENT_SIZE`, move on to the next segment.
But, if the size is the equal, it can be written to the current segment, so it was fixed so that it can be calculated correctly.

The `grn_io` layer allocates an space of `GRN_PAT_SEGMENT_SIZE`.