### PR TITLE
docs: api/grn_ctx: move summary to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
@@ -27,36 +27,6 @@ msgstr ""
 msgid "Summary"
 msgstr "概要"
 
-msgid ":c:type:`grn_ctx` is the most important object. :c:type:`grn_ctx` keeps the current information such as:"
-msgstr ":c:type:`grn_ctx` は最も重要なオブジェクトです。:c:type:`grn_ctx` はその時点の情報を保持します:"
-
-msgid "The last occurred error."
-msgstr "最後に発生したエラー。"
-
-msgid "The current encoding."
-msgstr "その時点のエンコーディング。"
-
-msgid "The default thresholds. (e.g. :ref:`select-match-escalation-threshold`)"
-msgstr "デフォルトの閾値。（例: :ref:`select-match-escalation-threshold`）"
-
-msgid "The default command version. (See :doc:`/reference/command/command_version`)"
-msgstr "デフォルトのコマンドバージョン。（ :doc:`/reference/command/command_version` ）を参照のこと。"
-
-msgid ":c:type:`grn_ctx` provides platform features such as:"
-msgstr ":c:type:`grn_ctx` は基盤となる機能を提供します:"
-
-msgid "Memory management."
-msgstr "メモリ管理機能"
-
-msgid "Logging."
-msgstr "ロギング機能"
-
-msgid "Most APIs receive :c:type:`grn_ctx` as the first argument."
-msgstr "ほとんどのAPIは :c:type:`grn_ctx` を最初の引数にとります。"
-
-msgid "You can't use the same :c:type:`grn_ctx` from two or more threads. You need to create a :c:type:`grn_ctx` for a thread. You can use two or more :c:type:`grn_ctx` in a thread but it is not needed for usual use-case."
-msgstr "同じ :c:type:`grn_ctx` を二つ以上のスレッドからは扱えません。:c:type:`grn_ctx` はスレッドごとに作成する必要があります。一つのスレッドでは :c:type:`grn_ctx` を二つ以上扱えますが、通常はその必要はありません。"
-
 msgid "Example"
 msgstr "例"
 

--- a/doc/source/reference/api/grn_ctx.rst
+++ b/doc/source/reference/api/grn_ctx.rst
@@ -6,26 +6,6 @@
 Summary
 -------
 
-:c:type:`grn_ctx` is the most important object. :c:type:`grn_ctx`
-keeps the current information such as:
-
-* The last occurred error.
-* The current encoding.
-* The default thresholds. (e.g. :ref:`select-match-escalation-threshold`)
-* The default command version. (See :doc:`/reference/command/command_version`)
-
-:c:type:`grn_ctx` provides platform features such as:
-
-* Memory management.
-* Logging.
-
-Most APIs receive :c:type:`grn_ctx` as the first argument.
-
-You can't use the same :c:type:`grn_ctx` from two or more threads. You
-need to create a :c:type:`grn_ctx` for a thread. You can use two or
-more :c:type:`grn_ctx` in a thread but it is not needed for usual
-use-case.
-
 Example
 -------
 

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -285,6 +285,27 @@ typedef enum {
  * ```
  */
 typedef struct _grn_obj grn_obj;
+/**
+ * \brief \ref grn_ctx is the most important object.
+ *
+ * \ref grn_ctx keeps the current information such as:
+ * - The last occurred error.
+ * - The current encoding.
+ * - The default thresholds.
+ *   - e.g. `match_escalation_threshold`.
+ * - The default command version.
+ *
+ * \ref grn_ctx provides platform features such as:
+ * - Memory management.
+ * - Logging.
+ *
+ * \note Most APIs receive \ref grn_ctx as the first argument.
+ *
+ * \attention You can't use the same \ref grn_ctx from two or more threads. You
+ *            need to create a \ref grn_ctx for a thread. You can use two or
+ *            more \ref grn_ctx in a thread but it is not needed for usual
+ *            use-case.
+ */
 typedef struct _grn_ctx grn_ctx;
 
 #define GRN_CTX_MSGSIZE (0x80)


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.