### PR TITLE
index_column: unify unit for memory usage

### DIFF
--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -477,19 +477,8 @@ grn_index_column_diff_format_memory(grn_ctx *ctx,
                                     uint64_t usage,
                                     const char **unit)
 {
-  if (usage < 1024) {
-    *unit = "B";
-    return (double)usage;
-  } else if (usage < (1024 * 1024)) {
-    *unit = "KiB";
-    return (double)usage / 1024.0;
-  } else if (usage < (1024 * 1024 * 1024)) {
-    *unit = "MiB";
-    return (double)usage / 1024.0 / 1024.0;
-  } else {
-    *unit = "GiB";
-    return (double)usage / 1024.0 / 1024.0 / 1024.0;
-  }
+  *unit = "MiB";
+  return (double)usage / 1024.0 / 1024.0;
 }
 
 static void


### PR DESCRIPTION
Currently, test results does not stable because of Groonga modify
output of unit for memory usgae by execution speed.

https://github.com/groonga/groonga/actions/runs/12923497411/job/36040891891#step:12:32

```diff
-#|e| [index-column][diff][progress][Terms.data_index] 10000/20001  50% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
-#|e| [index-column][diff][progress][Terms.data_index] 20000/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
-#|e| [index-column][diff][progress][Terms.data_index] 20001/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
+#|e| [index-column][diff][progress][Terms.data_index] 10000/20001  50% 0.00s/0.00s 0.00s(0.00records/s) 0.00GiB
+#|e| [index-column][diff][progress][Terms.data_index] 20000/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00GiB
+#|e| [index-column][diff][progress][Terms.data_index] 20001/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00GiB
```

So, I unify unit for memory usage to stable of tests.