### PR TITLE
test tokenizers/document_vector_bm25: use grntest not rm for x86_64 specific tests

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -57,13 +57,6 @@ fi
 mkdir -p /test
 cd /test
 cp -a /groonga/test/command ./
-if [ "${architecture}" = "arm64" ]; then
-  # Float32 value format is different.
-  rm command/suite/tokenizers/document_vector_bm25/alphabet.test
-  rm command/suite/tokenizers/document_vector_bm25/reindex.test
-  rm command/suite/tokenizers/document_vector_bm25/token_column.test
-  rm command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
-fi
 
 apt install -V -y \
   gcc \

--- a/test/command/suite/tokenizers/document_vector_bm25/alphabet.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/alphabet.test
@@ -1,3 +1,4 @@
+#@require-cpu !arm64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/reindex.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/reindex.test
@@ -1,3 +1,4 @@
+#@require-cpu !arm64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/token_column.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/token_column.test
@@ -1,3 +1,4 @@
+#@require-cpu !arm64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
@@ -1,3 +1,4 @@
+#@require-cpu !arm64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY


### PR DESCRIPTION
If we use grntest to determine whether we can use a test or not instead of executing `rm` before we run a test, developers don't need to execute `rm`.