### PR TITLE
docs: release: Update command to run in groonga/groonga.org

### DIFF
--- a/doc/source/contribution/development/release.rst
+++ b/doc/source/contribution/development/release.rst
@@ -268,7 +268,7 @@ forkしたリポジトリにて、pushされたブランチのGitHub Actionsが�
 .. code-block:: console
 
    $ cd ${GROONGA_ORG_PATH}
-   $ rake release:version:update
+   $ rake release
 
 Dockerイメージの更新
 --------------------


### PR DESCRIPTION
Can be released by `rake release` as well as groonga/groonga.
https://github.com/groonga/groonga.org/pull/96