### PR TITLE
ci debian trixie: disable because of Apache Arrow dependencies' mismatch

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -133,8 +133,14 @@ jobs:
         id:
           - debian-bookworm-amd64
           - debian-bookworm-arm64
-          - debian-trixie-amd64
-          - debian-trixie-arm64
+          # Temporarily disable because of Apache Arrow depedencies' mismatch.
+          # Apache Arrow currently depends on libre2-11-absl20230802, which is
+          # not available in Debian trixie. Trixie now provides libre2-11
+          # version 20240702-3.
+          # We will re-enable once Apache Arrow is rebuilt (expected release in
+          # April).
+          # - debian-trixie-amd64
+          # - debian-trixie-arm64
           - ubuntu-jammy-amd64
           - ubuntu-jammy-arm64
           - ubuntu-noble-amd64

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -56,8 +56,8 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
     [
       "debian-bookworm",
       "debian-bookworm-arm64",
-      "debian-trixie",
-      "debian-trixie-arm64",
+      # "debian-trixie",
+      # "debian-trixie-arm64",
     ]
   end
 


### PR DESCRIPTION
Debian trixie on CI is failing because Apache Arrow depends on libre2-11-absl20230802, which is no longer available. Trixie now provides libre2-11 version 20240702-3, causing a dependency mismatch during the Apache Arrow build.

ref: https://packages.debian.org/trixie/libre2-11

```
12.71 Unsatisfied dependencies:
12.77  libarrow1900 : Depends: libre2-11-absl20230802 but it is not installable
12.77 Error: Unable to correct problems, you have held broken packages.
```
ref: https://github.com/groonga/groonga/actions/runs/13889234637/job/38858485115

We will re-enable these tests once Apache Arrow is rebuilt with the updated dependency, expected in the next release in April.