### PR TITLE
expr_executor: operation slash: Separate implements when uint32_t or uint64_t and when not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,10 +375,13 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
 elseif(MSVC)
-  # unary minus operator applied to unsigned type, result still unsigned
-  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
-  string(APPEND GRN_C_COMPILE_FLAGS " /wd4146")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4146")
+  # # unary minus operator applied to unsigned type, result still unsigned
+  # # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
+  # string(APPEND GRN_C_COMPILE_FLAGS " /wd4146")
+  # string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4146")
+  # debug
+  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
+  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
   # 'argument' : conversion from 'type1' to 'type2', possible loss of data
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,9 +387,6 @@ elseif(MSVC)
   # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4334")
   string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4334")
-
-  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
 endif()
 
 option(GRN_WARN_CONVERSION "Enable -Wconversion" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,6 +375,13 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
 elseif(MSVC)
+  # # unary minus operator applied to unsigned type, result still unsigned
+  # # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
+  # string(APPEND GRN_C_COMPILE_FLAGS " /wd4146")
+  # string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4146")
+  # debug
+  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
+  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
   # 'argument' : conversion from 'type1' to 'type2', possible loss of data
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,13 +375,6 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
 elseif(MSVC)
-  # # unary minus operator applied to unsigned type, result still unsigned
-  # # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
-  # string(APPEND GRN_C_COMPILE_FLAGS " /wd4146")
-  # string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4146")
-  # debug
-  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
   # 'argument' : conversion from 'type1' to 'type2', possible loss of data
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,10 +375,15 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
 elseif(MSVC)
+  # Enable warnings
+
   # unary minus operator applied to unsigned type, result still unsigned
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
-  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
+  string(APPEND GRN_C_COMPILE_FLAGS " /w24146")
+  string(APPEND GRN_CXX_COMPILE_FLAGS " /w24146")
+
+  # Disable warnings
+
   # 'argument' : conversion from 'type1' to 'type2', possible loss of data
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,9 @@ elseif(MSVC)
   # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4334")
   string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4334")
+
+  string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
+  string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
 endif()
 
 option(GRN_WARN_CONVERSION "Enable -Wconversion" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,11 +375,8 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
 elseif(MSVC)
-  # # unary minus operator applied to unsigned type, result still unsigned
-  # # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
-  # string(APPEND GRN_C_COMPILE_FLAGS " /wd4146")
-  # string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4146")
-  # debug
+  # unary minus operator applied to unsigned type, result still unsigned
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
   string(APPEND GRN_C_COMPILE_FLAGS " /we4146")
   string(APPEND GRN_CXX_COMPILE_FLAGS " /we4146")
   # 'argument' : conversion from 'type1' to 'type2', possible loss of data

--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -320,7 +320,7 @@ namespace {
                                                     grn_obj *result)
   {
     // y == -1
-    if (grn::numeric::is_zero(std::abs(y + 1))) {
+    if (grn::numeric::is_zero(y + 1)) {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(-x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
@@ -339,7 +339,7 @@ namespace {
                                                     grn_obj *result)
   {
     // y == -1
-    if (grn::numeric::is_zero(std::abs(y + 1))) {
+    if (grn::numeric::is_zero(y + 1)) {
       grn::bulk::set<int64_t>(ctx, result, -static_cast<int64_t>(x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));

--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -252,8 +252,16 @@ namespace {
     }
   }
 
+  /* To avoid the following warning, which occur in uint32_t and uint64_t.
+   *
+   * warning C4146: unary minus operator applied to unsigned type, result still
+   * unsigned
+   */
   template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<std::is_signed_v<Y> && std::is_integral_v<Y>, bool>
+  std::enable_if_t<!(std::is_same_v<X, uint32_t> ||
+                     std::is_same_v<X, uint64_t>) &&
+                     std::is_signed_v<Y> && std::is_integral_v<Y>,
+                   bool>
   numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
                                                     X x,
                                                     Y y,
@@ -261,6 +269,24 @@ namespace {
   {
     if (y == -1) {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(-x));
+    } else {
+      grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
+    }
+    return true;
+  }
+
+  template <typename RESULT_TYPE, typename X, typename Y>
+  std::enable_if_t<(std::is_same_v<X, uint32_t> ||
+                    std::is_same_v<X, uint64_t>) &&
+                     std::is_signed_v<Y> && std::is_integral_v<Y>,
+                   bool>
+  numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
+                                                    X x,
+                                                    Y y,
+                                                    grn_obj *result)
+  {
+    if (y == -1) {
+      grn::bulk::set<int64_t>(ctx, result, -static_cast<int64_t>(x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
     }
@@ -278,8 +304,16 @@ namespace {
     return true;
   }
 
+  /* To avoid the following warning, which occur in uint32_t and uint64_t.
+   *
+   * warning C4146: unary minus operator applied to unsigned type, result still
+   * unsigned
+   * */
   template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<std::is_floating_point_v<Y>, bool>
+  std::enable_if_t<!(std::is_same_v<X, uint32_t> ||
+                     std::is_same_v<X, uint64_t>) &&
+                     std::is_floating_point_v<Y>,
+                   bool>
   numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
                                                     X x,
                                                     Y y,
@@ -288,6 +322,25 @@ namespace {
     // y == -1
     if (grn::numeric::is_zero(std::abs(y + 1))) {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(-x));
+    } else {
+      grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
+    }
+    return true;
+  }
+
+  template <typename RESULT_TYPE, typename X, typename Y>
+  std::enable_if_t<(std::is_same_v<X, uint32_t> ||
+                    std::is_same_v<X, uint64_t>) &&
+                     std::is_floating_point_v<Y>,
+                   bool>
+  numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
+                                                    X x,
+                                                    Y y,
+                                                    grn_obj *result)
+  {
+    // y == -1
+    if (grn::numeric::is_zero(std::abs(y + 1))) {
+      grn::bulk::set<int64_t>(ctx, result, -static_cast<int64_t>(x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
     }

--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -1019,8 +1019,13 @@ namespace {
     case GRN_DB_UINT32:
       {
         auto x_ = GRN_UINT32_VALUE(x);
-        CHECK(numeric_arithmetic_binary_operation_dispatch<
-              uint32_t>(ctx, op, x_, y, res, GRN_DB_UINT32));
+        if (op == GRN_OP_SLASH) {
+          CHECK(numeric_arithmetic_binary_operation_dispatch<
+                int64_t>(ctx, op, x_, y, res, GRN_DB_INT64));
+        } else {
+          CHECK(numeric_arithmetic_binary_operation_dispatch<
+                uint32_t>(ctx, op, x_, y, res, GRN_DB_UINT32));
+        }
       }
       break;
     case GRN_DB_INT64:
@@ -1050,8 +1055,13 @@ namespace {
     case GRN_DB_UINT64:
       {
         auto x_ = GRN_UINT64_VALUE(x);
-        CHECK(numeric_arithmetic_binary_operation_dispatch<
-              uint64_t>(ctx, op, x_, y, res, GRN_DB_UINT64));
+        if (op == GRN_OP_SLASH) {
+          CHECK(numeric_arithmetic_binary_operation_dispatch<
+                int64_t>(ctx, op, x_, y, res, GRN_DB_INT64));
+        } else {
+          CHECK(numeric_arithmetic_binary_operation_dispatch<
+                uint64_t>(ctx, op, x_, y, res, GRN_DB_UINT64));
+        }
       }
       break;
     case GRN_DB_FLOAT32:

--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -286,6 +286,7 @@ namespace {
                                                     grn_obj *result)
   {
     if (y == -1) {
+      grn_obj_reinit(ctx, result, GRN_DB_INT64, 0);
       grn::bulk::set<int64_t>(ctx, result, -static_cast<int64_t>(x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
@@ -1019,13 +1020,8 @@ namespace {
     case GRN_DB_UINT32:
       {
         auto x_ = GRN_UINT32_VALUE(x);
-        if (op == GRN_OP_SLASH) {
-          CHECK(numeric_arithmetic_binary_operation_dispatch<
-                int64_t>(ctx, op, x_, y, res, GRN_DB_INT64));
-        } else {
-          CHECK(numeric_arithmetic_binary_operation_dispatch<
-                uint32_t>(ctx, op, x_, y, res, GRN_DB_UINT32));
-        }
+        CHECK(numeric_arithmetic_binary_operation_dispatch<
+              uint32_t>(ctx, op, x_, y, res, GRN_DB_UINT32));
       }
       break;
     case GRN_DB_INT64:
@@ -1055,13 +1051,8 @@ namespace {
     case GRN_DB_UINT64:
       {
         auto x_ = GRN_UINT64_VALUE(x);
-        if (op == GRN_OP_SLASH) {
-          CHECK(numeric_arithmetic_binary_operation_dispatch<
-                int64_t>(ctx, op, x_, y, res, GRN_DB_INT64));
-        } else {
-          CHECK(numeric_arithmetic_binary_operation_dispatch<
-                uint64_t>(ctx, op, x_, y, res, GRN_DB_UINT64));
-        }
+        CHECK(numeric_arithmetic_binary_operation_dispatch<
+              uint64_t>(ctx, op, x_, y, res, GRN_DB_UINT64));
       }
       break;
     case GRN_DB_FLOAT32:

--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -305,16 +305,8 @@ namespace {
     return true;
   }
 
-  /* To avoid the following warning, which occur in uint32_t and uint64_t.
-   *
-   * warning C4146: unary minus operator applied to unsigned type, result still
-   * unsigned
-   * */
   template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<!(std::is_same_v<X, uint32_t> ||
-                     std::is_same_v<X, uint64_t>) &&
-                     std::is_floating_point_v<Y>,
-                   bool>
+  std::enable_if_t<std::is_floating_point_v<Y>, bool>
   numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
                                                     X x,
                                                     Y y,
@@ -322,26 +314,7 @@ namespace {
   {
     // y == -1
     if (grn::numeric::is_zero(y + 1)) {
-      grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(-x));
-    } else {
-      grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
-    }
-    return true;
-  }
-
-  template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<(std::is_same_v<X, uint32_t> ||
-                    std::is_same_v<X, uint64_t>) &&
-                     std::is_floating_point_v<Y>,
-                   bool>
-  numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
-                                                    X x,
-                                                    Y y,
-                                                    grn_obj *result)
-  {
-    // y == -1
-    if (grn::numeric::is_zero(y + 1)) {
-      grn::bulk::set<int64_t>(ctx, result, -static_cast<int64_t>(x));
+      grn::bulk::set<RESULT_TYPE>(ctx, result, -static_cast<RESULT_TYPE>(x));
     } else {
       grn::bulk::set<RESULT_TYPE>(ctx, result, static_cast<RESULT_TYPE>(x / y));
     }

--- a/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_float_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt64
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 9223372036854775807}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1.0'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt64"
+        ],
+        [
+          "value",
+          "UInt64"
+        ]
+      ],
+      [
+        9223372036854775807,
+        -9.223372036854776e+18
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_float_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_float_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt64
+
+load --table Values
+[
+{"value": 9223372036854775807}
+]
+
+select Values \
+  --output_columns 'value, value / -1.0'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt64
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 9223372036854775807}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt64"
+        ],
+        [
+          "value",
+          "UInt64"
+        ]
+      ],
+      [
+        9223372036854775807,
+        -9223372036854775807
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/int64_max_in_uint64_and_minus_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt64
+
+load --table Values
+[
+{"value": 9223372036854775807}
+]
+
+select Values \
+  --output_columns 'value, value / -1'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_float_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 4294967295}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1.0'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt32"
+        ],
+        [
+          "value",
+          "UInt32"
+        ]
+      ],
+      [
+        4294967295,
+        -4294967295.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_float_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_float_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt32
+
+load --table Values
+[
+{"value": 4294967295}
+]
+
+select Values \
+  --output_columns 'value, value / -1.0'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 4294967295}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt32"
+        ],
+        [
+          "value",
+          "UInt32"
+        ]
+      ],
+      [
+        4294967295,
+        -4294967295
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint32_max_and_minus_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt32
+
+load --table Values
+[
+{"value": 4294967295}
+]
+
+select Values \
+  --output_columns 'value, value / -1'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.expected
@@ -31,7 +31,7 @@ select Values   --output_columns 'value, value / -1.0'
       ],
       [
         18446744073709551615,
-        1.0
+        -1.844674407370955e+19
       ]
     ]
   ]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt64
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 18446744073709551615}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1.0'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt64"
+        ],
+        [
+          "value",
+          "UInt64"
+        ]
+      ],
+      [
+        18446744073709551615,
+        1.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_float_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt64
+
+load --table Values
+[
+{"value": 18446744073709551615}
+]
+
+select Values \
+  --output_columns 'value, value / -1.0'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_one.expected
@@ -1,0 +1,38 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt64
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 18446744073709551615}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "value",
+          "UInt64"
+        ],
+        [
+          "value",
+          "UInt64"
+        ]
+      ],
+      [
+        18446744073709551615,
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint64_max_and_minus_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt64
+
+load --table Values
+[
+{"value": 18446744073709551615}
+]
+
+select Values \
+  --output_columns 'value, value / -1'


### PR DESCRIPTION
This is to avoid the following warning.

```
warning C4146: unary minus operator applied to unsigned type, result still unsigned
```