### PR TITLE
docs: NormalizerNFKC*: Add a note about deprecation

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc.po
@@ -250,11 +250,17 @@ msgstr ""
 msgid "``\"15.0.0\"``"
 msgstr ""
 
+msgid "Same as :doc:`./normalizer_nfkc150`"
+msgstr ":doc:`./normalizer_nfkc150` と同じ"
+
 msgid "13.0.0"
 msgstr ""
 
 msgid "``\"13.0.0\"``"
 msgstr ""
+
+msgid "Same as :doc:`./normalizer_nfkc130`"
+msgstr ":doc:`./normalizer_nfkc130` と同じ"
 
 msgid "12.1.0"
 msgstr ""
@@ -262,17 +268,26 @@ msgstr ""
 msgid "``\"12.1.0\"``"
 msgstr ""
 
+msgid "Same as :doc:`./normalizer_nfkc121`"
+msgstr ":doc:`./normalizer_nfkc121` と同じ"
+
 msgid "10.0.0"
 msgstr ""
 
 msgid "``\"10.0.0\"``"
 msgstr ""
 
+msgid "Same as :doc:`./normalizer_nfkc100`"
+msgstr ":doc:`./normalizer_nfkc100` と同じ"
+
 msgid "5.0.0"
 msgstr ""
 
 msgid "``\"5.0.0\"``"
 msgstr ""
+
+msgid "Same as :doc:`./normalizer_nfkc51` (It is called ``NormalizerNFKC51``, but it is for Unicode version 5.0)"
+msgstr ":doc:`./normalizer_nfkc51` と同じ（``NormalizerNFKC51`` という名前ですが Unicode5.0用）"
 
 msgid "``unify_kana``"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc100.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc100.po
@@ -21,6 +21,12 @@ msgstr "実行例::"
 msgid "``NormalizerNFKC100``"
 msgstr ""
 
+msgid "Use :doc:`./normalizer_nfkc` instead."
+msgstr "代わりに :doc:`./normalizer_nfkc` をご利用ください。"
+
+msgid "``NormalizerNFKC100`` and ``NormalizerNFKC(\"version\", \"10.0.0\")`` are equal."
+msgstr "``NormalizerNFKC100`` は ``NormalizerNFKC(\"version\", \"10.0.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc121.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc121.po
@@ -21,6 +21,12 @@ msgstr "実行例::"
 msgid "``NormalizerNFKC121``"
 msgstr ""
 
+msgid "Use :doc:`./normalizer_nfkc` instead."
+msgstr "代わりに :doc:`./normalizer_nfkc` をご利用ください。"
+
+msgid "``NormalizerNFKC121`` and ``NormalizerNFKC(\"version\", \"12.1.0\")`` are equal."
+msgstr "``NormalizerNFKC121`` は ``NormalizerNFKC(\"version\", \"12.1.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc130.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc130.po
@@ -21,6 +21,12 @@ msgstr "実行例::"
 msgid "``NormalizerNFKC130``"
 msgstr ""
 
+msgid "Use :doc:`./normalizer_nfkc` instead."
+msgstr "代わりに :doc:`./normalizer_nfkc` をご利用ください。"
+
+msgid "``NormalizerNFKC130`` and ``NormalizerNFKC(\"version\", \"13.0.0\")`` are equal."
+msgstr "``NormalizerNFKC130`` は ``NormalizerNFKC(\"version\", \"13.0.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc150.po
@@ -22,6 +22,12 @@ msgstr ""
 msgid "``NormalizerNFKC150``"
 msgstr ""
 
+msgid "Use :doc:`./normalizer_nfkc` instead."
+msgstr "代わりに :doc:`./normalizer_nfkc` をご利用ください。"
+
+msgid "``NormalizerNFKC150`` and ``NormalizerNFKC(\"version\", \"15.0.0\")`` are equal."
+msgstr "``NormalizerNFKC150`` は ``NormalizerNFKC(\"version\", \"15.0.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc51.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/normalizers/normalizer_nfkc51.po
@@ -21,11 +21,20 @@ msgstr "実行例::"
 msgid "``NormalizerNFKC51``"
 msgstr ""
 
+msgid "Use :doc:`./normalizer_nfkc` instead."
+msgstr "代わりに :doc:`./normalizer_nfkc` をご利用ください。"
+
+msgid "``NormalizerNFKC51`` and ``NormalizerNFKC(\"version\", \"5.0.0\")`` are equal."
+msgstr "``NormalizerNFKC51`` は ``NormalizerNFKC(\"version\", \"5.0.0\")`` と同じです。"
+
+msgid "It is called ``NormalizerNFKC51``, but it is for Unicode version 5.0."
+msgstr "``NormalizerNFKC51`` という名前ですが、Unicode 5.0用です。"
+
 msgid "Summary"
 msgstr "概要"
 
-msgid "``NormalizerNFKC51`` normalizes texts by Unicode NFKC (Normalization Form Compatibility Composition) for Unicode version 5.1. It supports only UTF-8 encoding."
-msgstr "``NormalizerNFKC51`` はUnicode 5.1用のUnicode NFKC（Normalization Form Compatibility Composition）を使ってテキストを正規化します。UTF-8エンコーディングのみをサポートしています。"
+msgid "``NormalizerNFKC51`` normalizes texts by Unicode NFKC (Normalization Form Compatibility Composition) for Unicode version 5.0. It supports only UTF-8 encoding."
+msgstr "``NormalizerNFKC50`` はUnicode 5.0用のUnicode NFKC（Normalization Form Compatibility Composition）を使ってテキストを正規化します。UTF-8エンコーディングのみをサポートしています。"
 
 msgid "Normally you don't need to use ``NormalizerNFKC51`` explicitly. You can use ``NormalizerAuto`` instead."
 msgstr "通常、 ``NormalizerNFKC51`` を明示的に使う必要はありません。代わりに ``NormalizerAuto`` を使ってください。"

--- a/doc/source/reference/normalizers/normalizer_nfkc.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc.rst
@@ -352,19 +352,19 @@ Here are the available versions.
      - This is the default value.
    * - 15.0.0
      - ``"15.0.0"``
-     -
+     - Same as :doc:`./normalizer_nfkc150`
    * - 13.0.0
      - ``"13.0.0"``
-     -
+     - Same as :doc:`./normalizer_nfkc130`
    * - 12.1.0
      - ``"12.1.0"``
-     -
+     - Same as :doc:`./normalizer_nfkc121`
    * - 10.0.0
      - ``"10.0.0"``
-     -
+     - Same as :doc:`./normalizer_nfkc100`
    * - 5.0.0
      - ``"5.0.0"``
-     -
+     - Same as :doc:`./normalizer_nfkc51` (It is called ``NormalizerNFKC51``, but it is for Unicode version 5.0)
 
 .. _normalizer-nfkc-unify-kana:
 

--- a/doc/source/reference/normalizers/normalizer_nfkc100.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc100.rst
@@ -8,6 +8,12 @@
 ``NormalizerNFKC100``
 =====================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./normalizer_nfkc` instead.
+
+   ``NormalizerNFKC100`` and ``NormalizerNFKC("version", "10.0.0")`` are equal.
+
 Summary
 -------
 

--- a/doc/source/reference/normalizers/normalizer_nfkc121.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc121.rst
@@ -8,6 +8,12 @@
 ``NormalizerNFKC121``
 =====================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./normalizer_nfkc` instead.
+
+   ``NormalizerNFKC121`` and ``NormalizerNFKC("version", "12.1.0")`` are equal.
+
 Summary
 -------
 

--- a/doc/source/reference/normalizers/normalizer_nfkc130.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc130.rst
@@ -8,6 +8,12 @@
 ``NormalizerNFKC130``
 =====================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./normalizer_nfkc` instead.
+
+   ``NormalizerNFKC130`` and ``NormalizerNFKC("version", "13.0.0")`` are equal.
+
 Summary
 -------
 

--- a/doc/source/reference/normalizers/normalizer_nfkc150.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc150.rst
@@ -8,6 +8,12 @@
 ``NormalizerNFKC150``
 =====================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./normalizer_nfkc` instead.
+
+   ``NormalizerNFKC150`` and ``NormalizerNFKC("version", "15.0.0")`` are equal.
+
 Summary
 -------
 

--- a/doc/source/reference/normalizers/normalizer_nfkc51.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc51.rst
@@ -8,12 +8,24 @@
 ``NormalizerNFKC51``
 =====================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./normalizer_nfkc` instead.
+
+   ``NormalizerNFKC51`` and ``NormalizerNFKC("version", "5.0.0")`` are equal.
+
+   It is called ``NormalizerNFKC51``, but it is for Unicode version 5.0.
+
 Summary
 -------
 
 ``NormalizerNFKC51`` normalizes texts by Unicode NFKC (Normalization
-Form Compatibility Composition) for Unicode version 5.1. It supports
+Form Compatibility Composition) for Unicode version 5.0. It supports
 only UTF-8 encoding.
+
+.. note::
+
+   It is called ``NormalizerNFKC51``, but it is for Unicode version 5.0.
 
 Normally you don't need to use ``NormalizerNFKC51`` explicitly. You can
 use ``NormalizerAuto`` instead.


### PR DESCRIPTION
Guide the use of `NormalizerNFKC` instead.
With this change we noticed that NormalizerNFKC51 is actually for Unicode 5.0, so we added a note about that.