### PR TITLE
docs: api/cache move grn_cache type reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_cache.po
@@ -45,5 +45,5 @@ msgstr "以下はキャッシュを変更する例です。"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "It is an opaque cache object. You can create a ``grn_cache`` by :c:func:`grn_cache_open()` and free the created object by :c:func:`grn_cache_close()`."
-msgstr "``grn_cache`` は詳細を公開していないオブジェクトです。 :c:func:`grn_cache_open()` で作成し、 :c:func:`grn_cache_close()` で解放できます。"
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_cache.rst
+++ b/doc/source/reference/api/grn_cache.rst
@@ -51,8 +51,5 @@ Here is an example that change the current cache object.
 Reference
 ---------
 
-.. c:type:: grn_cache
-
-   It is an opaque cache object. You can create a ``grn_cache`` by
-   :c:func:`grn_cache_open()` and free the created object by
-   :c:func:`grn_cache_close()`.
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -23,6 +23,12 @@ extern "C" {
 #endif
 
 #define GRN_CACHE_DEFAULT_MAX_N_ENTRIES 100
+/**
+ * \brief Cache object.
+ *
+ *        You can create a new cache object using \ref grn_cache_open, and free
+ *        it using \ref grn_cache_close.
+ */
 typedef struct _grn_cache grn_cache;
 
 GRN_API void

--- a/include/groonga/cache.h
+++ b/include/groonga/cache.h
@@ -26,8 +26,8 @@ extern "C" {
 /**
  * \brief Cache object.
  *
- *        You can create a new cache object using \ref grn_cache_open, and free
- *        it using \ref grn_cache_close.
+ * You can create a new cache object using \ref grn_cache_open, and free it
+ * using \ref grn_cache_close.
  */
 typedef struct _grn_cache grn_cache;
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.