### PR TITLE
packages: use latest Apache Arrow version from GitHub Releases

### DIFF
--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -19,12 +19,10 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def detect_target_apache_arrow_version
-    cmake_yml = File.join(__dir__,
-                          "..",
-                          ".github",
-                          "workflows",
-                          "cmake.yml")
-    File.read(cmake_yml)[/ref: apache-arrow-([\d.]+)/, 1]
+    release_url = "https://api.github.com/repos/apache/arrow/releases/latest"
+    release_info = JSON.parse(URI.open(release_url).read)
+    version_tag = release_info["tag_name"]
+    version_tag[/\Aapache-arrow-([\d.]+)\z/, 1]
   end
 
   def detect_target_apache_arrow_so_version


### PR DESCRIPTION
## Issue

Previously, the target Apache Arrow version was extracted by reading the local `cmake.yml` file, which could result in using an outdated version.

## Solution

This change updates the detection logic to query the GitHub API for the latest release information.