### PR TITLE
Use `offsetof()` for Groonga record and hash entry size calculations

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1506,7 +1506,7 @@ calc_rec_size(grn_table_flags flags,
       break;
     }
     *value_size =
-      (uintptr_t)GRN_RSET_SUBRECS_NTH((((grn_rset_recinfo *)0)->subrecs),
+      (uintptr_t)GRN_RSET_SUBRECS_NTH(offsetof(grn_rset_recinfo, subrecs),
                                       *subrec_size,
                                       max_n_subrecs);
   } else {

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -1775,16 +1775,16 @@ grn_io_hash_calculate_entry_size(uint32_t key_size, uint32_t value_size,
 {
   if (flags & GRN_OBJ_KEY_VAR_SIZE) {
     if (flags & GRN_OBJ_KEY_LARGE) {
-      return (uintptr_t)((grn_io_hash_entry_large *)0)->value + value_size;
+      return offsetof(grn_io_hash_entry_large, value) + value_size;
     } else {
-      return (uintptr_t)((grn_io_hash_entry_normal *)0)->value + value_size;
+      return offsetof(grn_io_hash_entry_normal, value) + value_size;
     }
   } else {
     if (key_size == sizeof(uint32_t)) {
-      return (uintptr_t)((grn_plain_hash_entry *)0)->value + value_size;
+      return offsetof(grn_plain_hash_entry, value) + value_size;
     } else {
       return (uint32_t)(
-        (uintptr_t)((grn_rich_hash_entry *)0)->key_and_value +
+        offsetof(grn_rich_hash_entry, key_and_value) +
         key_size +
         value_size);
     }
@@ -1933,14 +1933,14 @@ grn_tiny_hash_calculate_entry_size(uint32_t key_size, uint32_t value_size,
 {
   uint32_t entry_size;
   if (flags & GRN_OBJ_KEY_VAR_SIZE) {
-    entry_size = (uintptr_t)((grn_tiny_hash_entry *)0)->value + value_size;
+    entry_size = offsetof(grn_tiny_hash_entry, value) + value_size;
   } else {
     if (key_size == sizeof(uint32_t)) {
-      entry_size = (uintptr_t)((grn_plain_hash_entry *)0)->value + value_size;
+      entry_size = offsetof(grn_plain_hash_entry, value) + value_size;
     } else {
       entry_size =
         (uint32_t)(
-          (uintptr_t)((grn_rich_hash_entry *)0)->key_and_value +
+          offsetof(grn_rich_hash_entry, key_and_value) +
           key_size +
           value_size);
     }

--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -15480,7 +15480,7 @@ grn_ii_builder_options_fix(grn_ii_builder_options *options)
 }
 
 #define GRN_II_BUILDER_TERM_INPLACE_SIZE                                       \
-  (sizeof(grn_ii_builder_term) - (uintptr_t)&((grn_ii_builder_term *)0)->dummy)
+  (sizeof(grn_ii_builder_term) - offsetof(grn_ii_builder_term, dummy))
 
 typedef struct {
   grn_id rid;   /* Last record ID */


### PR DESCRIPTION
GitHub: ref https://github.com/MariaDB/server/pull/3932
GitHub: GH-2273

This changes replace unsafe pointer arithmetic with `offsetof()` for calculating structure field offsets.
And they also fix the following runtime errors.

- runtime error: member access within null pointer of type 'grn_plain_hash_entry'
- runtime error: member access within null pointer of type 'grn_tiny_hash_entry'
- runtime error: member access within null pointer of type 'grn_io_hash_entry_normal'
- runtime error: member access within null pointer of type 'grn_io_hash_entry_large'
- runtime error: member access within null pointer of type 'grn_rich_hash_entry'
- runtime error: member access within null pointer of type 'grn_ii_builder_term'
- runtime error: member access within null pointer of type 'grn_rset_recinfo'