### PR TITLE
test command-line: remove unnecessary encoding logic

### DIFF
--- a/test/command_line/helper/groonga_log.rb
+++ b/test/command_line/helper/groonga_log.rb
@@ -232,7 +232,7 @@ module GroongaLog
   end
 
   def normalized_groonga_log_content
-    normalize_groonga_log(groonga_log_content).encode("locale")
+    normalize_groonga_log(groonga_log_content)
   end
 
   private


### PR DESCRIPTION
GitHub: ref GH-2172

Issue

When running grndb tests in a Windows environment, encoding file paths containing Japanese characters failed in the test logs. It caused tests to fail.

Cause

This issue occurred because Groonga log file encoded in UTF-8 were converted to CP932 but some chracters couldn't be converted.

Soulution

Groonga logs are originally in UTF-8 so we don't have to convert. We just remove the encodeing logic from test's helper.