### PR TITLE
test: command_line: Fix encoding conversion of logs

### DIFF
--- a/test/command_line/helper/command_runner.rb
+++ b/test/command_line/helper/command_runner.rb
@@ -220,6 +220,11 @@ failed to run: #{command_line.join(" ").encode("UTF-8")}
 
   def read_log(log_path)
     return "" unless log_path.exist?
-    log_path.read.encode("UTF-8", "locale")
+    if windows?
+      # For Windows, Windows-31J is required to be specified to be converted.
+      log_path.read.encode("UTF-8", "Windows-31J")
+    else
+      log_path.read.encode("UTF-8", "locale")
+    end
   end
 end


### PR DESCRIPTION
On Windows, `log_path.read.encoding` is UTF-8, but the characters may be broken.
In such a case, conversion with `encode("UTF-8", "Windows-31J")` will result in the expected encoding.

Even if the encoding of the log is UTF-8, the result of `encode("UTF-8", "Windows-31J")` will not be broken.