### PR TITLE
docs: api/global_configurations move grn_set_lock_timeout() reference  to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/global_configurations.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/global_configurations.po
@@ -15,12 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
-msgid "戻り値"
-msgstr ""
-
 msgid "Global configurations"
 msgstr "全体設定"
 
@@ -35,24 +29,3 @@ msgstr "リファレンス"
 
 msgid "We are currently switching to automatic generation using Doxygen."
 msgstr "現在、Doxygenを使った自動生成に切り替え中です。"
-
-msgid "Sets the lock timeout."
-msgstr "ロックタイムアウトを設定します。"
-
-msgid "See :c:func:`grn_get_lock_timeout` about lock timeout."
-msgstr "ロックタイムアウトについては、 :c:func:`grn_get_lock_timeout` を参照してください。"
-
-msgid "There are some special values for ``timeout``."
-msgstr "``timeout`` にはいくつか特別な値があります。"
-
-msgid "``0``: It means that Groonga doesn't retry acquiring a lock. Groonga reports a failure after one lock acquirement failure."
-msgstr "``0``: Groongaがロックを再度取得しようとしません。一度ロックの取得に失敗した時点でGroongaはその失敗を報告します。"
-
-msgid "negative value: It means that Groonga retries acquiring a lock until Groonga can acquire a lock."
-msgstr "負数: Groongaはロックを取得できるまでリトライします。"
-
-msgid "The new lock timeout."
-msgstr "新しいロックのタイムアウト。"
-
-msgid "``GRN_SUCCESS``. It doesn't fail."
-msgstr "``GRN_SUCCESS`` 。この関数は失敗しません。"

--- a/doc/source/reference/api/global_configurations.rst
+++ b/doc/source/reference/api/global_configurations.rst
@@ -14,19 +14,3 @@ Reference
 
 .. note::
    We are currently switching to automatic generation using Doxygen.
-
-.. c:function:: grn_rc grn_set_lock_timeout(int timeout)
-
-   Sets the lock timeout.
-
-   See :c:func:`grn_get_lock_timeout` about lock timeout.
-
-   There are some special values for ``timeout``.
-
-     * ``0``: It means that Groonga doesn't retry acquiring a lock.
-       Groonga reports a failure after one lock acquirement failure.
-     * negative value: It means that Groonga retries acquiring a lock
-       until Groonga can acquire a lock.
-
-   :param timeout: The new lock timeout.
-   :return: ``GRN_SUCCESS``. It doesn't fail.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -602,9 +602,10 @@ grn_get_lock_timeout(void);
  * Special cases for the `timeout` parameter:
  * - **0**: If `timeout` is 0, Groonga will attempt to acquire the lock only
  *   once. If it fails, it will not retry and the operation will fail
- *   immediately.
- * - **Negative value**: A negative `timeout` indicates that Groonga will
- *   retry acquiring the lock forever without timeout.
+ *   immediately without waiting for the lock to be released.
+ * - **Negative value**: If `timeout` is negative value, Groonga will wait
+ *   forever for retrying to acquire the lock without any timeout until it
+ *   succeeds.
  *
  * The default lock timeout is 900,000 milliseconds (15 minutes).
  *

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -596,6 +596,30 @@ grn_unset_variable(const char *name, int name_size);
  */
 GRN_API int
 grn_get_lock_timeout(void);
+/**
+ * \brief Set the lock timeout used during write operations.
+ *
+ * Special cases for the `timeout` parameter:
+ * - **0**: If `timeout` is 0, Groonga will attempt to acquire the lock only
+ *   once. If it fails, it will not retry and the operation will fail
+ *   immediately.
+ * - **Negative value**: A negative `timeout` indicates that Groonga will
+ *   retry acquiring the lock forever without timeout.
+ *
+ * The default lock timeout is 900,000 milliseconds (15 minutes).
+ *
+ * **Lock Timeout Configuration**:
+ *
+ * Lock timeout can be configured in two ways:
+ * - **Environment Variable**: Set `GRN_LOCK_TIMEOUT` before running the program
+ *   to specify a default lock timeout by milliseconds.
+ * - **API**: Use \ref grn_set_lock_timeout to override the environment variable
+ *   setting at runtime.
+ *
+ * \param timeout The new lock timeout in milliseconds.
+ *
+ * \return \ref GRN_SUCCESS on success.
+ */
 GRN_API grn_rc
 grn_set_lock_timeout(int timeout);
 

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -612,10 +612,10 @@ grn_get_lock_timeout(void);
  * **Lock Timeout Configuration**:
  *
  * Lock timeout can be configured in two ways:
- * - **Environment Variable**: Set `GRN_LOCK_TIMEOUT` before running the program
- *   to specify a default lock timeout by milliseconds.
- * - **API**: Use \ref grn_set_lock_timeout to override the environment variable
- *   setting at runtime.
+ * - **CMake Option**: Use `-DGRN_LOCK_TIMEOUT=<milliseconds>` when configuring
+ *   the build with CMake to specify a default lock timeout by milliseconds.
+ * - **API**: Use \ref grn_set_lock_timeout to override the default setting at
+ *   runtime.
  *
  * \param timeout The new lock timeout in milliseconds.
  *


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.