### PR TITLE
Add grn_qsort_r_grn_id() to sort the grn_id array

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,6 +99,7 @@ repos:
           ?lib/grn_obj\.h|
           ?lib/grn_output\.h|
           ?lib/grn_pat\.h|
+          ?lib/grn_portability\.h|
           ?lib/grn_proc\.h|
           ?lib/grn_request_canceler\.h|
           ?lib/grn_request_timer\.h|
@@ -130,6 +131,7 @@ repos:
           ?lib/operator\.c|
           ?lib/output\.c|
           ?lib/pat\.c|
+          ?lib/portability\.cpp|
           ?lib/proc/proc_column\.c|
           ?lib/proc/proc_distance\.c|
           ?lib/proc/proc_dump\.c|

--- a/include/groonga/portability.h
+++ b/include/groonga/portability.h
@@ -208,11 +208,3 @@
 #  define grn_mktime(tm)      mktime((tm))
 #  define grn_timegm(tm)      timegm((tm))
 #endif /* WIN32 */
-
-#ifdef WIN32
-#  define grn_qsort_r(base, nmemb, size, compar, arg)                          \
-    qsort_s((base), (nmemb), (size), (compar), (arg))
-#else /* WIN32 */
-#  define grn_qsort_r(base, nmemb, size, compar, arg)                          \
-    qsort_r((base), (nmemb), (size), (compar), (arg))
-#endif /* WIN32 */

--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -69,6 +69,7 @@ libgroonga_c_sources =				\
 	grn_output_columns.h			\
 	grn_pat.h				\
 	grn_plugin.h				\
+	grn_portability.h				\
 	grn_posting.h				\
 	grn_proc.h				\
 	grn_progress.h				\

--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -69,7 +69,7 @@ libgroonga_c_sources =				\
 	grn_output_columns.h			\
 	grn_pat.h				\
 	grn_plugin.h				\
-	grn_portability.h				\
+	grn_portability.h			\
 	grn_posting.h				\
 	grn_proc.h				\
 	grn_progress.h				\

--- a/lib/cpp_sources.am
+++ b/lib/cpp_sources.am
@@ -16,6 +16,7 @@ libgroonga_cpp_source =				\
 	grn_language_model.hpp			\
 	grn_task_executor.hpp			\
 	language_model.cpp			\
+	portability.cpp				\
 	token_column.cpp			\
 	trace_log.cpp				\
 	vector.cpp				\

--- a/lib/grn_portability.h
+++ b/lib/grn_portability.h
@@ -23,7 +23,9 @@ extern "C" {
 void
 grn_qsort_r_grn_id(grn_id *base,
                    size_t n_members,
-                   int (*compare)(const grn_id, const grn_id, void *),
+                   int (*compare)(const grn_id id1,
+                                  const grn_id id2,
+                                  void *arg),
                    void *arg);
 
 #ifdef __cplusplus

--- a/lib/grn_portability.h
+++ b/lib/grn_portability.h
@@ -22,8 +22,8 @@ extern "C" {
 
 void
 grn_qsort_r_grn_id(grn_id *base,
-                   size_t nmemb,
-                   int (*compar)(const grn_id, const grn_id, void *),
+                   size_t n_members,
+                   int (*compare)(const grn_id, const grn_id, void *),
                    void *arg);
 
 #ifdef __cplusplus

--- a/lib/grn_portability.h
+++ b/lib/grn_portability.h
@@ -1,0 +1,31 @@
+/*
+  Copyright (C) 2024  Abe Tomoaki <abe@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void
+grn_qsort_r_grn_id(grn_id *base,
+                   size_t nmemb,
+                   int (*compar)(const grn_id, const grn_id, void *),
+                   void *arg);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/portability.cpp
+++ b/lib/portability.cpp
@@ -16,9 +16,10 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <algorithm>
 #include "grn.h"
 #include "grn_portability.h"
+
+#include <algorithm>
 
 extern "C" {
 
@@ -26,17 +27,15 @@ extern "C" {
 void
 grn_qsort_r_grn_id(grn_id *base,
                    size_t n_members,
-                   int (*compare)(const grn_id, const grn_id, void *),
+                   int (*compare)(const grn_id id1,
+                                  const grn_id id2,
+                                  void *arg),
                    void *arg)
 {
-  if (compare) {
-    std::sort(base,
-              base + n_members,
-              [compare, arg](const grn_id id1, const grn_id id2) {
-                return compare(id1, id2, arg) < 0;
-              });
-  } else {
-    std::sort(base, base + n_members);
-  }
+  std::sort(base,
+            base + n_members,
+            [&compare, &arg](const grn_id id1, const grn_id id2) {
+              return compare(id1, id2, arg) < 0;
+            });
 }
 }

--- a/lib/portability.cpp
+++ b/lib/portability.cpp
@@ -1,0 +1,41 @@
+/*
+  Copyright (C) 2024  Abe Tomoaki <abe@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <algorithm>
+#include "grn.h"
+
+extern "C" {
+
+/* todo: Implement the general grn_qsort_r() that takes `base` as `void *`. */
+void
+grn_qsort_r_grn_id(grn_id *base,
+                   size_t nmemb,
+                   int (*compar)(const grn_id, const grn_id, void *),
+                   void *arg)
+{
+  if (compar) {
+    std::sort(base,
+              base + nmemb,
+              [compar, arg](const grn_id id1, const grn_id id2) {
+                return compar(id1, id2, arg) == -1;
+              });
+  } else {
+    std::sort(base, base + nmemb);
+  }
+}
+}

--- a/lib/portability.cpp
+++ b/lib/portability.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include "grn.h"
+#include "grn_portability.h"
 
 extern "C" {
 

--- a/lib/portability.cpp
+++ b/lib/portability.cpp
@@ -25,18 +25,18 @@ extern "C" {
 /* todo: Implement the general grn_qsort_r() that takes `base` as `void *`. */
 void
 grn_qsort_r_grn_id(grn_id *base,
-                   size_t nmemb,
-                   int (*compar)(const grn_id, const grn_id, void *),
+                   size_t n_members,
+                   int (*compare)(const grn_id, const grn_id, void *),
                    void *arg)
 {
-  if (compar) {
+  if (compare) {
     std::sort(base,
-              base + nmemb,
-              [compar, arg](const grn_id id1, const grn_id id2) {
-                return compar(id1, id2, arg) == -1;
+              base + n_members,
+              [compare, arg](const grn_id id1, const grn_id id2) {
+                return compare(id1, id2, arg) == -1;
               });
   } else {
-    std::sort(base, base + nmemb);
+    std::sort(base, base + n_members);
   }
 }
 }

--- a/lib/portability.cpp
+++ b/lib/portability.cpp
@@ -33,7 +33,7 @@ grn_qsort_r_grn_id(grn_id *base,
     std::sort(base,
               base + n_members,
               [compare, arg](const grn_id id1, const grn_id id2) {
-                return compare(id1, id2, arg) == -1;
+                return compare(id1, id2, arg) < 0;
               });
   } else {
     std::sort(base, base + n_members);


### PR DESCRIPTION
Since there is no portability in qsort_s() or qsort_r(), drop wrapping them.
For now, add a function to sort the grn_id array.

(The best is to implement a function that can sort any data with `void *`.)