### PR TITLE
docs: api/grn_geo: move grn_geo_cursor_next() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_geo.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_geo.po
@@ -15,9 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
 msgid "``grn_geo``"
 msgstr ""
 
@@ -33,8 +30,5 @@ msgstr "例"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "It returns the next posting that has record ID. It returns NULL after all records are returned."
-msgstr ""
-
-msgid "the geo cursor."
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_geo.rst
+++ b/doc/source/reference/api/grn_geo.rst
@@ -16,10 +16,5 @@ TODO...
 Reference
 ---------
 
-.. c:type:: grn_geo_point
-
-.. c:function:: grn_posting *grn_geo_cursor_next(grn_ctx *ctx, grn_obj *cursor)
-
-   It returns the next posting that has record ID. It returns NULL after all records are returned.
-
-   :param cursor: the geo cursor.
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/geo.h
+++ b/include/groonga/geo.h
@@ -140,6 +140,15 @@ grn_geo_cursor_open_in_rectangle(grn_ctx *ctx,
                                  grn_obj *bottom_right_point,
                                  int offset,
                                  int limit);
+/**
+ * \brief Retrieve the next posting from the geo cursor and advance to the next.
+ *
+ * \param ctx The context object.
+ * \param geo_cursor The geo cursor from which to retrieve the next posting.
+ *
+ * \return \ref grn_posting if the next posting is found, `NULL` otherwise.
+ *         You don't need to free the returned \ref grn_posting.
+ */
 GRN_API grn_posting *
 grn_geo_cursor_next(grn_ctx *ctx, grn_obj *cursor);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.