### PR TITLE
docs: api/grn_cache move grn_cache_close() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -54,23 +54,17 @@ msgstr "リファレンス"
 msgid "It is an opaque cache object. You can create a ``grn_cache`` by :c:func:`grn_cache_open()` and free the created object by :c:func:`grn_cache_close()`."
 msgstr "``grn_cache`` は詳細を公開していないオブジェクトです。 :c:func:`grn_cache_open()` で作成し、 :c:func:`grn_cache_close()` で解放できます。"
 
-msgid "Frees resourses of the ``cache``."
-msgstr "``cache`` のリソースを解放。"
+msgid "Sets the cache object that is used in :doc:`/reference/commands/select` command."
+msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクトを設定します。"
 
 msgid "The context."
 msgstr "その時点のコンテキスト。"
 
-msgid "The cache object to be freed."
-msgstr "キャッシュオブジェクトを解放する。"
+msgid "The cache object that is used in :doc:`/reference/commands/select` command."
+msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクト。"
 
 msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise."
 msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
-msgid "Sets the cache object that is used in :doc:`/reference/commands/select` command."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクトを設定します。"
-
-msgid "The cache object that is used in :doc:`/reference/commands/select` command."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクト。"
 
 msgid "Gets the cache object that is used in :doc:`/reference/commands/select` command."
 msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクトを取得します。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -57,14 +57,6 @@ Reference
    :c:func:`grn_cache_open()` and free the created object by
    :c:func:`grn_cache_close()`.
 
-.. c:function:: grn_rc grn_cache_close(grn_ctx *ctx, grn_cache *cache)
-
-   Frees resourses of the ``cache``.
-
-   :param ctx: The context.
-   :param cache: The cache object to be freed.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise.
-
 .. c:function:: grn_rc grn_cache_current_set(grn_ctx *ctx, grn_cache *cache)
 
    Sets the cache object that is used in

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -82,6 +82,14 @@ GRN_API grn_cache *
 grn_cache_open(grn_ctx *ctx);
 GRN_API grn_cache *
 grn_persistent_cache_open(grn_ctx *ctx, const char *base_path);
+/**
+ * \brief Free resourses of the `cache`.
+ *
+ * \param ctx The context object.
+ * \param cache The cache object to be freed.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_cache_close(grn_ctx *ctx, grn_cache *cache);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.