### PR TITLE
index_column_diff: interrupt process immediately on error

### DIFF
--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -611,7 +611,7 @@ grn_index_column_diff_posting_list_flush(
         }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
-          if (posting == NULL) {
+          if (ctx->rc != GRN_SUCCESS) {
             return;
           }
           posting_list->need_cursor_next = false;
@@ -936,7 +936,7 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
         }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
-          if (posting == NULL) {
+          if (ctx->rc != GRN_SUCCESS) {
             return;
           }
           posting_list->need_cursor_next = false;

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -606,8 +606,14 @@ grn_index_column_diff_posting_list_flush(
     if (with_position) {
       while (!posting_list->need_cursor_next ||
              grn_ii_cursor_next(ctx, cursor)) {
+        if (ctx->rc != GRN_SUCCESS) {
+          return;
+        }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
+          if (posting == NULL) {
+            return;
+          }
           posting_list->need_cursor_next = false;
           GRN_UINT32_PUT(ctx, remains, posting->rid);
           if (with_section) {
@@ -620,6 +626,9 @@ grn_index_column_diff_posting_list_flush(
     } else {
       grn_posting *posting;
       while ((posting = grn_ii_cursor_next(ctx, cursor))) {
+        if (ctx->rc != GRN_SUCCESS) {
+          return;
+        }
         GRN_UINT32_PUT(ctx, remains, posting->rid);
         if (with_section) {
           GRN_UINT32_PUT(ctx, remains, posting->sid);

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -588,6 +588,15 @@ grn_index_column_diff_posting_list_fin(
   grn_index_column_diff_data *data,
   grn_index_column_diff_posting_list *posting_list)
 {
+  if (ctx->rc != GRN_SUCCESS) {
+    GRN_OBJ_FIN(ctx, &(posting_list->look_ahead));
+    GRN_OBJ_FIN(ctx, &(posting_list->remains));
+    GRN_OBJ_FIN(ctx, &(posting_list->missings));
+    grn_ii_cursor_close(ctx, posting_list->cursor);
+    posting_list->cursor = NULL;
+
+    return;
+  }
   grn_obj *remains = &(posting_list->remains);
   grn_obj *missings = &(posting_list->missings);
   {
@@ -1216,16 +1225,15 @@ grn_index_column_diff_compute(grn_ctx *ctx, grn_index_column_diff_data *data)
   }
   GRN_TABLE_EACH_END(ctx, cursor);
 
-  if (ctx->rc == GRN_SUCCESS) {
-    GRN_HASH_EACH_BEGIN(ctx, data->posting_lists, cursor, id)
-    {
-      void *value;
-      grn_hash_cursor_get_value(ctx, cursor, &value);
-      grn_index_column_diff_posting_list *posting_list = value;
-      grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
-    }
-    GRN_HASH_EACH_END(ctx, cursor);
+  GRN_HASH_EACH_BEGIN(ctx, data->posting_lists, cursor, id)
+  {
+    void *value;
+    grn_hash_cursor_get_value(ctx, cursor, &value);
+    grn_index_column_diff_posting_list *posting_list = value;
+    grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
   }
+  GRN_HASH_EACH_END(ctx, cursor);
+
   grn_hash_close(ctx, data->posting_lists);
 }
 

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -661,8 +661,10 @@ grn_index_column_diff_posting_list_fin(
   GRN_OBJ_FIN(ctx, &(posting_list->look_ahead));
   GRN_OBJ_FIN(ctx, &(posting_list->remains));
   GRN_OBJ_FIN(ctx, &(posting_list->missings));
-  grn_ii_cursor_close(ctx, posting_list->cursor);
-  posting_list->cursor = NULL;
+  if (posting_list->cursor) {
+    grn_ii_cursor_close(ctx, posting_list->cursor);
+    posting_list->cursor = NULL;
+  }
 }
 
 static void

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -1218,12 +1218,12 @@ grn_index_column_diff_compute(grn_ctx *ctx, grn_index_column_diff_data *data)
 
   if (ctx->rc == GRN_SUCCESS) {
     GRN_HASH_EACH_BEGIN(ctx, data->posting_lists, cursor, id)
-      {
-        void *value;
-        grn_hash_cursor_get_value(ctx, cursor, &value);
-        grn_index_column_diff_posting_list *posting_list = value;
-        grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
-      }
+    {
+      void *value;
+      grn_hash_cursor_get_value(ctx, cursor, &value);
+      grn_index_column_diff_posting_list *posting_list = value;
+      grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
+    }
     GRN_HASH_EACH_END(ctx, cursor);
   }
   grn_hash_close(ctx, data->posting_lists);

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -658,9 +658,9 @@ grn_index_column_diff_posting_list_fin(
   if (ctx->rc == GRN_SUCCESS) {
     grn_index_column_diff_posting_list_flush(ctx, data, posting_list);
   }
-  GRN_OBJ_FIN(ctx, &(posting_list->look_ahead));
   GRN_OBJ_FIN(ctx, &(posting_list->remains));
   GRN_OBJ_FIN(ctx, &(posting_list->missings));
+  GRN_OBJ_FIN(ctx, &(posting_list->look_ahead));
   if (posting_list->cursor) {
     grn_ii_cursor_close(ctx, posting_list->cursor);
     posting_list->cursor = NULL;

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -909,6 +909,9 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
     if (with_position) {
       while (!posting_list->need_cursor_next ||
              grn_ii_cursor_next(ctx, cursor)) {
+        if (ctx->rc != GRN_SUCCESS) {
+          break;
+        }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
           posting_list->need_cursor_next = false;
@@ -961,6 +964,9 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
     } else {
       grn_posting *posting;
       while ((posting = grn_ii_cursor_next(ctx, cursor))) {
+        if (ctx->rc != GRN_SUCCESS) {
+          break;
+        }
         const grn_index_column_diff_compared compared =
           grn_index_column_diff_compare_posting(ctx, data, posting);
         GRN_LOG(ctx,
@@ -1210,14 +1216,16 @@ grn_index_column_diff_compute(grn_ctx *ctx, grn_index_column_diff_data *data)
   }
   GRN_TABLE_EACH_END(ctx, cursor);
 
-  GRN_HASH_EACH_BEGIN(ctx, data->posting_lists, cursor, id)
-  {
-    void *value;
-    grn_hash_cursor_get_value(ctx, cursor, &value);
-    grn_index_column_diff_posting_list *posting_list = value;
-    grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
+  if (ctx->rc == GRN_SUCCESS) {
+    GRN_HASH_EACH_BEGIN(ctx, data->posting_lists, cursor, id)
+      {
+        void *value;
+        grn_hash_cursor_get_value(ctx, cursor, &value);
+        grn_index_column_diff_posting_list *posting_list = value;
+        grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
+      }
+    GRN_HASH_EACH_END(ctx, cursor);
   }
-  GRN_HASH_EACH_END(ctx, cursor);
   grn_hash_close(ctx, data->posting_lists);
 }
 

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -927,6 +927,9 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
         }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
+          if (posting == NULL) {
+            return;
+          }
           posting_list->need_cursor_next = false;
           const grn_index_column_diff_compared compared =
             grn_index_column_diff_compare_posting(ctx, data, posting);

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -1233,7 +1233,6 @@ grn_index_column_diff_compute(grn_ctx *ctx, grn_index_column_diff_data *data)
     grn_index_column_diff_posting_list_fin(ctx, data, posting_list);
   }
   GRN_HASH_EACH_END(ctx, cursor);
-
   grn_hash_close(ctx, data->posting_lists);
 }
 

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -919,7 +919,7 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
       while (!posting_list->need_cursor_next ||
              grn_ii_cursor_next(ctx, cursor)) {
         if (ctx->rc != GRN_SUCCESS) {
-          break;
+          return;
         }
         grn_posting *posting;
         while ((posting = grn_ii_cursor_next_pos(ctx, cursor))) {
@@ -974,7 +974,7 @@ grn_index_column_diff_process_token_id(grn_ctx *ctx,
       grn_posting *posting;
       while ((posting = grn_ii_cursor_next(ctx, cursor))) {
         if (ctx->rc != GRN_SUCCESS) {
-          break;
+          return;
         }
         const grn_index_column_diff_compared compared =
           grn_index_column_diff_compare_posting(ctx, data, posting);


### PR DESCRIPTION
If we execute `index_column_diff` and `load` at the same time, `index_column_diff` may set an error while it traversing updating posting lists.

However, `index_column_diff` continues processing with ignoring errors. In this case, `index_column_diff` may be slow because it outputs many error logs.

By this change, `index_column_diff` interrupts its process immediately when an error is ocurered.