### PR TITLE
pat: add support for Float32 as key type

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2407,6 +2407,10 @@ chop(grn_ctx *ctx,
         int64_t v = *(int64_t *)(key);                                         \
         v ^= ((v >> 63) | (1ULL << 63));                                       \
         grn_hton((keybuf), &v, (size));                                        \
+      } else if ((size) == sizeof(int32_t)) {                                  \
+        int32_t v = *(int32_t *)(key);                                         \
+        v ^= ((v >> 31) | (1ULL << 31));                                       \
+        grn_hton((keybuf), &v, (size));                                        \
       }                                                                        \
       break;                                                                   \
     }                                                                          \
@@ -2433,6 +2437,11 @@ chop(grn_ctx *ctx,
         grn_hton(&v, (key), (size));                                           \
         *((int64_t *)(keybuf)) =                                               \
           v ^ ((((int64_t)(v ^ (1ULL << 63))) >> 63) | (1ULL << 63));          \
+      } else if ((size) == sizeof(int32_t)) {                                  \
+        int32_t v;                                                             \
+        grn_hton(&v, (key), (size));                                           \
+        *((int32_t *)(keybuf)) =                                               \
+          v ^ ((((int32_t)(v ^ (1ULL << 31))) >> 31) | (1ULL << 31));          \
       }                                                                        \
       break;                                                                   \
     }                                                                          \

--- a/test/command/suite/select/filter/index/compare_operation/greater/float32.expected
+++ b/test/command/suite/select/filter/index/compare_operation/greater/float32.expected
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values number COLUMN_SCALAR Float32
+[[0,0.0,0.0],true]
+table_create Numbers TABLE_PAT_KEY Float32
+[[0,0.0,0.0],true]
+column_create Numbers values_number COLUMN_INDEX Values number
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+[[0,0.0,0.0],3]
+select Values   --filter 'number > 3.1'   --output_columns 'number'
+[[0,0.0,0.0],[[[1],[["number","Float32"]],[4.1]]]]

--- a/test/command/suite/select/filter/index/compare_operation/greater/float32.test
+++ b/test/command/suite/select/filter/index/compare_operation/greater/float32.test
@@ -1,0 +1,16 @@
+table_create Values TABLE_NO_KEY
+column_create Values number COLUMN_SCALAR Float32
+
+table_create Numbers TABLE_PAT_KEY Float32
+column_create Numbers values_number COLUMN_INDEX Values number
+
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+
+select Values \
+  --filter 'number > 3.1' \
+  --output_columns 'number'

--- a/test/command/suite/select/filter/index/compare_operation/greater_equal/float32.expected
+++ b/test/command/suite/select/filter/index/compare_operation/greater_equal/float32.expected
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values number COLUMN_SCALAR Float32
+[[0,0.0,0.0],true]
+table_create Numbers TABLE_PAT_KEY Float32
+[[0,0.0,0.0],true]
+column_create Numbers values_number COLUMN_INDEX Values number
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+[[0,0.0,0.0],3]
+select Values   --filter 'number >= 3.1'   --output_columns 'number'
+[[0,0.0,0.0],[[[2],[["number","Float32"]],[3.1],[4.1]]]]

--- a/test/command/suite/select/filter/index/compare_operation/greater_equal/float32.test
+++ b/test/command/suite/select/filter/index/compare_operation/greater_equal/float32.test
@@ -1,0 +1,16 @@
+table_create Values TABLE_NO_KEY
+column_create Values number COLUMN_SCALAR Float32
+
+table_create Numbers TABLE_PAT_KEY Float32
+column_create Numbers values_number COLUMN_INDEX Values number
+
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+
+select Values \
+  --filter 'number >= 3.1' \
+  --output_columns 'number'

--- a/test/command/suite/select/filter/index/compare_operation/less/float32.expected
+++ b/test/command/suite/select/filter/index/compare_operation/less/float32.expected
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values number COLUMN_SCALAR Float32
+[[0,0.0,0.0],true]
+table_create Numbers TABLE_PAT_KEY Float32
+[[0,0.0,0.0],true]
+column_create Numbers values_number COLUMN_INDEX Values number
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+[[0,0.0,0.0],3]
+select Values   --filter 'number < 3.1'   --output_columns 'number'
+[[0,0.0,0.0],[[[1],[["number","Float32"]],[-1.1]]]]

--- a/test/command/suite/select/filter/index/compare_operation/less/float32.test
+++ b/test/command/suite/select/filter/index/compare_operation/less/float32.test
@@ -1,0 +1,16 @@
+table_create Values TABLE_NO_KEY
+column_create Values number COLUMN_SCALAR Float32
+
+table_create Numbers TABLE_PAT_KEY Float32
+column_create Numbers values_number COLUMN_INDEX Values number
+
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+
+select Values \
+  --filter 'number < 3.1' \
+  --output_columns 'number'

--- a/test/command/suite/select/filter/index/compare_operation/less_equal/float32.expected
+++ b/test/command/suite/select/filter/index/compare_operation/less_equal/float32.expected
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values number COLUMN_SCALAR Float32
+[[0,0.0,0.0],true]
+table_create Numbers TABLE_PAT_KEY Float32
+[[0,0.0,0.0],true]
+column_create Numbers values_number COLUMN_INDEX Values number
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+[[0,0.0,0.0],3]
+select Values   --filter 'number <= 3.1'   --output_columns 'number'   --sortby number
+[[0,0.0,0.0],[[[2],[["number","Float32"]],[-1.1],[3.1]]]]

--- a/test/command/suite/select/filter/index/compare_operation/less_equal/float32.test
+++ b/test/command/suite/select/filter/index/compare_operation/less_equal/float32.test
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+column_create Values number COLUMN_SCALAR Float32
+
+table_create Numbers TABLE_PAT_KEY Float32
+column_create Numbers values_number COLUMN_INDEX Values number
+
+load --table Values
+[
+{"number": 3.1},
+{"number": 4.1},
+{"number": -1.1}
+]
+
+select Values \
+  --filter 'number <= 3.1' \
+  --output_columns 'number' \
+  --sortby number

--- a/test/command/suite/select/filter/index/equal/float32.expected
+++ b/test/command/suite/select/filter/index/equal/float32.expected
@@ -1,6 +1,6 @@
 table_create Values TABLE_NO_KEY
 [[0,0.0,0.0],true]
-column_create Values number COLUMN_SCALAR Float3232
+column_create Values number COLUMN_SCALAR Float32
 [[0,0.0,0.0],true]
 table_create Numbers TABLE_PAT_KEY Float32
 [[0,0.0,0.0],true]

--- a/test/command/suite/select/filter/index/equal/float32.expected
+++ b/test/command/suite/select/filter/index/equal/float32.expected
@@ -1,0 +1,17 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values number COLUMN_SCALAR Float3232
+[[0,0.0,0.0],true]
+table_create Numbers TABLE_PAT_KEY Float32
+[[0,0.0,0.0],true]
+column_create Numbers values_number COLUMN_INDEX Values number
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"number": 1.1},
+{"number": 3.1},
+{"number": -1.1}
+]
+[[0,0.0,0.0],3]
+select Values   --filter 'number == -1.1'   --output_columns 'number'
+[[0,0.0,0.0],[[[1],[["number","Float32"]],[-1.1]]]]

--- a/test/command/suite/select/filter/index/equal/float32.test
+++ b/test/command/suite/select/filter/index/equal/float32.test
@@ -1,3 +1,6 @@
+# Equal for floating point number may not be portable.
+# If this test is fragile on some environments, we'll remove this test.
+
 table_create Values TABLE_NO_KEY
 column_create Values number COLUMN_SCALAR Float32
 

--- a/test/command/suite/select/filter/index/equal/float32.test
+++ b/test/command/suite/select/filter/index/equal/float32.test
@@ -1,0 +1,16 @@
+table_create Values TABLE_NO_KEY
+column_create Values number COLUMN_SCALAR Float32
+
+table_create Numbers TABLE_PAT_KEY Float32
+column_create Numbers values_number COLUMN_INDEX Values number
+
+load --table Values
+[
+{"number": 1.1},
+{"number": 3.1},
+{"number": -1.1}
+]
+
+select Values \
+  --filter 'number == -1.1' \
+  --output_columns 'number'


### PR DESCRIPTION
Currently, Groonga doesn't support Float32 as a key of patricia trie table.
So, Groonga can't encode Float32 value correctly when we register
Float32 value as a key of patricia trie table.

In this case, we can't get result correctly as below.

```
table_create Lexicon TABLE_PAT_KEY Float32

table_create Numbers TABLE_HASH_KEY UInt64
column_create Numbers id COLUMN_SCALAR Float32

load --table Numbers
[
["_key","id"],
[1,1.1],
[2,2.1],
[3,3.1]
]

column_create Lexicon index COLUMN_INDEX Numbers id

select Numbers --filter 'id >= 2.1' --output_pretty yes
[
  [
    0,
    1738641494.864537,
    0.002141714096069336
  ],
  [
    [
      [
        1
      ],
      [
        [
          "_id",
          "UInt32"
        ],
        [
          "_key",
          "UInt64"
        ],
        [
          "id",
          "Float32"
        ]
      ],
      [
        1,
        1,
        1.1
      ]
    ]
  ]
]
```