### PR TITLE
index_column_diff: avoid zero division in progress log

### DIFF
--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -516,8 +516,8 @@ grn_index_column_diff_progress(grn_ctx *ctx, grn_index_column_diff_data *data)
        current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
       ((double)(previous_time->tv_sec) +
        previous_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
-    const double throughput;
-    if (current_interval_seconds == 0) {
+    double throughput;
+    if (current_interval_seconds == 0.0) {
       throughput = interval;
     } else {
       throughput = interval / current_interval_seconds;

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -516,7 +516,12 @@ grn_index_column_diff_progress(grn_ctx *ctx, grn_index_column_diff_data *data)
        current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
       ((double)(previous_time->tv_sec) +
        previous_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
-    const double throughput = interval / current_interval_seconds;
+    const double throughput;
+    if (current_interval_seconds == 0) {
+      throughput = interval;
+    } else {
+      throughput = interval / current_interval_seconds;
+    }
     const double remained_seconds =
       elapsed_seconds + ((n_records - i) / throughput);
     const char *elapsed_unit = NULL;

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -19,6 +19,7 @@
 
 #include "grn_index_column.h"
 #include "grn_ii.h"
+#include "grn_float.h"
 #include "grn_hash.h"
 
 #include <string.h>

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -517,7 +517,7 @@ grn_index_column_diff_progress(grn_ctx *ctx, grn_index_column_diff_data *data)
       ((double)(previous_time->tv_sec) +
        previous_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
     double throughput;
-    if (current_interval_seconds == 0.0) {
+    if (grn_float_is_zero(current_interval_seconds)) {
       throughput = interval;
     } else {
       throughput = interval / current_interval_seconds;


### PR DESCRIPTION
If progress log interval is too small, interval seconds may be zero. If interval seconds is zero, the current implementation reports "inf" throughput.

We should not use "inf" for throughput.