### PR TITLE
docs: api/grn_expr move grn_expr_syntax_escape reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
@@ -54,30 +54,6 @@ msgstr "TODO..."
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Escapes ``target_characters`` in ``string`` by ``escape_character``."
-msgstr "``string`` 中の ``target_characters`` を ``escape_character`` でエスケープします。"
-
-msgid "Its encoding must be the same encoding of ``string``. It is used for allocating buffer for ``escaped_string``."
-msgstr "エンコーディングは ``string`` と同じでなければいけません。 ``escaped_string`` 用のバッファを確保するために使います。"
-
-msgid "String expression representation."
-msgstr "文字列式表現"
-
-msgid "The byte size of ``string``. ``-1`` means ``string`` is NULL terminated string."
-msgstr "``string`` のバイトサイズです。 ``-1`` を指定した場合は ``string`` がNULL終端文字列であるという意味になります。"
-
-msgid "NULL terminated escape target characters. For example, ``\"+-><~*()\\\"\\\\:\"`` is ``target_characters`` for :doc:`/reference/grn_expr/query_syntax`."
-msgstr "NULL終端されたエスケープ対象文字。たとえば、 :doc:`/reference/grn_expr/query_syntax` 用の ``target_characters`` は ``\"+-><~*()\\\"\\\\:\"`` になります。"
-
-msgid "The character to use escape a character in ``target_characters``. For example, ``\\\\`` (backslash) is ``escaped_character`` for :doc:`/reference/grn_expr/query_syntax`."
-msgstr "``target_characters`` の文字をエスケープする文字です。たとえば、 :doc:`/reference/grn_expr/query_syntax` 用の ``escaped_character`` は ``\\\\`` （バックスラッシュ）になります。"
-
-msgid "The output of escaped ``string``. It should be text typed bulk."
-msgstr "エスケープされた ``string`` の出力先です。テキスト型のbulkでなければいけません。"
-
-msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
-msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"
-
 msgid "Escapes special characters in :doc:`/reference/grn_expr/query_syntax`."
 msgstr ":doc:`/reference/grn_expr/query_syntax` にある特別な文字をエスケープします。"
 
@@ -92,3 +68,6 @@ msgstr "``query`` のバイトサイズです。 ``-1`` を指定した場合は
 
 msgid "The output of escaped ``query``. It should be text typed bulk."
 msgstr "エスケープされた ``query`` の出力。テキスト型用のbulkを返す。"
+
+msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
+msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"

--- a/doc/source/reference/api/grn_expr.rst
+++ b/doc/source/reference/api/grn_expr.rst
@@ -48,27 +48,6 @@ Reference
 
 .. c:function:: grn_rc grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs)
 
-.. c:function:: grn_rc grn_expr_syntax_escape(grn_ctx *ctx, const char *string, int string_size, const char *target_characters, char escape_character, grn_obj *escaped_string)
-
-   Escapes ``target_characters`` in ``string`` by ``escape_character``.
-
-   :param ctx: Its encoding must be the same encoding of ``string``.
-               It is used for allocating buffer for ``escaped_string``.
-   :param string: String expression representation.
-   :param string_size: The byte size of ``string``. ``-1`` means ``string``
-                       is NULL terminated string.
-   :param target_characters: NULL terminated escape target characters.
-                             For example, ``"+-><~*()\"\\:"`` is
-                             ``target_characters`` for
-                             :doc:`/reference/grn_expr/query_syntax`.
-   :param escape_character: The character to use escape a character in
-                            ``target_characters``. For example, ``\\``
-                            (backslash) is ``escaped_character`` for
-                            :doc:`/reference/grn_expr/query_syntax`.
-   :param escaped_string: The output of escaped ``string``. It should be
-                          text typed bulk.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
 .. c:function:: grn_rc grn_expr_syntax_escape_query(grn_ctx *ctx, const char *query, int query_size, grn_obj *escaped_query)
 
    Escapes special characters in

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -143,10 +143,10 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
  * \param query_size The byte size of \p query. A value of -1 indicates that
  *                   the query is null-terminated.
  * \param target_characters A null-terminated string containing the characters
- *                          to be escaped. For example, "+-><~*()\"\\:" is used
- *                          for query syntax.
+ *                          to be escaped. For example, `"+-><~*()\"\\:"` is
+ *                          used for query syntax.
  * \param escape_character The character to use for escaping characters found
- *                         in \p target_characters. For example, "\\"
+ *                         in \p target_characters. For example, `"\\"`
  *                         (backslash) is used.
  * \param escaped_query The buffer where the escaped query is stored.
  *

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -141,8 +141,8 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
  *            \p query.
  * \param query The input query to be escaped.
  * \param query_size The byte size of \p query. A value of -1 indicates that
- *                   the query is NULL terminated.
- * \param target_characters A NULL terminated string containing the characters
+ *                   the query is null-terminated.
+ * \param target_characters A null-terminated string containing the characters
  *                          to be escaped. For example, "+-><~*()\"\\:" is used
  *                          for query syntax.
  * \param escape_character The character to use for escaping characters found

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -134,6 +134,27 @@ grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs);
 GRN_API grn_rc
 grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
 
+/**
+ * \brief Escape target characters in a query by a specified escape character.
+ *
+ * \param ctx The context object. Its encoding must match that of the input
+ *            \p query.
+ * \param query The input query to be escaped.
+ * \param query_size The byte size of \p query. A value of -1 indicates that
+ *                   the query is NULL terminated.
+ * \param target_characters A NULL terminated string containing the characters
+ *                          to be escaped. For example, "+-><~*()\"\\:" is used
+ *                          for query syntax.
+ * \param escape_character The character to use for escaping characters found
+ *                         in \p target_characters. For example, "\\"
+ *                         (backslash) is used.
+ * \param escaped_query The buffer where the escaped query is stored.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *
+ * \see
+ * https://groonga.org/docs/reference/grn_expr/query_syntax.html
+ */
 GRN_API grn_rc
 grn_expr_syntax_escape(grn_ctx *ctx,
                        const char *query,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.