### PR TITLE
doc reference regular expression: fix wrong description about index ready

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/regular_expression.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/regular_expression.po
@@ -324,20 +324,20 @@ msgstr "インデックスを使えるか"
 msgid "The beginning of line"
 msgstr "行頭"
 
-msgid "o"
+msgid "x"
 msgstr ""
 
 msgid "The end of line"
 msgstr "行末"
-
-msgid "x"
-msgstr ""
 
 msgid "``\\A``"
 msgstr ""
 
 msgid "The beginning of text"
 msgstr "テキストの先頭"
+
+msgid "o"
+msgstr ""
 
 msgid "``\\z``"
 msgstr ""

--- a/doc/locale/ja/LC_MESSAGES/reference/regular_expression.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/regular_expression.po
@@ -324,7 +324,7 @@ msgstr "インデックスを使えるか"
 msgid "The beginning of line"
 msgstr "行頭"
 
-msgid "x"
+msgid "\\-"
 msgstr ""
 
 msgid "The end of line"
@@ -336,7 +336,7 @@ msgstr ""
 msgid "The beginning of text"
 msgstr "テキストの先頭"
 
-msgid "o"
+msgid "✓"
 msgstr ""
 
 msgid "``\\z``"

--- a/doc/source/reference/regular_expression.rst
+++ b/doc/source/reference/regular_expression.rst
@@ -375,7 +375,7 @@ can be evaluated by index.
      - Index ready
    * - ``^``
      - The beginning of line
-     - o
+     - x
    * - ``$``
      - The end of line
      - x
@@ -384,7 +384,7 @@ can be evaluated by index.
      - o
    * - ``\z``
      - The end of text
-     - x
+     - o
 
 Here is an example that uses ``\z``.
 

--- a/doc/source/reference/regular_expression.rst
+++ b/doc/source/reference/regular_expression.rst
@@ -375,16 +375,16 @@ can be evaluated by index.
      - Index ready
    * - ``^``
      - The beginning of line
-     - x
+     - \-
    * - ``$``
      - The end of line
-     - x
+     - \-
    * - ``\A``
      - The beginning of text
-     - o
+     - ✓
    * - ``\z``
      - The end of text
-     - o
+     - ✓
 
 Here is an example that uses ``\z``.
 


### PR DESCRIPTION
Only "\A" and "\z" can be evaluated by index.