### PR TITLE
nfkc: Add GRN_TEXT_INIT()

### DIFF
--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -197,6 +197,7 @@ grn_nfkc_version_option_process(grn_ctx *ctx,
     GRN_VALUE_FIX_SIZE_INIT(&value, GRN_OBJ_DO_SHALLOW_COPY, domain);
     GRN_TEXT_SET(ctx, &value, version, version_length);
     grn_obj inspected;
+    GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, &value);
     ERR(GRN_INVALID_ARGUMENT,
         "%s[%.*s] must be a text: <%.*s>",


### PR DESCRIPTION
Passing an invalid `version` of the value will cause a crash.

Example:

```
> normalize 'NormalizerNFKC("version", true)' "groonga" WITH_CHECKS|WITH_TYPES
Aborted (core dumped)
```

GRN_TEXT_INIT was missing, so add it.