### PR TITLE
index_column_diff: omit tests that use large data with HTTP

### DIFF
--- a/test/command/suite/index_column_diff/too_many_tokens/int64_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/int64_vector.test
@@ -1,10 +1,13 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create PostingLists TABLE_NO_KEY
 column_create PostingLists deltas COLUMN_VECTOR Int64
 
 table_create Deltas TABLE_PAT_KEY Int64
 column_create Deltas index COLUMN_INDEX|WITH_POSITION PostingLists deltas
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 PostingLists '{"deltas" => [1] * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/reference_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/reference_vector.test
@@ -1,3 +1,6 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create Tags TABLE_HASH_KEY ShortText
 
 table_create Memos TABLE_NO_KEY
@@ -5,7 +8,7 @@ column_create Memos tags COLUMN_VECTOR Tags
 
 column_create Tags memos_tags COLUMN_INDEX|WITH_POSITION Memos tags
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 Memos '{"tags" => ["tag"] * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text.test
@@ -1,10 +1,13 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create Diaries TABLE_NO_KEY
 column_create Diaries content COLUMN_SCALAR LongText
 
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenDelimit
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries content
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 Diaries '{"content" => "a " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_multi_sources.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_multi_sources.test
@@ -1,3 +1,6 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create Diaries TABLE_NO_KEY
 column_create Diaries title COLUMN_SCALAR ShortText
 column_create Diaries content COLUMN_SCALAR LongText
@@ -7,7 +10,7 @@ column_create Terms index \
   COLUMN_INDEX|WITH_POSITION|WITH_SECTION \
   Diaries title,content
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 Diaries '{"title" => "a", "content" => "a " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_multi_tokens.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_multi_tokens.test
@@ -1,10 +1,13 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create Diaries TABLE_NO_KEY
 column_create Diaries content COLUMN_SCALAR LongText
 
 table_create Terms TABLE_PAT_KEY ShortText --default_tokenizer TokenDelimit
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries content
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 Diaries '{"content" => "a b " * (0x1ffff + 1)}'
 #@enable-logging

--- a/test/command/suite/index_column_diff/too_many_tokens/text_vector.test
+++ b/test/command/suite/index_column_diff/too_many_tokens/text_vector.test
@@ -1,10 +1,13 @@
+# This is too slow with HTTP chunked.
+#@require-interface stdio
+
 table_create Diaries TABLE_NO_KEY
 column_create Diaries contents COLUMN_VECTOR Text
 
 table_create Terms TABLE_PAT_KEY ShortText
 column_create Terms index COLUMN_INDEX|WITH_POSITION Diaries contents
 
-#@timeout 120
+#@timeout 60
 #@disable-logging
 #@generate-series 1 1 Diaries '{"contents" => ["a"] * (0x1ffff + 1)}'
 #@enable-logging


### PR DESCRIPTION
Because HTTP chunked test is too slow with them although we extended the timeout from 60 to 120 seconds at GH-2090.