### PR TITLE
docs ubuntu: add packages.groonga.org as Groonga APT repository

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -50,13 +50,13 @@ msgid "Groonga packages are distributed via our Groonga APT repository at https:
 msgstr "Groongaパッケージは、Groonga APTリポジトリー（https://packages.groonga.org）にて配布されています。"
 
 msgid "Install `groonga-apt-source` to enable Groonga APT repository."
-msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリを登録できます。"
+msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリーを登録できます。"
 
 msgid "PPA (Personal Package Archive)"
 msgstr "PPA（Personal Package Archive）"
 
 msgid "The PPA will be deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building."
-msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリ（packages.groonga.org）の利用を強くお勧めします。なぜなら、Groonga APTリポジトリではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
+msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリー（packages.groonga.org）の利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
 
 msgid "The Groonga APT repository for Ubuntu uses PPA (Personal Package Archive) on Launchpad. You can install Groonga by APT from the PPA."
 msgstr "Ubuntu用のGroongaのAPTリポジトリーはLaunchpad上のPPA（Personal Package Archive）を使っています。このPPAからAPTでGroongaをインストールできます。"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -43,11 +43,11 @@ msgstr "32-bit用と64-bit用のパッケージを配布していますが、サ
 msgid "Register Groonga APT repository"
 msgstr "GroongaのAPTリポジトリー登録"
 
-msgid "APT Repository(packages.groonga.org)"
-msgstr "APTリポジトリー(packages.groonga.org)"
+msgid "APT Repository (packages.groonga.org)"
+msgstr "APTリポジトリー（packages.groonga.org）"
 
 msgid "Groonga packages are distributed via our Groonga APT repository at https://packages.groonga.org."
-msgstr "Groongaパッケージは、Groonga APTリポジトリー(https://packages.groonga.org)にて配布されています。"
+msgstr "Groongaパッケージは、Groonga APTリポジトリー（https://packages.groonga.org）にて配布されています。"
 
 msgid "Install `groonga-apt-source` to enable Groonga APT repository."
 msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリを登録できます。"
@@ -55,8 +55,8 @@ msgstr "`groonga-apt-source`をインストールすることで、Groonga APT�
 msgid "PPA (Personal Package Archive)"
 msgstr "PPA（Personal Package Archive）"
 
-msgid "The PPA will be deprecated. We strongly recommend using our Groonga APT repository(packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building."
-msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリ(packages.groonga.org)の利用を強くお勧めします。なぜなら、Groonga APTリポジトリではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
+msgid "The PPA will be deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building."
+msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリ（packages.groonga.org）の利用を強くお勧めします。なぜなら、Groonga APTリポジトリではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
 
 msgid "The Groonga APT repository for Ubuntu uses PPA (Personal Package Archive) on Launchpad. You can install Groonga by APT from the PPA."
 msgstr "Ubuntu用のGroongaのAPTリポジトリーはLaunchpad上のPPA（Personal Package Archive）を使っています。このPPAからAPTでGroongaをインストールできます。"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -40,6 +40,18 @@ msgstr "このセクションではUbuntu上でGroonga関連のdebパッケー�
 msgid "We distribute both 32-bit and 64-bit packages but we strongly recommend a 64-bit package for server. You should use a 32-bit package just only for tests or development. You will encounter an out of memory error with a 32-bit package even if you just process medium size data."
 msgstr "32-bit用と64-bit用のパッケージを配布していますが、サーバ用途には64-bitパッケージを利用することをオススメします。32-bit用パッケージはテスト用か開発用にだけ使って下さい。32-bit用パッケージを使った場合は、中程度のサイズのデータでもメモリ不足エラーになることがあります。"
 
+msgid "Register Groonga APT repository"
+msgstr "GroongaのAPTリポジトリー登録"
+
+msgid "APT Repository(packages.groonga.org)"
+msgstr "APTリポジトリー(packages.groonga.org)"
+
+msgid "Groonga packages are distributed via our Groonga APT repository at https://packages.groonga.org."
+msgstr "Groongaパッケージは、Groonga APTリポジトリー(https://packages.groonga.org)にて配布されています。"
+
+msgid "Install `groonga-apt-source` to enable Groonga APT repository."
+msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリを登録できます。"
+
 msgid "PPA (Personal Package Archive)"
 msgstr "PPA（Personal Package Archive）"
 
@@ -61,14 +73,23 @@ msgstr "Groongaをインストールするためにuniverseリポジトリを有
 msgid "Add the `ppa:groonga/ppa` PPA to your system:"
 msgstr "`ppa:groonga/ppa` PPAをシステムに登録します。"
 
+msgid "`groonga` package"
+msgstr "`groonga`パッケージ"
+
 msgid "Install:"
 msgstr "インストールします。"
+
+msgid "`groonga-tokenizer-mecab` package"
+msgstr "`groonga-tokenizer-mecab`パッケージ"
 
 msgid "If you want to use [MeCab](https://taku910.github.io/mecab/) as a tokenizer, install `groonga-tokenizer-mecab` package."
 msgstr "[MeCab](https://taku910.github.io/mecab/)をトークナイザーとして使いたいときは、`groonga-tokenizer-mecab`パッケージをインストールしてください。"
 
 msgid "Install `groonga-tokenizer-mecab` package:"
 msgstr "`groonga-tokenizer-mecab`パッケージをインストールします。"
+
+msgid "`groonga-token-filter-stem` package"
+msgstr "`groonga-token-filter-stem`パッケージ"
 
 msgid "If you want to use `TokenFilterStem` as a token filter, install `groonga-token-filter-stem` package."
 msgstr "`TokenFilterStem`をトークンフィルターとして使いたいときは`groonga-token-filter-stem`パッケージをインストールします。"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -55,6 +55,9 @@ msgstr "`groonga-apt-source`をインストールすることで、Groonga APT�
 msgid "PPA (Personal Package Archive)"
 msgstr "PPA（Personal Package Archive）"
 
+msgid "The PPA will be deprecated. We strongly recommend using our Groonga APT repository(packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building."
+msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリ(packages.groonga.org)の利用を強くお勧めします。なぜなら、Groonga APTリポジトリではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
+
 msgid "The Groonga APT repository for Ubuntu uses PPA (Personal Package Archive) on Launchpad. You can install Groonga by APT from the PPA."
 msgstr "Ubuntu用のGroongaのAPTリポジトリーはLaunchpad上のPPA（Personal Package Archive）を使っています。このPPAからAPTでGroongaをインストールできます。"
 

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -11,7 +11,7 @@ size data.
 
 ## Register Groonga APT repository
 
-### APT Repository(packages.groonga.org)
+### APT Repository (packages.groonga.org)
 
 Groonga packages are distributed via our Groonga APT repository at
 https://packages.groonga.org.
@@ -30,7 +30,7 @@ sudo apt update
 
 ```{note}
 The PPA will be deprecated. We strongly recommend using our Groonga APT
-repository(packages.groonga.org) because packages from that repository are built
+repository (packages.groonga.org) because packages from that repository are built
 with Apache Arrow enabled. This configuration unlocks extra features, such as
 parallel offline index building.
 ```

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -28,6 +28,13 @@ sudo apt update
 
 ### PPA (Personal Package Archive)
 
+```{note}
+The PPA will be deprecated. We strongly recommend using our Groonga APT
+repository(packages.groonga.org) because packages from that repository are built
+with Apache Arrow enabled. This configuration unlocks extra features, such as
+parallel offline index building.
+```
+
 The Groonga APT repository for Ubuntu uses PPA (Personal Package
 Archive) on Launchpad. You can install Groonga by APT from the PPA.
 

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -9,7 +9,24 @@ just only for tests or development. You will encounter an out of
 memory error with a 32-bit package even if you just process medium
 size data.
 
-## PPA (Personal Package Archive)
+## Register Groonga APT repository
+
+### APT Repository(packages.groonga.org)
+
+Groonga packages are distributed via our Groonga APT repository at
+https://packages.groonga.org.
+
+Install `groonga-apt-source` to enable Groonga APT repository.
+
+```bash
+sudo apt update
+sudo apt install -y -V ca-certificates lsb-release wget
+wget https://packages.groonga.org/ubuntu/groonga-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --short).deb
+sudo apt update
+```
+
+### PPA (Personal Package Archive)
 
 The Groonga APT repository for Ubuntu uses PPA (Personal Package
 Archive) on Launchpad. You can install Groonga by APT from the PPA.
@@ -33,6 +50,8 @@ sudo add-apt-repository -y ppa:groonga/ppa
 sudo apt update
 ```
 
+## `groonga` package
+
 Install:
 
 ```bash
@@ -43,6 +62,8 @@ sudo apt -V -y install groonga
 
 ```
 
+## `groonga-tokenizer-mecab` package
+
 If you want to use [MeCab](https://taku910.github.io/mecab/) as a
 tokenizer, install `groonga-tokenizer-mecab` package.
 
@@ -51,6 +72,8 @@ Install `groonga-tokenizer-mecab` package:
 ```bash
 sudo apt -V -y install groonga-tokenizer-mecab
 ```
+
+## `groonga-token-filter-stem` package
 
 If you want to use `TokenFilterStem` as a token filter, install
 `groonga-token-filter-stem` package.
@@ -61,6 +84,8 @@ Install groonga-token-filter-stem package:
 sudo apt -V -y install groonga-token-filter-stem
 ```
 
+## `groonga-munin-plugins` package
+
 There is a package that provides [Munin](http://munin-monitoring.org/)
 plugins. If you want to monitor Groonga status by Munin, install
 `groonga-munin-plugins` package.
@@ -70,6 +95,8 @@ Install `groonga-munin-plugins` package:
 ```bash
 sudo apt -V -y install groonga-munin-plugins
 ```
+
+## `groonga-normalizer-mysql` package
 
 There is a package that provides MySQL compatible normalizer as a
 Groonga plugin. If you want to use that one, install


### PR DESCRIPTION
GitHub: GH-2253

This is a first step to write the documentation to
recommend using packages.groonga.org instead of the
PPA.

Groonga packages for Ubuntu were available only
through the PPA on Launchpad (ppa:groonga/ppa).
Now packages are also distributed via our Groonga APT
repository at https://packages.groonga.org/.

Packages from our Groonga APT repository
(https://packages.groonga.org/) include Groonga built
with Apache Arrow enabled, which unlocks extra
features such as parallel offline index building.