### PR TITLE
docs: api/global_configurations move grn_get_lock_timeout() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/global_configurations.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/global_configurations.po
@@ -15,10 +15,10 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "戻り値"
+msgid "パラメータ"
 msgstr ""
 
-msgid "パラメータ"
+msgid "戻り値"
 msgstr ""
 
 msgid "Global configurations"
@@ -33,17 +33,8 @@ msgstr "Groongaにはグローバルな設定があります。それらにア�
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Returns the lock timeout."
-msgstr "ロックタイムアウトを返します。"
-
-msgid ":c:type:`grn_ctx` acquires a lock for updating a shared value. If other :c:type:`grn_ctx` is already updating the same value, :c:type:`grn_ctx` that try to acquire a lock can't acquires a lock. The :c:type:`grn_ctx` that can't acquires a lock waits 1 millisecond and try to acquire a lock again. The try is done ``timeout`` times. If the :c:type:`grn_ctx` that can't acquires a lock until ``timeout`` times, the tries are failed."
-msgstr ""
-
-msgid "The default lock timeout is ``10000000``. It means that Groonga doesn't report a lock failure until about 3 hours.  (1 * 10000000 [msec] = 10000 [sec] = 166.666... [min] = 2.777... [hour])"
-msgstr "デフォルトのロックタイムアウトは ``10000000`` です。つまりGroongaはロックの失敗をおよそ3時間経過するまで報告しません。(1 * 10000000 [msec] = 10000 [sec] = 166.666... [min] = 2.777... [hour])"
-
-msgid "The lock timeout."
-msgstr "ロックタイムアウト。"
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
 
 msgid "Sets the lock timeout."
 msgstr "ロックタイムアウトを設定します。"

--- a/doc/source/reference/api/global_configurations.rst
+++ b/doc/source/reference/api/global_configurations.rst
@@ -12,23 +12,8 @@ Groonga has the global configurations. You can access them by API.
 Reference
 ---------
 
-.. c:function:: int grn_get_lock_timeout(void)
-
-   Returns the lock timeout.
-
-   :c:type:`grn_ctx` acquires a lock for updating a shared value. If
-   other :c:type:`grn_ctx` is already updating the same value,
-   :c:type:`grn_ctx` that try to acquire a lock can't acquires a lock.
-   The :c:type:`grn_ctx` that can't acquires a lock waits 1
-   millisecond and try to acquire a lock again. The try is done
-   ``timeout`` times. If the :c:type:`grn_ctx` that can't acquires a
-   lock until ``timeout`` times, the tries are failed.
-
-   The default lock timeout is ``10000000``. It means that Groonga
-   doesn't report a lock failure until about 3 hours.  (1 * 10000000
-   [msec] = 10000 [sec] = 166.666... [min] = 2.777... [hour])
-
-   :return: The lock timeout.
+.. note::
+   We are currently switching to automatic generation using Doxygen.
 
 .. c:function:: grn_rc grn_set_lock_timeout(int timeout)
 

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -577,16 +577,14 @@ grn_unset_variable(const char *name, int name_size);
 /**
  * \brief Retrieve the current lock timeout.
  *
- * Groonga uses read lock-free mechanism. It allows multiple threads or
- * processes to perform read operations, even during write operations.
- * On the other hand, Groonga uses a locking mechanism specifically for managing
- * write operations on shared values. If a \ref grn_ctx instance attempts to
- * acquire a lock while another \ref grn_ctx instance is updating the same
- * resource. The lock acquisition will be retried until the lock is successfully
- * acquired or the specified timeout is reached.
+ * Groonga uses a read lock-free mechanism. It allows multiple threads or
+ * processes to perform read operations concurrently, even during write
+ * operations. Write operations, in contrast, require locking to ensure data
+ * consistency.
  *
- * During this process:
- * - The \ref grn_ctx waits for 1 millisecond before retrying.
+ * When performing write operations:
+ * - If acquiring a lock is not immediately available, it waits for 1
+ *   millisecond before retrying.
  * - The retries continue until the cumulative wait time reaches the lock
  *   timeout duration.
  * - If the lock cannot be acquired within the specified timeout duration, the

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -574,6 +574,25 @@ grn_ctx_get_variable(grn_ctx *ctx, const char *name, int name_size);
 GRN_API grn_rc
 grn_unset_variable(const char *name, int name_size);
 
+/**
+ * \brief Retrieve the current lock timeout.
+ *
+ * Groonga uses a locking mechanism when updating a shared value. If a
+ * \ref grn_ctx instance attempts to acquire a lock while another \ref grn_ctx
+ * instance is updating the same resource. The lock acquisition will be retried
+ * until the lock is successfully acquired or the specified timeout is reached.
+ *
+ * During this process:
+ * - The \ref grn_ctx waits for 1 millisecond before retrying.
+ * - The retries continue until the cumulative wait time reaches the lock
+ *   timeout duration.
+ * - If the lock cannot be acquired within the specified timeout duration, the
+ *   operation fails.
+ *
+ * The default lock timeout is set to 900,000 milliseconds (15 minutes).
+ *
+ * \return The current lock timeout in milliseconds.
+ */
 GRN_API int
 grn_get_lock_timeout(void);
 GRN_API grn_rc

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -577,10 +577,13 @@ grn_unset_variable(const char *name, int name_size);
 /**
  * \brief Retrieve the current lock timeout.
  *
- * Groonga uses a locking mechanism when updating a shared value. If a
- * \ref grn_ctx instance attempts to acquire a lock while another \ref grn_ctx
- * instance is updating the same resource. The lock acquisition will be retried
- * until the lock is successfully acquired or the specified timeout is reached.
+ * Groonga uses read lock-free mechanism. It allows multiple threads or
+ * processes to perform read operations, even during write operations.
+ * On the other hand, Groonga uses a locking mechanism specifically for managing
+ * write operations on shared values. If a \ref grn_ctx instance attempts to
+ * acquire a lock while another \ref grn_ctx instance is updating the same
+ * resource. The lock acquisition will be retried until the lock is successfully
+ * acquired or the specified timeout is reached.
  *
  * During this process:
  * - The \ref grn_ctx waits for 1 millisecond before retrying.


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.