### PR TITLE
docs: api/grn_content_type move grn_content_type enum reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_content_type.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_content_type.po
@@ -30,35 +30,5 @@ msgstr ""
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Here are available values:"
-msgstr "指定可能な値は以下の通りです。"
-
-msgid "It means that outputting nothing or using the original format. :doc:`/reference/commands/dump` uses the type."
-msgstr ""
-
-msgid "`GRN_CONTENT_NONE`"
-msgstr ""
-
-msgid "`GRN_CONTENT_TSV`"
-msgstr ""
-
-msgid "It means tab separated values format."
-msgstr ""
-
-msgid "`GRN_CONTENT_JSON`"
-msgstr ""
-
-msgid "It means JSON format."
-msgstr "JSON形式::"
-
-msgid "`GRN_CONTENT_XML`"
-msgstr ""
-
-msgid "It means XML format."
-msgstr ""
-
-msgid "`GRN_CONTENT_MSGPACK`"
-msgstr ""
-
-msgid "It means MessagePack format. You need MessagePack library on building Groonga. If you don't have MessagePack library, you can't use this type."
-msgstr ""
+msgid "We are currently switching to automatic generation using Doxygen."
+msgstr "現在、Doxygenを使った自動生成に切り替え中です。"

--- a/doc/source/reference/api/grn_content_type.rst
+++ b/doc/source/reference/api/grn_content_type.rst
@@ -17,23 +17,5 @@ Normally, you don't need to use this type. It is used internally in
 Reference
 ---------
 
-.. c:type:: grn_content_type
-
-   Here are available values:
-
-   `GRN_CONTENT_NONE`
-     It means that outputting nothing or using the original format.
-     :doc:`/reference/commands/dump` uses the type.
-
-   `GRN_CONTENT_TSV`
-     It means tab separated values format.
-
-   `GRN_CONTENT_JSON`
-     It means JSON format.
-
-   `GRN_CONTENT_XML`
-     It means XML format.
-
-   `GRN_CONTENT_MSGPACK`
-     It means MessagePack format. You need MessagePack library on building
-     Groonga. If you don't have MessagePack library, you can't use this type.
+.. note::
+   We are currently switching to automatic generation using Doxygen.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -242,7 +242,7 @@ typedef enum {
   GRN_CONTENT_GROONGA_COMMAND_LIST,
   /**
    * The content is in Apache Arrow format, specifically using the only IPC
-   * Streaming format, although Apache Arrow supports two IPC formats which are
+   * Streaming Format, although Apache Arrow supports two IPC Formats which are
    * the IPC Streaming Format and the IPC File Format. This requires that Apache
    * Arrow is available during Groonga's build process. Without it, this type
    * cannot be used.

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -222,26 +222,26 @@ grn_log_level_parse(const char *string, grn_log_level *level);
 /** \brief The input/output content format. */
 typedef enum {
   /**
-   * Output is in no specific format. This means that either no output is
-   * produced or the output remains in its original format.
+   * The content is in no specific format. This means that either no content is
+   * produced or the content remains in its original format.
    */
   GRN_CONTENT_NONE = 0,
-  /** Output is in a tab-separated values (TSV) format. */
+  /** The content is in a tab-separated values (TSV) format. */
   GRN_CONTENT_TSV,
-  /** Output is in JSON format. */
+  /** The content is in JSON format. */
   GRN_CONTENT_JSON,
-  /** Output is in XML format. */
+  /** The content is in XML format. */
   GRN_CONTENT_XML,
   /**
-   * Output is in MessagePack format. This requires that MessagePack is
+   * The content is in MessagePack format. This requires that MessagePack is
    * available during Groonga's build process. Without it, this type cannot be
    * used.
    */
   GRN_CONTENT_MSGPACK,
-  /** Output is a list of Groonga commands. */
+  /** The content is a list of Groonga commands. */
   GRN_CONTENT_GROONGA_COMMAND_LIST,
   /**
-   * Output is in Apache Arrow format. This requires that Apache Arrow is
+   * The content is in Apache Arrow format. This requires that Apache Arrow is
    * available during Groonga's build process. Without it, this type cannot be
    * used.
    */

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -241,9 +241,11 @@ typedef enum {
   /** The content is a list of Groonga commands. */
   GRN_CONTENT_GROONGA_COMMAND_LIST,
   /**
-   * The content is in Apache Arrow format. This requires that Apache Arrow is
-   * available during Groonga's build process. Without it, this type cannot be
-   * used.
+   * The content is in Apache Arrow format, specifically using the only IPC
+   * Streaming format, although Apache Arrow supports two IPC formats which are
+   * the IPC Streaming Format and the IPC File Format. This requires that Apache
+   * Arrow is available during Groonga's build process. Without it, this type
+   * cannot be used.
    */
   GRN_CONTENT_APACHE_ARROW
 } grn_content_type;

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -219,13 +219,32 @@ grn_log_level_parse(const char *string, grn_log_level *level);
    GRN_QUERY_LOG_SCORE)
 #define GRN_QUERY_LOG_DEFAULT GRN_QUERY_LOG_ALL
 
+/** \brief The input/output content format. */
 typedef enum {
+  /**
+   * Output is in no specific format. This means that either no output is
+   * produced or the output remains in its original format.
+   */
   GRN_CONTENT_NONE = 0,
+  /** Output is in a tab-separated values (TSV) format. */
   GRN_CONTENT_TSV,
+  /** Output is in JSON format. */
   GRN_CONTENT_JSON,
+  /** Output is in XML format. */
   GRN_CONTENT_XML,
+  /**
+   * Output is in MessagePack format. This requires that MessagePack is
+   * available during Groonga's build process. Without it, this type cannot be
+   * used.
+   */
   GRN_CONTENT_MSGPACK,
+  /** Output is a list of Groonga commands. */
   GRN_CONTENT_GROONGA_COMMAND_LIST,
+  /**
+   * Output is in Apache Arrow format. This requires that Apache Arrow is
+   * available during Groonga's build process. Without it, this type cannot be
+   * used.
+   */
   GRN_CONTENT_APACHE_ARROW
 } grn_content_type;
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.