### PR TITLE
docs: Add required gem, red-datasets

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -3,14 +3,14 @@ on:
   push:
     paths:
       - 'Rakefile'
-      - 'doc/Doxyfile'
+      - 'doc/**'
       - 'include/**/*.h'
       - 'include/**/*.hpp'
       - '.github/workflows/document.yml'
   pull_request:
     paths:
       - 'Rakefile'
-      - 'doc/Doxyfile'
+      - 'doc/**'
       - 'include/**/*.h'
       - 'include/**/*.hpp'
       - '.github/workflows/document.yml'

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -17,3 +17,4 @@
 source 'https://rubygems.org'
 
 gem 'gettext'
+gem 'red-datasets'


### PR DESCRIPTION
We need to install Red Datasets explicitly to use gettext gem's auto locale information fill feature.

`Plural-Forms` is output correctly and the following warnings are no longer printed.

```
WARNING: reading error: /home/runner/work/groonga/groonga/doc/source/../locale/en/LC_MESSAGES/news/1.1.po, invalid literal for int() with base 10: ''
```

Plural-Forms before: `"Plural-Forms: nplurals=; plural=;\n"`
Plural-Forms after : `"Plural-Forms: nplurals=2; plural=n != 1;\n"`