### PR TITLE
docs: api/cache move grn_cache_current_get() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -65,9 +65,3 @@ msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッ�
 
 msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise."
 msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
-msgid "Gets the cache object that is used in :doc:`/reference/commands/select` command."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクトを取得します。"
-
-msgid "The cache object that is used in :doc:`/reference/commands/select` command. It may be ``NULL``."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクト。 ``NULL`` のこともあります。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -66,12 +66,3 @@ Reference
    :param cache: The cache object that is used in
                  :doc:`/reference/commands/select` command.
    :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise.
-
-.. c:function:: grn_cache *grn_cache_current_get(grn_ctx *ctx)
-
-   Gets the cache object that is used in
-   :doc:`/reference/commands/select` command.
-
-   :param ctx: The context.
-   :return: The cache object that is used in
-            :doc:`/reference/commands/select` command. It may be ``NULL``.

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -96,16 +96,13 @@ grn_cache_close(grn_ctx *ctx, grn_cache *cache);
 GRN_API grn_rc
 grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
 /**
- * \brief Retrieve the current \ref grn_cache object used in the select command.
- *
- * \see For more details about the select command, please see
- *      https://groonga.org/docs/reference/commands/select.html.
+ * \brief Retrieve the current \ref grn_cache object.
  *
  * \param ctx The context object.
  *
- * \return The \ref grn_cache object is associated with the database in the
- *         select command context. If there is no specific cache, it returns
- *         the current cache which might be `NULL`.
+ * \return The \ref grn_cache object is associated with the database that the
+ *         context is using. If there is no specific cache, it returns the
+ *         current cache which might be NULL.
  */
 GRN_API grn_cache *
 grn_cache_current_get(grn_ctx *ctx);

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -105,7 +105,7 @@ grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
  *
  * \return The \ref grn_cache object is associated with the database in the
  *         select command context. If there is no specific cache, it returns
- *         the current cache which might be NULL.
+ *         the current cache which might be `NULL`.
  */
 GRN_API grn_cache *
 grn_cache_current_get(grn_ctx *ctx);

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -95,6 +95,21 @@ grn_cache_close(grn_ctx *ctx, grn_cache *cache);
 
 GRN_API grn_rc
 grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
+/**
+ * \brief Retrieve the current \ref grn_cache object used in the select command.
+ *
+ * \note For more details about the select command, please see
+ * \htmlonly
+ *   <a href="https://groonga.org/docs/reference/commands/select.html">
+ *     Groonga command select documentation
+ *   </a>.
+ * \endhtmlonly
+ *
+ * \param ctx The context object.
+ *
+ * \return The \ref grn_cache object used in the select command on success,
+ *         `NULL` on error.
+ */
 GRN_API grn_cache *
 grn_cache_current_get(grn_ctx *ctx);
 

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -98,12 +98,8 @@ grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
 /**
  * \brief Retrieve the current \ref grn_cache object used in the select command.
  *
- * \note For more details about the select command, please see
- * \htmlonly
- *   <a href="https://groonga.org/docs/reference/commands/select.html">
- *     Groonga command select documentation
- *   </a>.
- * \endhtmlonly
+ * \see For more details about the select command, please see
+ *      https://groonga.org/docs/reference/commands/select.html.
  *
  * \param ctx The context object.
  *

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -103,8 +103,9 @@ grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
  *
  * \param ctx The context object.
  *
- * \return The \ref grn_cache object used in the select command on success,
- *         `NULL` on error.
+ * \return The \ref grn_cache object is associated with the database in the
+ *         select command context. If there is no specific cache, it returns
+ *         the current cache which might be NULL.
  */
 GRN_API grn_cache *
 grn_cache_current_get(grn_ctx *ctx);


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.