### PR TITLE
grn_ii_select: add missing grn_ii_select_data_fin() calls 

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -14673,8 +14673,7 @@ grn_ii_select(grn_ctx *ctx,
     return ctx->rc;
   }
   if (data->mode == GRN_OP_REGEXP) {
-    ctx->rc =
-      grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
+    ctx->rc = grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
     if (ctx->rc != GRN_SUCCESS) {
       goto exit;
     }

--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -14659,16 +14659,33 @@ grn_ii_select(grn_ctx *ctx,
   data->op = op;
   grn_ii_select_data_init(ctx, data, optarg);
   if (data->mode == GRN_OP_SIMILAR) {
-    return grn_ii_similar_search_internal(ctx, data);
+    ctx->rc = grn_ii_similar_search_internal(ctx, data);
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    return ctx->rc;
   }
   if (data->mode == GRN_OP_TERM_EXTRACT) {
-    return grn_ii_term_extract_internal(ctx, data);
+    ctx->rc = grn_ii_term_extract_internal(ctx, data);
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    return ctx->rc;
   }
   if (data->mode == GRN_OP_REGEXP) {
-    return grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
+    ctx->rc =
+      grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    return ctx->rc;
   }
   if (data->mode == GRN_OP_QUORUM) {
-    return grn_ii_quorum_match(ctx, ii, data);
+    ctx->rc = grn_ii_quorum_match(ctx, ii, data);
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    return ctx->rc;
   }
   /* todo : support subrec
   rep = (s->record_unit == GRN_REC_POSITION || s->subrec_unit ==

--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -14659,32 +14659,25 @@ grn_ii_select(grn_ctx *ctx,
   data->op = op;
   grn_ii_select_data_init(ctx, data, optarg);
   if (data->mode == GRN_OP_SIMILAR) {
-    ctx->rc = grn_ii_similar_search_internal(ctx, data);
-    if (ctx->rc != GRN_SUCCESS) {
-      goto exit;
-    }
-    return ctx->rc;
+    grn_rc rc = grn_ii_similar_search_internal(ctx, data);
+    grn_ii_select_data_fin(ctx, data);
+    return rc;
   }
   if (data->mode == GRN_OP_TERM_EXTRACT) {
-    ctx->rc = grn_ii_term_extract_internal(ctx, data);
-    if (ctx->rc != GRN_SUCCESS) {
-      goto exit;
-    }
-    return ctx->rc;
+    grn_rc rc = grn_ii_term_extract_internal(ctx, data);
+    grn_ii_select_data_fin(ctx, data);
+    return rc;
   }
   if (data->mode == GRN_OP_REGEXP) {
-    ctx->rc = grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
-    if (ctx->rc != GRN_SUCCESS) {
-      goto exit;
-    }
-    return ctx->rc;
+    grn_rc rc =
+      grn_ii_select_regexp(ctx, ii, string, string_len, s, op, optarg);
+    grn_ii_select_data_fin(ctx, data);
+    return rc;
   }
   if (data->mode == GRN_OP_QUORUM) {
-    ctx->rc = grn_ii_quorum_match(ctx, ii, data);
-    if (ctx->rc != GRN_SUCCESS) {
-      goto exit;
-    }
-    return ctx->rc;
+    grn_rc rc = grn_ii_quorum_match(ctx, ii, data);
+    grn_ii_select_data_fin(ctx, data);
+    return rc;
   }
   /* todo : support subrec
   rep = (s->record_unit == GRN_REC_POSITION || s->subrec_unit ==


### PR DESCRIPTION
In general, we should call `init()`/`fin()` as a pair. `grn_ii_select()` calls `grn_ii_select_data_init()`. So it should ensure calling `grn_ii_select_data_fin()`. But there are some cases that `grn_ii_select_data_fin()` isn't called.

There is no memory leak in those cases. But we should call `grn_ii_select_data_fin()` for consistency.