### PR TITLE
docs: api/cache move grn_cache_set_max_n_entries() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -71,12 +71,3 @@ msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッ�
 
 msgid "The cache object that is used in :doc:`/reference/commands/select` command. It may be ``NULL``."
 msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクト。 ``NULL`` のこともあります。"
-
-msgid "Sets the max number of entries of the cache object."
-msgstr "キャッシュオブジェクトのエントリの最大数を設定します。"
-
-msgid "The cache object to be changed."
-msgstr "変更するキャッシュオブジェクト。"
-
-msgid "The new max number of entries of the cache object."
-msgstr "キャッシュオブジェクトの新しい最大エントリ数。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -75,12 +75,3 @@ Reference
    :param ctx: The context.
    :return: The cache object that is used in
             :doc:`/reference/commands/select` command. It may be ``NULL``.
-
-.. c:function:: grn_rc grn_cache_set_max_n_entries(grn_ctx *ctx, grn_cache *cache, unsigned int n)
-
-   Sets the max number of entries of the cache object.
-
-   :param ctx: The context.
-   :param cache: The cache object to be changed.
-   :param n: The new max number of entries of the cache object.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise.

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -101,6 +101,15 @@ grn_cache_current_get(grn_ctx *ctx);
 GRN_API grn_rc
 grn_cache_default_reopen(void);
 
+/**
+ * \brief Set the maximum number of entries in the \ref grn_cache object.
+ *
+ * \param ctx The context object.
+ * \param cache The cache object whose maximum entry count is updated.
+ * \param n The new maximum number of entries.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_cache_set_max_n_entries(grn_ctx *ctx, grn_cache *cache, unsigned int n);
 /**


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.