### PR TITLE
packages ubuntu: support Apache Arrow in packages.groonga.org

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -43,11 +43,9 @@ apt install -V -y \
   ${repositories_dir}/${distribution}/pool/${code_name}/${component}/*/*/*_{${architecture},all}.deb
 
 groonga --version
-if [ "${distribution}" != "ubuntu" ]; then
-  if ! groonga --version | grep -q apache-arrow; then
-    echo "Apache Arrow isn't enabled"
-    exit 1
-  fi
+if ! groonga --version | grep -q apache-arrow; then
+  echo "Apache Arrow isn't enabled"
+  exit 1
 fi
 
 # There are some problems for running arm64 tests:

--- a/packages/apt/ubuntu-jammy/Dockerfile
+++ b/packages/apt/ubuntu-jammy/Dockerfile
@@ -11,6 +11,14 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
+    ca-certificates \
+    lsb-release \
+    wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     ccache \
@@ -18,6 +26,7 @@ RUN \
     debhelper \
     devscripts \
     dh-apparmor \
+    libarrow-dev \
     libedit-dev \
     libevent-dev \
     liblz4-dev \

--- a/packages/apt/ubuntu-noble/Dockerfile
+++ b/packages/apt/ubuntu-noble/Dockerfile
@@ -11,6 +11,14 @@ RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
+    ca-certificates \
+    lsb-release \
+    wget && \
+  wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt install -y -V ${quiet} ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     ccache \
@@ -18,6 +26,7 @@ RUN \
     debhelper \
     devscripts \
     dh-apparmor \
+    libarrow-dev \
     libedit-dev \
     libevent-dev \
     liblz4-dev \


### PR DESCRIPTION
Previously, we did not provide Groonga with Apache Arrow in the Launchpad because Launchpad could not reference Apache Arrow. By distributing from packages.groonga.org instead, we remove that restriction.

Enabling Apache Arrow as a dependency in Groonga unlocks additional features, including the recently added static parallel index building support. By adding Apache Arrow to Groonga dependencies, these features become available.