### PR TITLE
docs: api/grn_ctx: move grn_ctx_get_output_type() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_ctx.po
@@ -65,12 +65,3 @@ msgstr ""
 
 msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
 msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
-msgid "Gets the current output type of the context."
-msgstr "コンテキストの出力形式を取得します。"
-
-msgid "Normally, this function isn't needed."
-msgstr ""
-
-msgid "The output type of the context."
-msgstr ""

--- a/doc/source/reference/api/grn_ctx.rst
+++ b/doc/source/reference/api/grn_ctx.rst
@@ -72,12 +72,3 @@ Reference
    :param ctx: The context object.
    :param table_buffer: The output buffer to store tables.
    :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
-.. c:function:: grn_content_type grn_ctx_get_output_type(grn_ctx *ctx)
-
-   Gets the current output type of the context.
-
-   Normally, this function isn't needed.
-
-   :param ctx: The context object.
-   :return: The output type of the context.

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -239,6 +239,18 @@ grn_ctx_output_table_records(grn_ctx *ctx,
                              grn_obj *table,
                              grn_obj_format *format);
 
+/**
+ * \brief Get the current output type of the context.
+ *
+ * \note Normally, you don't need to call this function unless you need to
+ *       check the output type explicitly.
+ *
+ * \param ctx The context object.
+ *
+ * \return Return the output type of the context, which is one of the values
+ *         defined in \ref grn_content_type. Return \ref GRN_CONTENT_NONE If the
+ *         context is invalid.
+ */
 GRN_API grn_content_type
 grn_ctx_get_output_type(grn_ctx *ctx);
 /**

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -248,7 +248,7 @@ grn_ctx_output_table_records(grn_ctx *ctx,
  * \param ctx The context object.
  *
  * \return Return the output type of the context, which is one of the values
- *         defined in \ref grn_content_type. Return \ref GRN_CONTENT_NONE If the
+ *         defined in \ref grn_content_type. Return \ref GRN_CONTENT_NONE if the
  *         context is invalid.
  */
 GRN_API grn_content_type


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.