### PR TITLE
ci release: switch release workflow trigger from workflow_call to tag push event

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -883,14 +883,3 @@ jobs:
             --timeout 360 `
             --use-http-chunked `
             test\command\suite
-
-  release:
-    if: |
-      github.ref_type == 'tag'
-    name: Release for Windows MSVC
-    needs: windows-msvc
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ github.ref_name }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -67,13 +67,3 @@ jobs:
         with:
           name: release-document
           path: document-*.tar.gz
-  release:
-    if: |
-      github.ref_type == 'tag'
-    name: Release
-    needs: build
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ github.ref_name }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -308,14 +308,3 @@ jobs:
         with:
           name: release-linux-packages
           path: "*.tar.gz"
-
-  release:
-    if: |
-      github.ref_type == 'tag'
-    name: Release
-    needs: prepare-for-release
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ github.ref_name }}
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
                          --jq '.[].databaseId' \
                          --json databaseId \
                          --limit 1 \
-                         --repo ${GITHUB_REPOSITORY} \
                          --workflow ${workflow})
               if [ -n "${run_id}" ]; then
                 break
@@ -32,12 +31,10 @@ jobs:
             gh run watch \
               --exit-status \
               --interval 300 \
-              --repo ${GITHUB_REPOSITORY} \
               ${run_id}
             gh run download ${run_id} \
               --dir release-artifacts \
-              --pattern "release-*" \
-              --repo ${GITHUB_REPOSITORY}
+              --pattern "release-*"
           done
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,47 @@
 name: Release
 on:
-  workflow_call:
-    inputs:
-      tag:
-        required: true
-        type: string
-    secrets:
-      token:
-        required: true
+  push:
+    tags:
+      - "*"
 jobs:
-  page:
-    name: Release Page
+  publish:
+    name: Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
-      - name: Create release page
+      - name: Download artifacts
+        run: |
+          workflows=(cmake.yml document.yml package.yml)
+          for workflow in "${workflows[@]}"; do
+            run_id=""
+            while true; do
+              echo "Waiting for run to start ${workflow}..."
+              run_id=$(gh run list \
+                         --branch ${GITHUB_REF_NAME} \
+                         --jq '.[].databaseId' \
+                         --json databaseId \
+                         --limit 1 \
+                         --repo ${GITHUB_REPOSITORY} \
+                         --workflow ${workflow})
+              if [ -n "${run_id}" ]; then
+                break
+              fi
+              sleep 300
+            done
+            gh run watch \
+              --exit-status \
+              --interval 300 \
+              --repo ${GITHUB_REPOSITORY} \
+              ${run_id}
+            gh run download ${run_id} \
+              --dir release-artifacts \
+              --pattern "release-*" \
+              --repo ${GITHUB_REPOSITORY}
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Extract release note
         run: |
           (cd doc/source/news && \
            ruby \
@@ -35,26 +62,18 @@ jobs:
           echo "" >> release-note.md
           echo "### Translations" >> release-note.md
           echo "" >> release-note.md
-          tag=${{ inputs.tag }}
-          version=${tag#v}
+          version=${GITHUB_REF_NAME#v}
           major_version=${version%%.*}
           version_hyphen=$(echo ${version} | tr . -)
           echo "  * [Japanese](https://groonga.org/ja/docs/news/${major_version}.html#release-${version_hyphen})" >> release-note.md
+      - name: Publish release page
+        run: |
           title="$(head -n1 release-note.md | sed -e 's/^## //')"
           tail -n +2 release-note.md > release-note-without-version.md
-          gh release create "${tag}" \
+          gh release create "${GITHUB_REF_NAME}" \
             --discussion-category Releases \
             --notes-file release-note-without-version.md \
-            --title "${title}" || :
+            --title "${title}" \
+            release-artifacts/*/*
         env:
-          GH_TOKEN: ${{ secrets.token }}
-      - uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-          pattern: release-*
-          merge-multiple: true
-      - name: Upload to release
-        run: |
-          gh release upload "${{ inputs.tag }}" artifacts/*
-        env:
-          GH_TOKEN: ${{ secrets.token }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR changes our release workflow trigger from using workflow_call to a push event (tag push). The motivations are as follows.

## Enhanced security and simplified variable management

Using `workflow_call` requires that every calling workflow supply necessary variables and secrets. It means each workflow must have access to sensitive information. This increases the risk of misconfiguration or potential leaks. Switching to a tag push trigger allows the release workflow to manage its own secrets internally. It reduces exposure and simplifies the configuration process.

ref: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

## Increased maintainability and consistency

Adopting the release event approach aligns our process with related projects like PGroonga and Mroonga. Standardizing on the tag push method improves overall maintainability by unifying our release strategy across projects.