### PR TITLE
docs: api/grn_expr move grn_expr_get_keywords reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
@@ -54,36 +54,6 @@ msgstr "TODO..."
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Extracts keywords from ``expr`` and stores to ``keywords``. Keywords in ``keywords`` are owned by ``expr``. Don't unlink them. Each keyword is ``GRN_BULK`` and its domain is ``GRN_DB_TEXT``."
-msgstr ""
-
-msgid "``keywords`` must be ``GRN_PVECTOR``."
-msgstr ""
-
-msgid "Here is an example code::"
-msgstr "以下はスキーマの例です。"
-
-msgid "The context that creates the ``expr``."
-msgstr ""
-
-msgid "The expression to be extracted."
-msgstr ""
-
-msgid "The container to store extracted keywords. It must be ``GRN_PVECTOR``.  Each extracted keyword is ``GRN_BULK`` and its domain is ``GRN_DB_TEXT``.  Extracted keywords are owned by ``expr``. Don't unlink them."
-msgstr ""
-
-msgid "The container to store extracted keywords. It must be ``GRN_PVECTOR``."
-msgstr ""
-
-msgid "Each extracted keyword is ``GRN_BULK`` and its domain is ``GRN_DB_TEXT``."
-msgstr ""
-
-msgid "Extracted keywords are owned by ``expr``. Don't unlink them."
-msgstr ""
-
-msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
-msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
 msgid "Escapes ``target_characters`` in ``string`` by ``escape_character``."
 msgstr "``string`` 中の ``target_characters`` を ``escape_character`` でエスケープします。"
 
@@ -104,6 +74,9 @@ msgstr "``target_characters`` の文字をエスケープする文字です。�
 
 msgid "The output of escaped ``string``. It should be text typed bulk."
 msgstr "エスケープされた ``string`` の出力先です。テキスト型のbulkでなければいけません。"
+
+msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
+msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
 
 msgid "Escapes special characters in :doc:`/reference/grn_expr/query_syntax`."
 msgstr ":doc:`/reference/grn_expr/query_syntax` にある特別な文字をエスケープします。"

--- a/doc/source/reference/api/grn_expr.rst
+++ b/doc/source/reference/api/grn_expr.rst
@@ -48,51 +48,6 @@ Reference
 
 .. c:function:: grn_rc grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs)
 
-.. c:function:: grn_rc grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords)
-
-   Extracts keywords from ``expr`` and stores to
-   ``keywords``. Keywords in ``keywords`` are owned by ``expr``. Don't
-   unlink them. Each keyword is ``GRN_BULK`` and its domain is
-   ``GRN_DB_TEXT``.
-
-   ``keywords`` must be ``GRN_PVECTOR``.
-
-   Here is an example code::
-
-      grn_obj keywords;
-      GRN_PTR_INIT(&keywords, GRN_OBJ_VECTOR, GRN_ID_NIL);
-      grn_expr_get_keywords(ctx, expr, &keywords);
-      {
-        int i, n_keywords;
-        n_keywords = GRN_BULK_VSIZE(&keywords) / sizeof(grn_obj *);
-        for (i = 0; i < n_keywords; i++) {
-          grn_obj *keyword = GRN_PTR_VALUE_AT(&keywords, i);
-          const char *keyword_content;
-          int keyword_size;
-          keyword_content = GRN_TEXT_VALUE(keyword);
-          keyword_size = GRN_TEXT_LEN(keyword);
-          /*
-            Use keyword_content and keyword_size.
-            You don't need to unlink keyword.
-            keyword is owned by expr.
-          */
-        }
-      }
-      GRN_OBJ_FIN(ctx, &keywords);
-
-
-   :param ctx: The context that creates the ``expr``.
-   :param expr: The expression to be extracted.
-   :param keywords: The container to store extracted keywords.
-                    It must be ``GRN_PVECTOR``.
-
-                    Each extracted keyword is ``GRN_BULK`` and its
-                    domain is ``GRN_DB_TEXT``.
-
-                    Extracted keywords are owned by ``expr``. Don't
-                    unlink them.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
 .. c:function:: grn_rc grn_expr_syntax_escape(grn_ctx *ctx, const char *string, int string_size, const char *target_characters, char escape_character, grn_obj *escaped_string)
 
    Escapes ``target_characters`` in ``string`` by ``escape_character``.

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -123,8 +123,10 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  * \param ctx The context object.
  * \param expr The expression object from which keywords will be extracted.
  * \param keywords The keywords container (typically a \ref GRN_PVECTOR) where
- *                 the extracted keywords will be stored. The extracted keywords
- *                 are owned by \p expr and should not be unlinked.
+ *                 the extracted keywords will be stored. Each extracted keyword
+ *                 is a \ref GRN_BULK whose domain is \ref GRN_DB_TEXT. The
+ *                 extracted keywords are owned by \p expr and should not be
+ *                 unlinked.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  */

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -103,7 +103,7 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  * ```c
  *  grn_obj keywords;
  *  GRN_PTR_INIT(&keywords, GRN_OBJ_VECTOR, GRN_ID_NIL);
- *  // You don't need to unlink keyword because it is owned by \p expr.
+ *  // You don't need to unlink keyword because it is owned by expr.
  *  grn_expr_get_keywords(ctx, expr, &keywords);
  *  {
  *    size_t i, n_keywords;

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -123,7 +123,7 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  * \param ctx The context object.
  * \param expr The expression object from which keywords will be extracted.
  * \param keywords The keywords container (typically a \ref GRN_PVECTOR) where
- *                 the extracted keywords will be stored.The extracted keywords
+ *                 the extracted keywords will be stored. The extracted keywords
  *                 are owned by \p expr and should not be unlinked.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -126,9 +126,8 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  * \param ctx The context object.
  * \param expr The expression object from which keywords will be extracted.
  * \param keywords The keywords container where the extracted keywords will be
- *                 be stored. Each extracted keyword is a \ref GRN_BULK whose
- *                 domain is \ref GRN_DB_TEXT. The extracted keywords are owned
- *                 by \p expr and should not be unlinked.
+ *                 be stored. Each extracted keyword's domain is
+ *                 \ref GRN_DB_TEXT.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  */

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -106,12 +106,12 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  *  // You don't need to unlink keyword because it is owned by \p expr.
  *  grn_expr_get_keywords(ctx, expr, &keywords);
  *  {
- *    int i, n_keywords;
- *    n_keywords = GRN_BULK_VSIZE(&keywords) / sizeof(grn_obj *);
+ *    size_t i, n_keywords;
+ *    n_keywords = GRN_PTR_VECTOR_SIZE(&keywords);
  *    for (i = 0; i < n_keywords; i++) {
  *      grn_obj *keyword = GRN_PTR_VALUE_AT(&keywords, i);
  *      const char *keyword_content;
- *      int keyword_size;
+ *      size_t keyword_size;
  *      keyword_content = GRN_TEXT_VALUE(keyword);
  *      keyword_size = GRN_TEXT_LEN(keyword);
  *      // Use keyword_content and keyword_size.

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -102,18 +102,21 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  * For example usage:
  * ```c
  *  grn_obj keywords;
- *  GRN_PTR_INIT(&keywords, GRN_OBJ_VECTOR, GRN_ID_NIL);
+ *  GRN_TEXT_INIT(&keywords, GRN_OBJ_VECTOR);
  *  // You don't need to unlink keyword because it is owned by expr.
  *  grn_expr_get_keywords(ctx, expr, &keywords);
  *  {
  *    size_t i, n_keywords;
- *    n_keywords = GRN_PTR_VECTOR_SIZE(&keywords);
+ *    n_keywords = grn_vector_size(ctx, &keywords);
  *    for (i = 0; i < n_keywords; i++) {
- *      grn_obj *keyword = GRN_PTR_VALUE_AT(&keywords, i);
  *      const char *keyword_content;
  *      size_t keyword_size;
- *      keyword_content = GRN_TEXT_VALUE(keyword);
- *      keyword_size = GRN_TEXT_LEN(keyword);
+ *      keyword_size = grn_vector_get_element(ctx,
+ *                                            &keywords,
+ *                                            i,
+ *                                            &keyword_content,
+ *                                            NULL,
+ *                                            NULL);
  *      // Use keyword_content and keyword_size.
  *    }
  *  }
@@ -122,11 +125,10 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
  *
  * \param ctx The context object.
  * \param expr The expression object from which keywords will be extracted.
- * \param keywords The keywords container (typically a \ref GRN_PVECTOR) where
- *                 the extracted keywords will be stored. Each extracted keyword
- *                 is a \ref GRN_BULK whose domain is \ref GRN_DB_TEXT. The
- *                 extracted keywords are owned by \p expr and should not be
- *                 unlinked.
+ * \param keywords The keywords container where the extracted keywords will be
+ *                 be stored. Each extracted keyword is a \ref GRN_BULK whose
+ *                 domain is \ref GRN_DB_TEXT. The extracted keywords are owned
+ *                 by \p expr and should not be unlinked.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
  */

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -96,6 +96,38 @@ grn_expr_append_const_float(
 GRN_API grn_rc
 grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
 
+/**
+ * \brief Extract keywords from an expression.
+ *
+ * For example usage:
+ * ```c
+ *  grn_obj keywords;
+ *  GRN_PTR_INIT(&keywords, GRN_OBJ_VECTOR, GRN_ID_NIL);
+ *  // You don't need to unlink keyword because it is owned by \p expr.
+ *  grn_expr_get_keywords(ctx, expr, &keywords);
+ *  {
+ *    int i, n_keywords;
+ *    n_keywords = GRN_BULK_VSIZE(&keywords) / sizeof(grn_obj *);
+ *    for (i = 0; i < n_keywords; i++) {
+ *      grn_obj *keyword = GRN_PTR_VALUE_AT(&keywords, i);
+ *      const char *keyword_content;
+ *      int keyword_size;
+ *      keyword_content = GRN_TEXT_VALUE(keyword);
+ *      keyword_size = GRN_TEXT_LEN(keyword);
+ *      // Use keyword_content and keyword_size.
+ *    }
+ *  }
+ *  GRN_OBJ_FIN(ctx, &keywords);
+ * ```
+ *
+ * \param ctx The context object.
+ * \param expr The expression object from which keywords will be extracted.
+ * \param keywords The keywords container (typically a \ref GRN_PVECTOR) where
+ *                 the extracted keywords will be stored.The extracted keywords
+ *                 are owned by \p expr and should not be unlinked.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ */
 GRN_API grn_rc
 grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
 


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.