### PR TITLE
docs: api/cache move grn_cache_current_set() reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -15,12 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
-msgid "戻り値"
-msgstr ""
-
 msgid "``grn_cache``"
 msgstr "``grn_cache``"
 
@@ -53,15 +47,3 @@ msgstr "リファレンス"
 
 msgid "It is an opaque cache object. You can create a ``grn_cache`` by :c:func:`grn_cache_open()` and free the created object by :c:func:`grn_cache_close()`."
 msgstr "``grn_cache`` は詳細を公開していないオブジェクトです。 :c:func:`grn_cache_open()` で作成し、 :c:func:`grn_cache_close()` で解放できます。"
-
-msgid "Sets the cache object that is used in :doc:`/reference/commands/select` command."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクトを設定します。"
-
-msgid "The context."
-msgstr "その時点のコンテキスト。"
-
-msgid "The cache object that is used in :doc:`/reference/commands/select` command."
-msgstr ":doc:`/reference/commands/select` コマンドで使われるキャッシュオブジェクト。"
-
-msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise."
-msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -56,13 +56,3 @@ Reference
    It is an opaque cache object. You can create a ``grn_cache`` by
    :c:func:`grn_cache_open()` and free the created object by
    :c:func:`grn_cache_close()`.
-
-.. c:function:: grn_rc grn_cache_current_set(grn_ctx *ctx, grn_cache *cache)
-
-   Sets the cache object that is used in
-   :doc:`/reference/commands/select` command.
-
-   :param ctx: The context.
-   :param cache: The cache object that is used in
-                 :doc:`/reference/commands/select` command.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` otherwise.

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -99,7 +99,7 @@ grn_cache_close(grn_ctx *ctx, grn_cache *cache);
  * \param ctx The context object.
  * \param cache The new current cache object.
  *
- * \return \ref GRN_SUCCESS on success.
+ * \return \ref GRN_SUCCESS always.
  */
 GRN_API grn_rc
 grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -93,6 +93,14 @@ grn_persistent_cache_open(grn_ctx *ctx, const char *base_path);
 GRN_API grn_rc
 grn_cache_close(grn_ctx *ctx, grn_cache *cache);
 
+/**
+ * \brief Set the current \ref grn_cache object.
+ *
+ * \param ctx The context object.
+ * \param cache The new current cache object.
+ *
+ * \return \ref GRN_SUCCESS on success.
+ */
 GRN_API grn_rc
 grn_cache_current_set(grn_ctx *ctx, grn_cache *cache);
 /**


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.