### PR TITLE
rake: release: Run `git push` at the end of `release:version:update` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -153,6 +153,7 @@ namespace :release do
          "commit",
          "-m",
          "package: update version info to #{version} (#{new_release_date})")
+      sh("git", "push")
     end
   end
 


### PR DESCRIPTION
Since it is necessary to push finally.

mroonga/mroonga also does so.
https://github.com/mroonga/mroonga/blob/110095fd48db417b80fada90a6bbe639391b72d1/Rakefile#L114-L131