### PR TITLE
ci cmake: use latest Apache Arrow source archive

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -693,7 +693,7 @@ jobs:
           $DOWNLOAD_URL = `
             "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_RELEASE_TAG}.tar.gz?action=download"
           Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_RELEASE_TAG}.tar.gz"
-          mkdir apache-arrow
+          New-Item -ItemType Directory -Path "apache-arrow"
           tar -xzf "${LATEST_RELEASE_TAG}.tar.gz" --strip-components=1 -C apache-arrow
           Remove-Item "${LATEST_RELEASE_TAG}.tar.gz"
       - name: Set version

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -686,14 +686,14 @@ jobs:
         run: |
           $LATEST_RELEASE_INFO = Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
           # e.g. "apache-arrow-19.0.0"
-          $APACHE_ARROW_VERSION = $LATEST_RELEASE_INFO.tag_name
-          # "apache-arrow-19.0.0" -> "19.0.0"
-          $ARROW_VERSION = $APACHE_ARROW_VERSION -replace '^apache-', ''
-          $DOWNLOAD_URL = "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${APACHE_ARROW_VERSION}.tar.gz?action=download"
-          Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${APACHE_ARROW_VERSION}.tar.gz"
+          $LATEST_TAG_NAME = $LATEST_RELEASE_INFO.tag_name
+          # "apache-arrow-19.0.0" -> "arrow-19.0.0"
+          $ARROW_VERSION = $LATEST_TAG_NAME -replace '^apache-', ''
+          $DOWNLOAD_URL = "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_TAG_NAME}.tar.gz?action=download"
+          Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_TAG_NAME}.tar.gz"
           mkdir apache-arrow
-          tar -xzf "${APACHE_ARROW_VERSION}.tar.gz" --strip-components=1 -C apache-arrow
-          Remove-Item "${APACHE_ARROW_VERSION}.tar.gz"
+          tar -xzf "${LATEST_TAG_NAME}.tar.gz" --strip-components=1 -C apache-arrow
+          Remove-Item "${LATEST_TAG_NAME}.tar.gz"
       - name: Set version
         run: |
           "GRN_VERSION=${Env:GROONGA_VERSION}" | Set-Content version.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -693,7 +693,7 @@ jobs:
           $DOWNLOAD_URL = `
             "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_RELEASE_TAG}.tar.gz?action=download"
           Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_RELEASE_TAG}.tar.gz"
-          New-Item -ItemType Directory -Path "apache-arrow"
+          New-Item -Path "apache-arrow" -ItemType Directory 
           tar -xzf "${LATEST_RELEASE_TAG}.tar.gz" --strip-components=1 -C apache-arrow
           Remove-Item "${LATEST_RELEASE_TAG}.tar.gz"
       - name: Set version

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -687,15 +687,15 @@ jobs:
           $LATEST_RELEASE_INFO = `
             Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
           # e.g. "apache-arrow-19.0.0"
-          $LATEST_TAG_NAME = $LATEST_RELEASE_INFO.tag_name
+          $LATEST_RELEASE_TAG = $LATEST_RELEASE_INFO.tag_name
           # "apache-arrow-19.0.0" -> "arrow-19.0.0"
-          $ARROW_VERSION = $LATEST_TAG_NAME -replace '^apache-', ''
+          $ARROW_VERSION = $LATEST_RELEASE_TAG -replace '^apache-', ''
           $DOWNLOAD_URL = `
-            "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_TAG_NAME}.tar.gz?action=download"
-          Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_TAG_NAME}.tar.gz"
+            "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_RELEASE_TAG}.tar.gz?action=download"
+          Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_RELEASE_TAG}.tar.gz"
           mkdir apache-arrow
-          tar -xzf "${LATEST_TAG_NAME}.tar.gz" --strip-components=1 -C apache-arrow
-          Remove-Item "${LATEST_TAG_NAME}.tar.gz"
+          tar -xzf "${LATEST_RELEASE_TAG}.tar.gz" --strip-components=1 -C apache-arrow
+          Remove-Item "${LATEST_RELEASE_TAG}.tar.gz"
       - name: Set version
         run: |
           "GRN_VERSION=${Env:GROONGA_VERSION}" | Set-Content version.sh

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -684,12 +684,14 @@ jobs:
           ccache --show-stats --verbose --version
       - name: Download Apache Arrow latest source archive
         run: |
-          $LATEST_RELEASE_INFO = Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
+          $LATEST_RELEASE_INFO = `
+            Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
           # e.g. "apache-arrow-19.0.0"
           $LATEST_TAG_NAME = $LATEST_RELEASE_INFO.tag_name
           # "apache-arrow-19.0.0" -> "arrow-19.0.0"
           $ARROW_VERSION = $LATEST_TAG_NAME -replace '^apache-', ''
-          $DOWNLOAD_URL = "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_TAG_NAME}.tar.gz?action=download"
+          $DOWNLOAD_URL = `
+            "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${LATEST_TAG_NAME}.tar.gz?action=download"
           Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${LATEST_TAG_NAME}.tar.gz"
           mkdir apache-arrow
           tar -xzf "${LATEST_TAG_NAME}.tar.gz" --strip-components=1 -C apache-arrow

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -689,7 +689,7 @@ jobs:
           $APACHE_ARROW_VERSION = $LATEST_RELEASE_INFO.tag_name
           # "apache-arrow-19.0.0" -> "19.0.0"
           $ARROW_VERSION = $APACHE_ARROW_VERSION -replace '^apache-', ''
-          $DOWNLOAD_URL = "https://dlcdn.apache.org/arrow/${ARROW_VERSION}/${APACHE_ARROW_VERSION}.tar.gz"
+          $DOWNLOAD_URL = "https://www.apache.org/dyn/closer.lua/arrow/${ARROW_VERSION}/${APACHE_ARROW_VERSION}.tar.gz?action=download"
           Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${APACHE_ARROW_VERSION}.tar.gz"
           mkdir apache-arrow
           tar -xzf "${APACHE_ARROW_VERSION}.tar.gz" --strip-components=1 -C apache-arrow

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -682,7 +682,7 @@ jobs:
           Get-Command ccache
           (Get-Command ccache).Source
           ccache --show-stats --verbose --version
-      - name: Download Apache Arrow latest source archive and verify via PGP
+      - name: Download Apache Arrow latest source archive
         run: |
           $LATEST_RELEASE_INFO = Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
           # e.g. "apache-arrow-19.0.0"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -603,12 +603,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/checkout@v4
-        with:
-          path: apache-arrow
-          ref: apache-arrow-18.0.0
-          repository: apache/arrow
-          submodules: recursive
       # Use CMake 3.27 not 3.26.
       # Workaround: https://github.com/actions/runner-images/issues/8598
       - name: Remove Strawberry Perl
@@ -688,6 +682,18 @@ jobs:
           Get-Command ccache
           (Get-Command ccache).Source
           ccache --show-stats --verbose --version
+      - name: Download Apache Arrow latest source archive and verify via PGP
+        run: |
+          $LATEST_RELEASE_INFO = Invoke-RestMethod "https://api.github.com/repos/apache/arrow/releases/latest"
+          # e.g. "apache-arrow-19.0.0"
+          $APACHE_ARROW_VERSION = $LATEST_RELEASE_INFO.tag_name
+          # "apache-arrow-19.0.0" -> "19.0.0"
+          $ARROW_VERSION = $APACHE_ARROW_VERSION -replace '^apache-', ''
+          $DOWNLOAD_URL = "https://dlcdn.apache.org/arrow/${ARROW_VERSION}/${APACHE_ARROW_VERSION}.tar.gz"
+          Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile "${APACHE_ARROW_VERSION}.tar.gz"
+          mkdir apache-arrow
+          tar -xzf "${APACHE_ARROW_VERSION}.tar.gz" --strip-components=1 -C apache-arrow
+          Remove-Item "${APACHE_ARROW_VERSION}.tar.gz"
       - name: Set version
         run: |
           "GRN_VERSION=${Env:GROONGA_VERSION}" | Set-Content version.sh


### PR DESCRIPTION
## Issue

Previously, the workflow checked out a fixed Apache Arrow repository revision(ref: apache-arrow-18.0.0).

## Solution

This change replaces that step with a process that queries the GitHub API for the latest Apache Arrow release and downloads its official source archive from the Apache mirror.