### PR TITLE
docs: api/grn_ctx: move `grn_ctx_set_output_type()` reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
@@ -104,9 +104,3 @@ msgstr ""
 
 msgid "The output type of the context."
 msgstr ""
-
-msgid "Sets the new output type to the context. It is used by executing a command by :c:func:`grn_expr_exec()`. If you use :c:func:`grn_ctx_send()`, the new output type isn't used. :c:func:`grn_ctx_send()` sets output type from command line internally."
-msgstr ""
-
-msgid "The new output type."
-msgstr "新しい出力形式。"

--- a/doc/source/reference/api/grn_ctx.rst
+++ b/doc/source/reference/api/grn_ctx.rst
@@ -101,17 +101,3 @@ Reference
 
    :param ctx: The context object.
    :return: The output type of the context.
-
-.. c:function:: grn_rc grn_ctx_set_output_type(grn_ctx *ctx, grn_content_type type)
-
-   Sets the new output type to the context. It is used by executing a
-   command by :c:func:`grn_expr_exec()`. If you use
-   :c:func:`grn_ctx_send()`, the new output type isn't
-   used. :c:func:`grn_ctx_send()` sets output type from command line
-   internally.
-
-   Normally, this function isn't needed.
-
-   :param ctx: The context object.
-   :param type: The new output type.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -241,6 +241,32 @@ grn_ctx_output_table_records(grn_ctx *ctx,
 
 GRN_API grn_content_type
 grn_ctx_get_output_type(grn_ctx *ctx);
+/**
+ * \brief Set the output type for the context when executing commands.
+ *
+ * The output type determines the format of the result when executing commands
+ * using \ref grn_expr_exec. If you use \ref grn_ctx_send, the new output type
+ * isn't used because \ref grn_ctx_send sets the output type internally based on
+ * the command.
+ *
+ * \note Normally, you don't need to call this function unless you need to
+ * change the output type explicitly when executing commands using \ref
+ * grn_expr_exec.
+ *
+ * \param ctx The context object.
+ * \param type The new output type to set. It can be one of the followings:
+ *             - \ref GRN_CONTENT_NONE
+ *             - \ref GRN_CONTENT_TSV
+ *             - \ref GRN_CONTENT_JSON
+ *             - \ref GRN_CONTENT_XML
+ *             - \ref GRN_CONTENT_MSGPACK
+ *             - \ref GRN_CONTENT_GROONGA_COMMAND_LIST
+ *             - \ref GRN_CONTENT_APACHE_ARROW
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *         For example, \ref GRN_INVALID_ARGUMENT is returned if `type` is
+ *         invalid.
+ */
 GRN_API grn_rc
 grn_ctx_set_output_type(grn_ctx *ctx, grn_content_type type);
 GRN_API const char *

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -242,15 +242,15 @@ grn_ctx_output_table_records(grn_ctx *ctx,
 GRN_API grn_content_type
 grn_ctx_get_output_type(grn_ctx *ctx);
 /**
- * \brief Set the output type for the context when executing commands.
+ * \brief Set the output type for the context when executing a command.
  *
- * The output type determines the format of the result when executing commands
+ * The output type determines the format of the result when executing a command
  * using \ref grn_expr_exec. If you use \ref grn_ctx_send, the new output type
  * isn't used because \ref grn_ctx_send sets the output type internally based on
  * the command.
  *
  * \note Normally, you don't need to call this function unless you need to
- * change the output type explicitly when executing commands using \ref
+ * change the output type explicitly when executing a command using \ref
  * grn_expr_exec.
  *
  * \param ctx The context object.

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -254,14 +254,7 @@ grn_ctx_get_output_type(grn_ctx *ctx);
  * grn_expr_exec.
  *
  * \param ctx The context object.
- * \param type The new output type to set. It can be one of the followings:
- *             - \ref GRN_CONTENT_NONE
- *             - \ref GRN_CONTENT_TSV
- *             - \ref GRN_CONTENT_JSON
- *             - \ref GRN_CONTENT_XML
- *             - \ref GRN_CONTENT_MSGPACK
- *             - \ref GRN_CONTENT_GROONGA_COMMAND_LIST
- *             - \ref GRN_CONTENT_APACHE_ARROW
+ * \param type The new output type to set.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  *         For example, \ref GRN_INVALID_ARGUMENT is returned if `type` is


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.