### PR TITLE
test tokenizers/document_vector_bm25: use "x86_64" not "!arm64"

### DIFF
--- a/test/command/suite/tokenizers/document_vector_bm25/alphabet.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/alphabet.test
@@ -1,4 +1,4 @@
-#@require-cpu !arm64
+#@require-cpu x86_64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/reindex.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/reindex.test
@@ -1,4 +1,4 @@
-#@require-cpu !arm64
+#@require-cpu x86_64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/token_column.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/token_column.test
@@ -1,4 +1,4 @@
-#@require-cpu !arm64
+#@require-cpu x86_64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY

--- a/test/command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
+++ b/test/command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
@@ -1,4 +1,4 @@
-#@require-cpu !arm64
+#@require-cpu x86_64
 #@require-os !Darwin
 
 table_create Memos TABLE_NO_KEY


### PR DESCRIPTION
`status`'s `"cpu"` uses `CMAKE_SYSTEM_PROCESSOR` (`CMAKE_HOST_SYSTEM_PROCESSOR` for non cross-compiling). It uses `uname -m` on Linux and `uname -p` on macOS:  https://cmake.org/cmake/help/latest/variable/CMAKE_HOST_SYSTEM_PROCESSOR.html

`uname -m` on aarch64 Linux returns `aarch64` not `arm64` and `uname -p` on arm macOS returns `arm` not `arm64`. So `!arm64` didn't work as we expected.

We confirmed the current expected values are valid only on x86_64 for now. The current expected values may work on other architecture but we use them only for x86_64 safety and easy to maintain.

So let's use `x86_64` for now.