### PR TITLE
Revert: portability: Add grn_qsort_r()

### DIFF
--- a/include/groonga/portability.h
+++ b/include/groonga/portability.h
@@ -208,11 +208,3 @@
 #  define grn_mktime(tm)      mktime((tm))
 #  define grn_timegm(tm)      timegm((tm))
 #endif /* WIN32 */
-
-#ifdef WIN32
-#  define grn_qsort_r(base, nmemb, size, compar, arg)                          \
-    qsort_s((base), (nmemb), (size), (compar), (arg))
-#else /* WIN32 */
-#  define grn_qsort_r(base, nmemb, size, compar, arg)                          \
-    qsort_r((base), (nmemb), (size), (compar), (arg))
-#endif /* WIN32 */


### PR DESCRIPTION
* The definition of `compar` is different for qsort_s() and qsort_r()
* Different definition of qsort_s() in macOS