### PR TITLE
expr_executor: operation slash: Separate cases by uintN_t

### DIFF
--- a/lib/expr_executor.cpp
+++ b/lib/expr_executor.cpp
@@ -252,16 +252,17 @@ namespace {
     }
   }
 
-  /* To avoid the following warning, which occur in uint32_t and uint64_t.
+  /* To avoid the following warning, which occur in uintN_t.
    *
    * warning C4146: unary minus operator applied to unsigned type, result still
    * unsigned
    */
   template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<!(std::is_same_v<X, uint32_t> ||
-                     std::is_same_v<X, uint64_t>) &&
-                     std::is_signed_v<Y> && std::is_integral_v<Y>,
-                   bool>
+  std::enable_if_t<
+    !(std::is_same_v<X, uint8_t> || std::is_same_v<X, uint16_t> ||
+      std::is_same_v<X, uint32_t> || std::is_same_v<X, uint64_t>) &&
+      std::is_signed_v<Y> && std::is_integral_v<Y>,
+    bool>
   numeric_arithmetic_binary_operation_execute_slash(grn_ctx *ctx,
                                                     X x,
                                                     Y y,
@@ -276,7 +277,8 @@ namespace {
   }
 
   template <typename RESULT_TYPE, typename X, typename Y>
-  std::enable_if_t<(std::is_same_v<X, uint32_t> ||
+  std::enable_if_t<(std::is_same_v<X, uint8_t> || std::is_same_v<X, uint16_t> ||
+                    std::is_same_v<X, uint32_t> ||
                     std::is_same_v<X, uint64_t>) &&
                      std::is_signed_v<Y> && std::is_integral_v<Y>,
                    bool>

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_float_one.expected
@@ -1,0 +1,11 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt16
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 65535}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1.0'
+[[0,0.0,0.0],[[[1],[["value","UInt16"],["value","UInt16"]],[65535,-65535.0]]]]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_float_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_float_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt16
+
+load --table Values
+[
+{"value": 65535}
+]
+
+select Values \
+  --output_columns 'value, value / -1.0'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_one.expected
@@ -1,0 +1,11 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt16
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 65535}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1'
+[[0,0.0,0.0],[[[1],[["value","UInt16"],["value","UInt16"]],[65535,-65535]]]]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint16_max_and_minus_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt16
+
+load --table Values
+[
+{"value": 65535}
+]
+
+select Values \
+  --output_columns 'value, value / -1'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_float_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_float_one.expected
@@ -1,0 +1,11 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt8
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 255}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1.0'
+[[0,0.0,0.0],[[[1],[["value","UInt8"],["value","UInt8"]],[255,-255.0]]]]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_float_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_float_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt8
+
+load --table Values
+[
+{"value": 255}
+]
+
+select Values \
+  --output_columns 'value, value / -1.0'

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_one.expected
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_one.expected
@@ -1,0 +1,11 @@
+table_create Values TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Values value COLUMN_SCALAR UInt8
+[[0,0.0,0.0],true]
+load --table Values
+[
+{"value": 255}
+]
+[[0,0.0,0.0],1]
+select Values   --output_columns 'value, value / -1'
+[[0,0.0,0.0],[[[1],[["value","UInt8"],["value","UInt8"]],[255,-255]]]]

--- a/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_one.test
+++ b/test/command/suite/select/filter/arithmetic_operation/slash/uint8_max_and_minus_one.test
@@ -1,0 +1,10 @@
+table_create Values TABLE_NO_KEY
+column_create Values value COLUMN_SCALAR UInt8
+
+load --table Values
+[
+{"value": 255}
+]
+
+select Values \
+  --output_columns 'value, value / -1'


### PR DESCRIPTION
Related Commit:
https://github.com/groonga/groonga/commit/138a586b597e136df33fffac30c031288c8bd949

`UInt8 / -1` and `UInt16 / -1` should also be negative.