### PR TITLE
docs: api/cache move grn_cache_get_max_n_entries() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -80,12 +80,3 @@ msgstr "変更するキャッシュオブジェクト。"
 
 msgid "The new max number of entries of the cache object."
 msgstr "キャッシュオブジェクトの新しい最大エントリ数。"
-
-msgid "Gets the max number of entries of the cache object."
-msgstr "キャッシュオブジェクトのエントリの最大数を取得します。"
-
-msgid "The target cache object."
-msgstr "ターゲットキャッシュオブジェクト。"
-
-msgid "The max number of entries of the cache object."
-msgstr "キャッシュオブジェクトの最大エントリ数。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -84,11 +84,3 @@ Reference
    :param cache: The cache object to be changed.
    :param n: The new max number of entries of the cache object.
    :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise.
-
-.. c:function:: unsigned int grn_cache_get_max_n_entries(grn_ctx *ctx, grn_cache *cache)
-
-   Gets the max number of entries of the cache object.
-
-   :param ctx: The context.
-   :param cache: The target cache object.
-   :return: The max number of entries of the cache object.

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -103,6 +103,14 @@ grn_cache_default_reopen(void);
 
 GRN_API grn_rc
 grn_cache_set_max_n_entries(grn_ctx *ctx, grn_cache *cache, unsigned int n);
+/**
+ * \brief Retrieve the maximum number of entries in the \ref grn_cache object.
+ *
+ * \param ctx The context object.
+ * \param cache The cache object whose maximum entry count is to be retrieved.
+ *
+ * \return The maximum number of entries for \ref grn_cache object.
+ */
 GRN_API unsigned int
 grn_cache_get_max_n_entries(grn_ctx *ctx, grn_cache *cache);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.