### PR TITLE
rake: Automatically set version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,7 +72,7 @@ namespace :dev do
   namespace :version do
     desc "Bump version for new development"
     task :bump do
-      File.write("base_version", env_var("NEW_VERSION"))
+      File.write("base_version", env_var("NEW_VERSION", version.succ))
     end
   end
 


### PR DESCRIPTION
We can get the next version with `String#succ`.

```
irb(main):001:0> "15.0.0".succ
=> "15.0.1"
irb(main):002:0> "15.0.9".succ
=> "15.1.0"
```

It is no longer necessary to specify in `NEW_VERSION`.