### PR TITLE
ci package ubuntu focal: add missing Threads::Threads dependencies

### DIFF
--- a/src/suggest/CMakeLists.txt
+++ b/src/suggest/CMakeLists.txt
@@ -51,8 +51,14 @@ if(GRN_WITH_SUGGEST_LEARNER)
   add_executable(groonga-suggest-learner ${GROONGA_SUGGEST_LEARNER_SOURCES})
   set_source_files_properties(${GROONGA_SUGGEST_LEARNER_SOURCES}
                               PROPERTIES COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS}")
-  target_link_libraries(groonga-suggest-learner groonga-suggest-util libgroonga
-                        Groonga::libevent Groonga::zeromq Groonga::msgpackc)
+  target_link_libraries(
+    groonga-suggest-learner
+    groonga-suggest-util
+    libgroonga
+    Groonga::libevent
+    Groonga::zeromq
+    Groonga::msgpackc
+    Threads::Threads)
 
   read_file_list(${CMAKE_CURRENT_SOURCE_DIR}/httpd_sources.am
                  GROONGA_SUGGEST_HTTPD_SOURCES)

--- a/src/suggest/CMakeLists.txt
+++ b/src/suggest/CMakeLists.txt
@@ -65,8 +65,14 @@ if(GRN_WITH_SUGGEST_LEARNER)
   add_executable(groonga-suggest-httpd ${GROONGA_SUGGEST_HTTPD_SOURCES})
   set_source_files_properties(${GROONGA_SUGGEST_HTTPD_SOURCES}
                               PROPERTIES COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS}")
-  target_link_libraries(groonga-suggest-httpd groonga-suggest-util libgroonga
-                        Groonga::libevent Groonga::zeromq Groonga::msgpackc)
+  target_link_libraries(
+    groonga-suggest-httpd
+    groonga-suggest-util
+    libgroonga
+    Groonga::libevent
+    Groonga::zeromq
+    Groonga::msgpackc
+    Threads::Threads)
 
   install(TARGETS groonga-suggest-learner groonga-suggest-httpd
           DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
CI failed because `groonga-suggest-learner` & `groonga-suggest-httpd` couldn't be linked to `libpthread.so.0` like the followings.

- `groonga-suggest-learner`

```
...
[400/416] : && /usr/bin/cc -g -O2 -fdebug-prefix-map=/build/groonga-14.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG  -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now src/suggest/CMakeFiles/groonga-suggest-learner.dir/groonga_suggest_learner.c.o  -o src/suggest/groonga-suggest-learner  -Wl,-rpath,/build/groonga-14.1.1/obj-x86_64-linux-gnu/lib:  src/suggest/libgroonga-suggest-util.a  lib/libgroonga.so.0.0.0  /usr/lib/x86_64-linux-gnu/libmsgpackc.so  /usr/lib/x86_64-linux-gnu/libevent.so  /usr/lib/x86_64-linux-gnu/libzmq.so && :
FAILED: src/suggest/groonga-suggest-learner 
: && /usr/bin/cc -g -O2 -fdebug-prefix-map=/build/groonga-14.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG  -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now src/suggest/CMakeFiles/groonga-suggest-learner.dir/groonga_suggest_learner.c.o  -o src/suggest/groonga-suggest-learner  -Wl,-rpath,/build/groonga-14.1.1/obj-x86_64-linux-gnu/lib:  src/suggest/libgroonga-suggest-util.a  lib/libgroonga.so.0.0.0  /usr/lib/x86_64-linux-gnu/libmsgpackc.so  /usr/lib/x86_64-linux-gnu/libevent.so  /usr/lib/x86_64-linux-gnu/libzmq.so && :
/usr/bin/ld: src/suggest/CMakeFiles/groonga-suggest-learner.dir/groonga_suggest_learner.c.o: undefined reference to symbol 'pthread_join@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
...
```

- groonga-suggest-httpd

```
...
[403/416] : && /usr/bin/cc -g -O2 -fdebug-prefix-map=/build/groonga-14.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG  -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now src/suggest/CMakeFiles/groonga-suggest-httpd.dir/groonga_suggest_httpd.c.o  -o src/suggest/groonga-suggest-httpd  -Wl,-rpath,/build/groonga-14.1.1/obj-x86_64-linux-gnu/lib:  src/suggest/libgroonga-suggest-util.a  lib/libgroonga.so.0.0.0  /usr/lib/x86_64-linux-gnu/libmsgpackc.so  /usr/lib/x86_64-linux-gnu/libevent.so  /usr/lib/x86_64-linux-gnu/libzmq.so && :
FAILED: src/suggest/groonga-suggest-httpd 
: && /usr/bin/cc -g -O2 -fdebug-prefix-map=/build/groonga-14.1.1=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -O2 -g -DNDEBUG  -Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now src/suggest/CMakeFiles/groonga-suggest-httpd.dir/groonga_suggest_httpd.c.o  -o src/suggest/groonga-suggest-httpd  -Wl,-rpath,/build/groonga-14.1.1/obj-x86_64-linux-gnu/lib:  src/suggest/libgroonga-suggest-util.a  lib/libgroonga.so.0.0.0  /usr/lib/x86_64-linux-gnu/libmsgpackc.so  /usr/lib/x86_64-linux-gnu/libevent.so  /usr/lib/x86_64-linux-gnu/libzmq.so && :
/usr/bin/ld: src/suggest/CMakeFiles/groonga-suggest-httpd.dir/groonga_suggest_httpd.c.o: undefined reference to symbol 'pthread_join@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
...
```

So we added Threads::Threads to the dependencies.