### PR TITLE
docs: release: Remove the announcement task to the mailing lists

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/contribution/development/release.po
+++ b/doc/locale/ja/LC_MESSAGES/contribution/development/release.po
@@ -391,18 +391,6 @@ msgstr ""
 msgid "上記URLを参照するとわかるようにソースアーカイブのurlとsha1チェックサムを更新します。"
 msgstr ""
 
-msgid "リリースアナウンス"
-msgstr ""
-
-msgid "作成したリリースアナウンスをメーリングリストへと流します。"
-msgstr ""
-
-msgid "groonga-dev groonga-dev@lists.osdn.me"
-msgstr ""
-
-msgid "Groonga-talk groonga-talk@lists.sourceforge.net"
-msgstr ""
-
 msgid "Twitterでリリースアナウンスをする"
 msgstr ""
 

--- a/doc/source/contribution/development/release.rst
+++ b/doc/source/contribution/development/release.rst
@@ -343,14 +343,6 @@ Groonga 3.0.6のときは以下のように更新してpull requestを送りま�
 
 上記URLを参照するとわかるようにソースアーカイブのurlとsha1チェックサムを更新します。
 
-リリースアナウンス
-------------------
-
-作成したリリースアナウンスをメーリングリストへと流します。
-
-* groonga-dev groonga-dev@lists.osdn.me
-* Groonga-talk groonga-talk@lists.sourceforge.net
-
 Twitterでリリースアナウンスをする
 ---------------------------------
 


### PR DESCRIPTION
We are not notifying the mailing list now.