### PR TITLE
release blog: implement the logic of the rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -294,7 +294,7 @@ namespace :release do
   end
 end
 
-release_task = ReleaseTask.new("Groonga")
+release_task = ReleaseTask.new("groonga", version, env_var("GROONGA_ORG_DIR"))
 release_task.define
 
 namespace :nfkc do

--- a/release_task.rb
+++ b/release_task.rb
@@ -45,7 +45,7 @@ class ReleaseTask
     "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
   end
 
-  def post(language)
+  def post_content(language)
     # TODO: We will write blog post contents here.
     # After writing contents, we will remove this comment.
     "#{language}, #{@package}, #{@version}"
@@ -53,8 +53,8 @@ class ReleaseTask
 
   def write_blog_posts
     ["ja", "en"].each do |language|
-      File.open("#{@jekyll_path}/#{language}/_posts/#{post_name}", "w") do |blog_post|
-        blog_post.write(post(language))
+      File.open("#{@jekyll_path}/#{language}/_posts/#{post_name}", "w") do |post|
+        post.write(post_content(language))
       end
     end
   end

--- a/release_task.rb
+++ b/release_task.rb
@@ -41,7 +41,7 @@ class ReleaseTask
     end
   end
 
-  def file_name
+  def post_name
     "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
   end
 
@@ -52,7 +52,7 @@ class ReleaseTask
 
   def blog_posts
     ["ja", "en"].each do |language|
-      File.open("#{@jekyll_path}/#{language}/_posts/#{file_name}", "w") do |blog_post|
+      File.open("#{@jekyll_path}/#{language}/_posts/#{post_name}", "w") do |blog_post|
         blog_post.write(post(language, @package, @version))
       end
     end

--- a/release_task.rb
+++ b/release_task.rb
@@ -46,7 +46,8 @@ class ReleaseTask
   end
 
   def post(language, package, version)
-    # TODO: Write blog post
+    # TODO: We will write blog post contents here.
+    # After writing contents, we will remove this comment.
     "#{language}, #{package}, #{version}"
   end
 

--- a/release_task.rb
+++ b/release_task.rb
@@ -35,7 +35,7 @@ class ReleaseTask
       namespace :blog do
         desc "Generate release announce posts from a release note"
         task :generate do
-          blog_posts
+          write_blog_posts
         end
       end
     end
@@ -51,7 +51,7 @@ class ReleaseTask
     "#{language}, #{package}, #{version}"
   end
 
-  def blog_posts
+  def write_blog_posts
     ["ja", "en"].each do |language|
       File.open("#{@jekyll_path}/#{language}/_posts/#{post_name}", "w") do |blog_post|
         blog_post.write(post(language, @package, @version))

--- a/release_task.rb
+++ b/release_task.rb
@@ -18,10 +18,10 @@
 class ReleaseTask
   include Rake::DSL
 
-  def initialize(package, version, doc_path)
+  def initialize(package, version, jekyll_path)
     @package = package
     @version = version
-    @doc_path = doc_path
+    @jekyll_path = jekyll_path
   end
 
   def define
@@ -52,7 +52,7 @@ class ReleaseTask
 
   def blog_posts
     ["ja", "en"].each do |language|
-      File.open("#{@doc_path}/#{language}/_posts/#{file_name}", "w") do |blog_post|
+      File.open("#{@jekyll_path}/#{language}/_posts/#{file_name}", "w") do |blog_post|
         blog_post.write(post(language, @package, @version))
       end
     end

--- a/release_task.rb
+++ b/release_task.rb
@@ -45,16 +45,16 @@ class ReleaseTask
     "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
   end
 
-  def post(language, package, version)
+  def post(language)
     # TODO: We will write blog post contents here.
     # After writing contents, we will remove this comment.
-    "#{language}, #{package}, #{version}"
+    "#{language}, #{@package}, #{@version}"
   end
 
   def write_blog_posts
     ["ja", "en"].each do |language|
       File.open("#{@jekyll_path}/#{language}/_posts/#{post_name}", "w") do |blog_post|
-        blog_post.write(post(language, @package, @version))
+        blog_post.write(post(language))
       end
     end
   end

--- a/release_task.rb
+++ b/release_task.rb
@@ -18,8 +18,10 @@
 class ReleaseTask
   include Rake::DSL
 
-  def initialize(package)
+  def initialize(package, version, doc_path)
     @package = package
+    @version = version
+    @doc_path = doc_path
   end
 
   def define
@@ -33,8 +35,25 @@ class ReleaseTask
       namespace :blog do
         desc "Generate release announce posts from a release note"
         task :generate do
-          puts "TODO: Generate release announce posts for #{@package}"
+          blog_posts
         end
+      end
+    end
+  end
+
+  def file_name
+    "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
+  end
+
+  def post(language, package, version)
+    # TODO: Write blog post
+    "#{language}, #{package}, #{version}"
+  end
+
+  def blog_posts
+    ["ja", "en"].each do |language|
+      File.open("#{@doc_path}/#{language}/_posts/#{file_name}", "w") do |blog_post|
+        blog_post.write(post(language, @package, @version))
       end
     end
   end


### PR DESCRIPTION
GitHub: GH-2114

In this PR, we prepare a rake task for generating release announces in blog from the release note.

At the following PRs, we will implement the contents.

We confirm correct results as below.

```
% rake release:blog:generate
% ls ../groonga.org/ja/_posts | grep 2024-12-02
2024-12-02-groonga-14.1.1.md
```