### PR TITLE
docs install/ubuntu: update supported versions

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -52,7 +52,7 @@ msgstr "サポートしているUbuntuのバージョンは次の通りです。
 msgid "22.04 LTS Jammy Jellyfish"
 msgstr ""
 
-msgid "23.04 Lunar Lobster"
+msgid "24.04 LTS Noble Numbat"
 msgstr ""
 
 msgid "Enable the universe repository to install Groonga:"

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -17,7 +17,7 @@ Archive) on Launchpad. You can install Groonga by APT from the PPA.
 Here are supported Ubuntu versions:
 
 - 22.04 LTS Jammy Jellyfish
-- 23.04 Lunar Lobster
+- 24.04 LTS Noble Numbat
 
 Enable the universe repository to install Groonga:
 


### PR DESCRIPTION
GitHub: close GH-2223

Because we has already dropped Lunar and supported Noble.