### PR TITLE
docs: api/grn_geo: remove grn_geo_estimate_in_rectangle() reference

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_geo.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_geo.po
@@ -33,7 +33,7 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "It estimates number of records in the rectangle specified by top_left_point parameter and bottom_right_point parameter. Number of records is estimated by index parameter. If an error is occurred, -1 is returned."
+msgid "It opens a cursor to get records in the rectangle specified by top_left_point parameter and bottom_right_point parameter."
 msgstr ""
 
 msgid "the index column for TokyoGeoPoint or WGS84GeoPpoint type."
@@ -43,9 +43,6 @@ msgid "the top left point of the target rectangle. (ShortText, Text, LongText, T
 msgstr ""
 
 msgid "the bottom right point of the target rectangle. (ShortText, Text, LongText, TokyoGeoPoint or WGS84GeoPoint)"
-msgstr ""
-
-msgid "It opens a cursor to get records in the rectangle specified by top_left_point parameter and bottom_right_point parameter."
 msgstr ""
 
 msgid "the cursor returns records from offset parameter position. offset parameter is based on 0."

--- a/doc/source/reference/api/grn_geo.rst
+++ b/doc/source/reference/api/grn_geo.rst
@@ -18,14 +18,6 @@ Reference
 
 .. c:type:: grn_geo_point
 
-.. c:function:: int grn_geo_estimate_in_rectangle(grn_ctx *ctx, grn_obj *index, grn_obj *top_left_point, grn_obj *bottom_right_point)
-
-   It estimates number of records in the rectangle specified by top_left_point parameter and bottom_right_point parameter. Number of records is estimated by index parameter. If an error is occurred, -1 is returned.
-
-   :param index: the index column for TokyoGeoPoint or WGS84GeoPpoint type.
-   :param top_left_point: the top left point of the target rectangle. (ShortText, Text, LongText, TokyoGeoPoint or WGS84GeoPoint)
-   :param bottom_right_point: the bottom right point of the target rectangle. (ShortText, Text, LongText, TokyoGeoPoint or WGS84GeoPoint)
-
 .. c:function:: grn_obj *grn_geo_cursor_open_in_rectangle(grn_ctx *ctx, grn_obj *index, grn_obj *top_left_point, grn_obj *bottom_right_point, int offset, int limit)
 
    It opens a cursor to get records in the rectangle specified by top_left_point parameter and bottom_right_point parameter.


### PR DESCRIPTION
GitHub: GH-2103

In the GH-2103, we forgot to remove the moved documentation. This PR deals with it.