### PR TITLE
release blog: generate blog post from release note

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@
 
 require "open-uri"
 require "tmpdir"
+require_relative "blog_task"
 
 def sh_capture_output(*command_line)
   IO.pipe do |read, write|
@@ -291,6 +292,9 @@ namespace :release do
        "Groonga #{version}!!!")
     sh("git", "push", "origin", "v#{version}")
   end
+
+  groonga_blog_task = BlogTask.new("Groonga")
+  groonga_blog_task.define
 end
 
 namespace :nfkc do

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@
 
 require "open-uri"
 require "tmpdir"
-require_relative "blog_task"
+require_relative "release_task"
 
 def sh_capture_output(*command_line)
   IO.pipe do |read, write|
@@ -292,10 +292,10 @@ namespace :release do
        "Groonga #{version}!!!")
     sh("git", "push", "origin", "v#{version}")
   end
-
-  groonga_blog_task = BlogTask.new("Groonga")
-  groonga_blog_task.define
 end
+
+release_task = ReleaseTask.new("Groonga")
+release_task.define
 
 namespace :nfkc do
   icu_version = ENV["ICU_VERSION"] || ""

--- a/blog_task.rb
+++ b/blog_task.rb
@@ -8,12 +8,12 @@
 #
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 # Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 class BlogTask
   include Rake::DSL

--- a/blog_task.rb
+++ b/blog_task.rb
@@ -1,0 +1,40 @@
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+# Copyright (C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 2.1 as published by the Free Software Foundation.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+class BlogTask
+  include Rake::DSL
+
+  def initialize(package)
+    @package = package
+  end
+
+  def define
+    define_generate_announce_task
+  end
+
+  private
+
+  def define_generate_announce_task
+    namespace :blog do
+      namespace :announce do
+        desc "Generate release announces from a release note"
+        task :generate do
+          puts "TODO: Generate release announce for #{@package}"
+        end
+      end
+    end
+  end
+end

--- a/blog_task.rb
+++ b/blog_task.rb
@@ -3,7 +3,8 @@
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
-# License version 2.1 as published by the Free Software Foundation.
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
 #
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/release_task.rb
+++ b/release_task.rb
@@ -15,7 +15,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-class BlogTask
+class ReleaseTask
   include Rake::DSL
 
   def initialize(package)
@@ -29,11 +29,13 @@ class BlogTask
   private
 
   def define_generate_announce_task
-    namespace :blog do
-      namespace :announce do
-        desc "Generate release announces from a release note"
-        task :generate do
-          puts "TODO: Generate release announce for #{@package}"
+    namespace :release do
+      namespace :blog do
+        namespace :announce do
+          desc "Generate release announces from a release note"
+          task :generate do
+            puts "TODO: Generate release announce for #{@package}"
+          end
         end
       end
     end

--- a/release_task.rb
+++ b/release_task.rb
@@ -23,12 +23,12 @@ class ReleaseTask
   end
 
   def define
-    define_generate_announce_task
+    define_generate_blog_task
   end
 
   private
 
-  def define_generate_announce_task
+  def define_generate_blog_task
     namespace :release do
       namespace :blog do
         desc "Generate release announce posts from a release note"

--- a/release_task.rb
+++ b/release_task.rb
@@ -31,11 +31,9 @@ class ReleaseTask
   def define_generate_announce_task
     namespace :release do
       namespace :blog do
-        namespace :announce do
-          desc "Generate release announces from a release note"
-          task :generate do
-            puts "TODO: Generate release announce for #{@package}"
-          end
+        desc "Generate release announce posts from a release note"
+        task :generate do
+          puts "TODO: Generate release announce posts for #{@package}"
         end
       end
     end


### PR DESCRIPTION
GitHub: GH-2114

In this PR, we prepare a rake task for generating release
announces in blog from the release note. 

At the following PRs, we will implement the logic and contents
step by step.

## What I checked in this PR

- The rake task is registered.

```console
$ rake -T | grep announce
git ls-files
rake release:blog:generate    # Generate release announce posts from a release note
```

- Call this rake task

```console
rake release:blog:generate
git ls-files
TODO: Generate release announce posts for Groonga
```