### PR TITLE
docs: Add TokenFilterNFKC reference

### DIFF
--- a/doc/files.am
+++ b/doc/files.am
@@ -1296,6 +1296,7 @@ absolute_source_files = \
 	$(top_srcdir)/doc/source/reference/tables.rst \
 	$(top_srcdir)/doc/source/reference/token_filter/summary.rst \
 	$(top_srcdir)/doc/source/reference/token_filters.rst \
+	$(top_srcdir)/doc/source/reference/token_filters/token_filter_nfkc.rst \
 	$(top_srcdir)/doc/source/reference/token_filters/token_filter_nfkc100.rst \
 	$(top_srcdir)/doc/source/reference/token_filters/token_filter_nfkc150.rst \
 	$(top_srcdir)/doc/source/reference/token_filters/token_filter_stem.rst \
@@ -2655,6 +2656,7 @@ source_files_relative_from_doc_dir = \
 	source/reference/tables.rst \
 	source/reference/token_filter/summary.rst \
 	source/reference/token_filters.rst \
+	source/reference/token_filters/token_filter_nfkc.rst \
 	source/reference/token_filters/token_filter_nfkc100.rst \
 	source/reference/token_filters/token_filter_nfkc150.rst \
 	source/reference/token_filters/token_filter_stem.rst \
@@ -3000,6 +3002,7 @@ po_files = \
 	reference/tables.po \
 	reference/token_filter/summary.po \
 	reference/token_filters.po \
+	reference/token_filters/token_filter_nfkc.po \
 	reference/token_filters/token_filter_nfkc100.po \
 	reference/token_filters/token_filter_nfkc150.po \
 	reference/token_filters/token_filter_stem.po \
@@ -3344,6 +3347,7 @@ po_files_relative_from_locale_dir = \
 	LC_MESSAGES/reference/tables.po \
 	LC_MESSAGES/reference/token_filter/summary.po \
 	LC_MESSAGES/reference/token_filters.po \
+	LC_MESSAGES/reference/token_filters/token_filter_nfkc.po \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc100.po \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc150.po \
 	LC_MESSAGES/reference/token_filters/token_filter_stem.po \
@@ -3688,6 +3692,7 @@ edit_po_files = \
 	reference/tables.edit \
 	reference/token_filter/summary.edit \
 	reference/token_filters.edit \
+	reference/token_filters/token_filter_nfkc.edit \
 	reference/token_filters/token_filter_nfkc100.edit \
 	reference/token_filters/token_filter_nfkc150.edit \
 	reference/token_filters/token_filter_stem.edit \
@@ -4032,6 +4037,7 @@ edit_po_files_relative_from_locale_dir = \
 	LC_MESSAGES/reference/tables.edit \
 	LC_MESSAGES/reference/token_filter/summary.edit \
 	LC_MESSAGES/reference/token_filters.edit \
+	LC_MESSAGES/reference/token_filters/token_filter_nfkc.edit \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc100.edit \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc150.edit \
 	LC_MESSAGES/reference/token_filters/token_filter_stem.edit \
@@ -4376,6 +4382,7 @@ mo_files = \
 	reference/tables.mo \
 	reference/token_filter/summary.mo \
 	reference/token_filters.mo \
+	reference/token_filters/token_filter_nfkc.mo \
 	reference/token_filters/token_filter_nfkc100.mo \
 	reference/token_filters/token_filter_nfkc150.mo \
 	reference/token_filters/token_filter_stem.mo \
@@ -4720,6 +4727,7 @@ mo_files_relative_from_locale_dir = \
 	LC_MESSAGES/reference/tables.mo \
 	LC_MESSAGES/reference/token_filter/summary.mo \
 	LC_MESSAGES/reference/token_filters.mo \
+	LC_MESSAGES/reference/token_filters/token_filter_nfkc.mo \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc100.mo \
 	LC_MESSAGES/reference/token_filters/token_filter_nfkc150.mo \
 	LC_MESSAGES/reference/token_filters/token_filter_stem.mo \
@@ -5099,6 +5107,7 @@ html_files_relative_from_locale_dir = \
 	html/reference/tables.html \
 	html/reference/token_filter/summary.html \
 	html/reference/token_filters.html \
+	html/reference/token_filters/token_filter_nfkc.html \
 	html/reference/token_filters/token_filter_nfkc100.html \
 	html/reference/token_filters/token_filter_nfkc150.html \
 	html/reference/token_filters/token_filter_stem.html \

--- a/doc/files.cmake
+++ b/doc/files.cmake
@@ -1296,6 +1296,7 @@ set(GRN_DOC_SOURCES
     reference/tables.rst
     reference/token_filter/summary.rst
     reference/token_filters.rst
+    reference/token_filters/token_filter_nfkc.rst
     reference/token_filters/token_filter_nfkc100.rst
     reference/token_filters/token_filter_nfkc150.rst
     reference/token_filters/token_filter_stem.rst
@@ -1675,6 +1676,7 @@ set(GRN_DOC_HTML_FILES
     reference/tables.html
     reference/token_filter/summary.html
     reference/token_filters.html
+    reference/token_filters/token_filter_nfkc.html
     reference/token_filters/token_filter_nfkc100.html
     reference/token_filters/token_filter_nfkc150.html
     reference/token_filters/token_filter_stem.html

--- a/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc.po
@@ -1,0 +1,81 @@
+# Japanese translations for Groonga package.
+# Copyright (C) 2009-2025 Groonga Project
+# This file is distributed under the same license as the Groonga package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Groonga 14.1.3\n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: 2025-01-28 06:21+0000\n"
+"Language-Team: Japanese\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Execution example::"
+msgstr ""
+
+msgid "``TokenFilterNFKC``"
+msgstr ""
+
+msgid "Summary"
+msgstr ""
+
+msgid "This token filter can use the same option by :ref:`normalizer-nfkc`. This token filter is used to normalize after tokenizing. Because, if you normalize before tokenizing with ``TokenMecab`` , the meaning of a token may be lost."
+msgstr "このトークンフィルターは、 :ref:`normalizer-nfkc` と同じオプションを使えます。 ``TokenMecab`` を使ってトークナイズする前にノーマライズをすると、トークンの意味が失われることがあるため、このトークンフィルターは、トークナイズ後にノーマライズするために使用します。"
+
+msgid "Syntax"
+msgstr "構文"
+
+msgid "``TokenFilterNFKC`` has optional parameter."
+msgstr "``TokenFilterNFKC`` は省略可能な引数があります。"
+
+msgid "No options::"
+msgstr "オプションなし::"
+
+msgid "``TokenFilterNFKC`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition)."
+msgstr "``TokenFilterNFKC`` はUnicode NFKC（Normalization Form Compatibility Composition）を使ってテキストを正規化します。"
+
+msgid "Example of option specification::"
+msgstr "オプション指定例::"
+
+msgid "Other options available same as :ref:`normalizer-nfkc`."
+msgstr "他にも :ref:`normalizer-nfkc` と同じオプションが利用できます。"
+
+msgid "Usage"
+msgstr "使い方"
+
+msgid "Simple usage"
+msgstr "簡単な使い方"
+
+msgid "Normalization is the same as in :ref:`normalizer-nfkc`, so here are a few examples of how to use the options."
+msgstr "正規化自体は :ref:`normalizer-nfkc` と同じなので、いくつかオプションの使い方を紹介します。"
+
+msgid "Here is an example of ``TokenFilterNFKC``. ``TokenFilterNFKC`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition)."
+msgstr "以下は、 ``TokenFilterNFKC`` の使用例です。 ``TokenFilterNFKC`` はUnicode NFKC（Normalization Form Compatibility Composition）を使ってテキストを正規化します。"
+
+msgid "Here is an example of :ref:`normalizer-nfkc-unify-kana` option."
+msgstr "以下は :ref:`normalizer-nfkc-unify-kana` オプションの使用例です。"
+
+msgid "This option enables that same pronounced characters in all of full-width Hiragana, full-width Katakana and half-width Katakana are regarded as the same character as below."
+msgstr "このオプションは、以下のように同じ音となる全角ひらがな、全角カタカナ、半角カタカナの文字を同一視します。"
+
+msgid "Here is an example of :ref:`normalizer-nfkc-unify-hyphen` option. This option enables normalize hyphen to \"-\" (U+002D HYPHEN-MINUS) as below."
+msgstr "以下は、 :ref:`normalizer-nfkc-unify-hyphen` オプションの使用例です。このオプションは、以下のように、ハイフンを\"-\" (U+002D HYPHEN-MINUS)に正規化します。"
+
+msgid "Here is an example of :ref:`normalizer-nfkc-unify-to-romaji` option. This option enables normalize hiragana and katakana to romaji as below."
+msgstr "以下は、 :ref:`normalizer-nfkc-unify-to-romaji` オプションの使用例です。このオプションは、以下のように、ひらがなとカタカナをローマ字に正規化します。"
+
+msgid "Advanced usage"
+msgstr "高度な使い方"
+
+msgid "You can output all input string as hiragana with cimbining ``TokenFilterNFKC`` with ``use_reading`` option of ``TokenMecab`` as below."
+msgstr "``TokenFilterNFKC`` と ``TokenMecab`` の ``use_reading`` オプションを組み合わせることで、入力文字列を全てひらがなとして出力できます。"
+
+msgid "Parameters"
+msgstr "引数"
+
+msgid "See :ref:`normalizer-nfkc-parameters` in ``NormalizerNFKC`` for details."
+msgstr "``NormalizerNFKC`` の :ref:`normalizer-nfkc-parameters` をご覧ください。"

--- a/doc/source/reference/normalizers/normalizer_nfkc.rst
+++ b/doc/source/reference/normalizers/normalizer_nfkc.rst
@@ -331,6 +331,8 @@ Use ``unify_to_katakana`` with other options
 
 For example, using ``unify_to_katakana`` and ``unify_katakana_v_sounds`` together, you can search "バイオリン", "ヴァイオリン", "ばいおりん" and "ゔぁいおりん" with "ばいおりん".
 
+.. _normalizer-nfkc-parameters:
+
 Parameters
 ----------
 

--- a/doc/source/reference/token_filters/token_filter_nfkc.rst
+++ b/doc/source/reference/token_filters/token_filter_nfkc.rst
@@ -1,0 +1,90 @@
+.. -*- rst -*-
+
+.. groonga-command
+.. database: token_filters_nfkc
+
+``TokenFilterNFKC``
+===================
+
+Summary
+-------
+
+.. versionadded:: 14.1.3
+
+This token filter can use the same option by :ref:`normalizer-nfkc`.
+This token filter is used to normalize after tokenizing.
+Because, if you normalize before tokenizing with ``TokenMecab`` , the meaning of a token may be lost.
+
+Syntax
+------
+
+``TokenFilterNFKC`` has optional parameter.
+
+No options::
+
+  TokenFilterNFKC
+
+``TokenFilterNFKC`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition).
+
+Example of option specification::
+
+  TokenFilterNFKC("version", "16.0.0")
+
+  TokenFilterNFKC("unify_kana", true)
+
+  TokenFilterNFKC("unify_hyphen", true)
+
+  TokenFilterNFKC("unify_to_romaji", true)
+
+Other options available same as :ref:`normalizer-nfkc`.
+
+Usage
+-----
+
+Simple usage
+------------
+
+Normalization is the same as in :ref:`normalizer-nfkc`, so here are a few examples of how to use the options.
+
+Here is an example of ``TokenFilterNFKC``. ``TokenFilterNFKC`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition).
+
+.. groonga-command
+.. include:: ../../example/reference/token_filters/nfkc150.log
+.. tokenize TokenDelimit "©" --token_filters TokenFilterNFKC
+
+Here is an example of :ref:`normalizer-nfkc-unify-kana` option.
+
+This option enables that same pronounced characters in all of full-width Hiragana, full-width Katakana and half-width Katakana are regarded as the same character as below.
+
+.. groonga-command
+.. include:: ../../example/reference/token_filters/nfkc150-unify-kana.log
+.. tokenize TokenDelimit "あイｳｪおヽヾ" --token_filters 'TokenFilterNFKC("unify_kana", true)'
+
+
+Here is an example of :ref:`normalizer-nfkc-unify-hyphen` option.
+This option enables normalize hyphen to "-" (U+002D HYPHEN-MINUS) as below.
+
+.. groonga-command
+.. include:: ../../example/reference/token_filters/nfkc150-unify-hyphen.log
+.. tokenize TokenDelimit "-˗֊‐‑‒–⁃⁻₋−" --token_filters 'TokenFilterNFKC("unify_hyphen", true)'
+
+Here is an example of :ref:`normalizer-nfkc-unify-to-romaji` option.
+This option enables normalize hiragana and katakana to romaji as below.
+
+.. groonga-command
+.. include:: ../../example/reference/token_filters/nfkc150-unify-to-romaji.log
+.. tokenize TokenDelimit "アァイィウゥエェオォ" --token_filters  'TokenFilterNFKC("unify_to_romaji", true)'
+
+Advanced usage
+--------------
+
+You can output all input string as hiragana with cimbining ``TokenFilterNFKC`` with ``use_reading`` option of ``TokenMecab`` as below.
+
+.. groonga-command
+.. include:: ../../example/reference/token_filters/nfkc150-with-token-mecab.log
+.. tokenize   'TokenMecab("use_reading", true)'   "私は林檎を食べます。"   --token_filters 'TokenFilterNFKC("unify_kana", true)'
+
+Parameters
+----------
+
+See :ref:`normalizer-nfkc-parameters` in ``NormalizerNFKC`` for details.

--- a/doc/source/reference/token_filters/token_filter_nfkc.rst
+++ b/doc/source/reference/token_filters/token_filter_nfkc.rst
@@ -42,7 +42,7 @@ Usage
 -----
 
 Simple usage
-------------
+^^^^^^^^^^^^
 
 Normalization is the same as in :ref:`normalizer-nfkc`, so here are a few examples of how to use the options.
 
@@ -76,7 +76,7 @@ This option enables normalize hiragana and katakana to romaji as below.
 .. tokenize TokenDelimit "アァイィウゥエェオォ" --token_filters  'TokenFilterNFKC("unify_to_romaji", true)'
 
 Advanced usage
---------------
+^^^^^^^^^^^^^^
 
 You can output all input string as hiragana with cimbining ``TokenFilterNFKC`` with ``use_reading`` option of ``TokenMecab`` as below.
 


### PR DESCRIPTION
`TokenFilterNFKC150` was used as a base.
We also tried to refer to `NormalizerNFKC` as much as possible.

An example of execution will be updated later.