### PR TITLE
ci: Create the release page first

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -129,37 +129,9 @@ jobs:
       # Release
       - name: Upload to release
         if: |
-          startsWith(github.ref, 'refs/tags/')
+          github.ref_type == 'tag'
         run: |
-          (cd doc/source/news && \
-           ruby \
-             -e 'print("## Groonga "); \
-                 puts(ARGF.read.split(/^## Release /)[1]. \
-                        gsub(/^\(.+\)=$/, ""). \
-                        gsub(/{doc}`(.+?)`/) { \
-                          id = $1; \
-                          title = id.split("\/").last; \
-                          path = id.delete_prefix("/"); \
-                          url = "https://groonga.org/docs/#{path}.html"; \
-                          "[#{title}](#{url})"; \
-                        }. \
-                        gsub(/{ref}`(.+?)`/) {$1}.
-                        strip)' \
-             $(ls *.md | sort --human-numeric-sort | tail -n1)) > \
-            release-note.md
-          echo "" >> release-note.md
-          echo "### Translations" >> release-note.md
-          echo "" >> release-note.md
-          version=${GITHUB_REF_NAME#v}
-          major_version=${version%%.*}
-          version_hyphen=$(echo ${version} | tr . -)
-          echo "  * [Japanese](https://groonga.org/ja/docs/news/${major_version}.html#release-${version_hyphen})" >> release-note.md
-          title="$(head -n1 release-note.md | sed -e 's/^## //')"
-          tail -n +2 release-note.md > release-note-without-version.md
-          gh release create ${GITHUB_REF_NAME} \
-            --discussion-category Releases \
-            --notes-file release-note-without-version.md \
-            --title "${title}" \
+          gh release upload ${GITHUB_REF_NAME} \
             groonga-*.tar.gz \
             groonga-*.zip
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  page:
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release page
+        run: |
+          (cd doc/source/news && \
+           ruby \
+             -e 'print("## Groonga "); \
+                 puts(ARGF.read.split(/^## Release /)[1]. \
+                        gsub(/^\(.+\)=$/, ""). \
+                        gsub(/{doc}`(.+?)`/) { \
+                          id = $1; \
+                          title = id.split("\/").last; \
+                          path = id.delete_prefix("/"); \
+                          url = "https://groonga.org/docs/#{path}.html"; \
+                          "[#{title}](#{url})"; \
+                        }. \
+                        gsub(/{ref}`(.+?)`/) {$1}.
+                        strip)' \
+             $(ls *.md | sort --human-numeric-sort | tail -n1)) > \
+            release-note.md
+          echo "" >> release-note.md
+          echo "### Translations" >> release-note.md
+          echo "" >> release-note.md
+          version=${GITHUB_REF_NAME#v}
+          major_version=${version%%.*}
+          version_hyphen=$(echo ${version} | tr . -)
+          echo "  * [Japanese](https://groonga.org/ja/docs/news/${major_version}.html#release-${version_hyphen})" >> release-note.md
+          title="$(head -n1 release-note.md | sed -e 's/^## //')"
+          tail -n +2 release-note.md > release-note-without-version.md
+          gh release create ${GITHUB_REF_NAME} \
+            --discussion-category Releases \
+            --notes-file release-note-without-version.md \
+            --title "${title}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
When the tag is pushed, the first release page is created.
It is easier to upload archive files for multiple jobs.