### PR TITLE
test command-line: use locale encoding for Japanese file paths on Windows

### DIFF
--- a/test/command_line/helper/command_runner.rb
+++ b/test/command_line/helper/command_runner.rb
@@ -189,7 +189,7 @@ module CommandRunner
           rescue SystemCallError
           end
         end
-        error_output = @error_output_log_path.read
+        error_output = @error_output_log_path.read.encode("UTF-8", "locale")
         Result.new("", error_output)
       end
     end
@@ -201,8 +201,8 @@ module CommandRunner
       :err => @error_output_log_path.to_s,
     }
     succeeded = system(*command_line, options)
-    output = @output_log_path.read.encode("UTF-8", "filesystem")
-    error_output = @error_output_log_path.read.encode("UTF-8", "filesystem")
+    output = @output_log_path.read.encode("UTF-8", "locale")
+    error_output = @error_output_log_path.read.encode("UTF-8", "locale")
     unless succeeded
       message = <<-MESSAGE.chomp
 failed to run: #{command_line.join(" ").encode("UTF-8")}

--- a/test/command_line/helper/command_runner.rb
+++ b/test/command_line/helper/command_runner.rb
@@ -219,7 +219,7 @@ failed to run: #{command_line.join(" ").encode("UTF-8")}
   end
 
   def read_log(log_path)
-    return "" unless File.exist?(log_path)
-    File.read(@log_path).encode("UTF-8", "locale")
+    return "" unless log_path.exist?
+    log_path.read.encode("UTF-8", "locale")
   end
 end

--- a/test/command_line/helper/command_runner.rb
+++ b/test/command_line/helper/command_runner.rb
@@ -189,7 +189,7 @@ module CommandRunner
           rescue SystemCallError
           end
         end
-        error_output = @error_output_log_path.read.encode("UTF-8", "locale")
+        error_output = read_log(@error_output_log_path)
         Result.new("", error_output)
       end
     end
@@ -201,8 +201,8 @@ module CommandRunner
       :err => @error_output_log_path.to_s,
     }
     succeeded = system(*command_line, options)
-    output = @output_log_path.read.encode("UTF-8", "locale")
-    error_output = @error_output_log_path.read.encode("UTF-8", "locale")
+    output = read_log(@output_log_path)
+    error_output = read_log(@error_output_log_path)
     unless succeeded
       message = <<-MESSAGE.chomp
 failed to run: #{command_line.join(" ").encode("UTF-8")}
@@ -216,5 +216,10 @@ failed to run: #{command_line.join(" ").encode("UTF-8")}
       raise Error.new(output, error_output, message)
     end
     Result.new(output, error_output)
+  end
+
+  def read_log(log_path)
+    return "" unless File.exist?(log_path)
+    File.read(@log_path).encode("UTF-8", "locale")
   end
 end


### PR DESCRIPTION
## Issue

When running `grndb` tests in a Windows environment, encoding file paths
containing Japanese characters failed in the test logs. It caused tests to
fail.

## Cause

This issue occurred because file paths encoded in CP932 were misinterpreted as
UTF-8 and then converted to UTF-8. The root of the problem lies in the change of
Ruby's behavior. From Ruby 3.0, `Encoding.find("filesystem")` now returns
"UTF-8" instead of the expected CP932 on Windows. Previously, `grndb` would have
treated CP932 data correctly, converting them from CP932(`"filesystem"`) to
UTF-8 without issues by Ruby. With the change, the conversion was incorrectly
attempting to interpret CP932 data as UTF-8(`"filesystem"`), which led to
failures.

### Note

- `grndb` outputs results using the encoding specified by the system locale.
- On Windows, the locale typically uses CP932, meaning `grndb` outputs
  CP932-encoded data.
- A change in Ruby 3.0 altered how `"filesystem"` encoding is resolved.
  - see https://github.com/ruby/ruby/commit/5b98b2ce39ed979aec614365a2dc3e1c30052bca

## Solution

We modified the `CommandRunner's run_command_(sync|interactive)` to use the locale encoding (`"locale"`)
instead of relying on `"filesystem"` encoding. This ensures that reading and
encoding operations correctly handle CP932-encoded paths on Windows, converting
them properly to UTF-8.
