### PR TITLE
docs: TokenFilterNFKC*: Add a note about deprecation

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc100.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc100.po
@@ -21,6 +21,12 @@ msgstr "実行例::"
 msgid "``TokenFilterNFKC100``"
 msgstr ""
 
+msgid "Use :doc:`./token_filter_nfkc` instead."
+msgstr "代わりに :doc:`./token_filter_nfkc` をご利用ください。"
+
+msgid "``TokenFilterNFKC100`` and ``TokenFilterNFKC(\"version\", \"10.0.0\")`` are equal."
+msgstr "``TokenFilterNFKC100`` は ``TokenFilterNFKC(\"version\", \"10.0.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc150.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/token_filters/token_filter_nfkc150.po
@@ -22,6 +22,12 @@ msgstr ""
 msgid "``TokenFilterNFKC150``"
 msgstr ""
 
+msgid "Use :doc:`./token_filter_nfkc` instead."
+msgstr "代わりに :doc:`./token_filter_nfkc` をご利用ください。"
+
+msgid "``TokenFilterNFKC150`` and ``TokenFilterNFKC(\"version\", \"15.0.0\")`` are equal."
+msgstr "``TokenFilterNFKC150`` は ``TokenFilterNFKC(\"version\", \"15.0.0\")`` と同じです。"
+
 msgid "Summary"
 msgstr "概要"
 

--- a/doc/source/reference/token_filters/token_filter_nfkc100.rst
+++ b/doc/source/reference/token_filters/token_filter_nfkc100.rst
@@ -6,6 +6,12 @@
 ``TokenFilterNFKC100``
 ======================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./token_filter_nfkc` instead.
+
+   ``TokenFilterNFKC100`` and ``TokenFilterNFKC("version", "10.0.0")`` are equal.
+
 Summary
 -------
 
@@ -53,7 +59,7 @@ Usage
 -----
 
 Simple usage
-------------
+^^^^^^^^^^^^
 
 Here is an example of ``TokenFilterNFKC100``. ``TokenFilterNFKC100`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition) for Unicode version 10.0.
 
@@ -144,7 +150,7 @@ This option enables normalize hiragana and katakana to romaji as below.
 .. tokenize TokenDelimit "アァイィウゥエェオォ" --token_filters  'TokenFilterNFKC100("unify_to_romaji", true)'
 
 Advanced usage
---------------
+^^^^^^^^^^^^^^
 
 You can output all input string as hiragana with cimbining ``TokenFilterNFKC100`` with ``use_reading`` option of ``TokenMecab`` as below.
 

--- a/doc/source/reference/token_filters/token_filter_nfkc150.rst
+++ b/doc/source/reference/token_filters/token_filter_nfkc150.rst
@@ -6,6 +6,12 @@
 ``TokenFilterNFKC150``
 ======================
 
+.. deprecated:: 14.1.3
+
+   Use :doc:`./token_filter_nfkc` instead.
+
+   ``TokenFilterNFKC150`` and ``TokenFilterNFKC("version", "15.0.0")`` are equal.
+
 Summary
 -------
 
@@ -53,7 +59,7 @@ Usage
 -----
 
 Simple usage
-------------
+^^^^^^^^^^^^
 
 Here is an example of ``TokenFilterNFKC150``. ``TokenFilterNFKC150`` normalizes text by Unicode NFKC (Normalization Form Compatibility Composition) for Unicode version 15.0.
 
@@ -144,7 +150,7 @@ This option enables normalize hiragana and katakana to romaji as below.
 .. tokenize TokenDelimit "アァイィウゥエェオォ" --token_filters  'TokenFilterNFKC150("unify_to_romaji", true)'
 
 Advanced usage
---------------
+^^^^^^^^^^^^^^
 
 You can output all input string as hiragana with cimbining ``TokenFilterNFKC150`` with ``use_reading`` option of ``TokenMecab`` as below.
 


### PR DESCRIPTION
Guide the use of `TokenFilterNFKC` instead.