### PR TITLE
doc install/ubuntu: remove deprecated PPA steps

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -53,10 +53,10 @@ msgid "Install `groonga-apt-source` to enable Groonga APT repository."
 msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリーを登録できます。"
 
 msgid "Deprecated Groonga PPA (Personal Package Archive)"
-msgstr "非推奨なPPA（Personal Package Archive）"
+msgstr "非推奨なGroonga PPA（Personal Package Archive）"
 
-msgid "The PPA is deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building. If you are currently using the Groonga PPA, please see {ref}`migrate-from-ppa-to-apt-repository`."
-msgstr "Groonga PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリーの利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。Groonga PPAを利用されている場合は、{ref}`migrate-from-ppa-to-apt-repository`を確認してください。"
+msgid "The Grppmga PPA (Personal Package Archive, ppa:groonga/ppa) is deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building. If you are currently using the Groonga PPA, please see {ref}`migrate-from-ppa-to-apt-repository`."
+msgstr "Groonga PPA（Personal Package Archive, ppa:groonga/ppa）は非推奨となります。ご利用の場合は、Groonga APTリポジトリーの利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。Groonga PPAを利用されている場合は、{ref}`migrate-from-ppa-to-apt-repository`を確認してください。"
 
 msgid "`groonga` package"
 msgstr "`groonga`パッケージ"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -55,8 +55,8 @@ msgstr "`groonga-apt-source`をインストールすることで、Groonga APT�
 msgid "Deprecated Groonga PPA (Personal Package Archive)"
 msgstr "非推奨なPPA（Personal Package Archive）"
 
-msgid "The PPA is deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building. If you are currently using the Groonga PPA, please see [Migration from Groonga PPA to Groonga APT Repository](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org)."
-msgstr "Groonga PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリーの利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。Groonga PPAを利用されている場合は、[Groonga PPAからGroonga APTリポジトリーへの移行](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org)を確認してください。"
+msgid "The PPA is deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building. If you are currently using the Groonga PPA, please see {ref}`migrate-from-ppa-to-apt-repository`."
+msgstr "Groonga PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリーの利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。Groonga PPAを利用されている場合は、{ref}`migrate-from-ppa-to-apt-repository`を確認してください。"
 
 msgid "`groonga` package"
 msgstr "`groonga`パッケージ"

--- a/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
+++ b/doc/locale/ja/LC_MESSAGES/install/ubuntu.po
@@ -43,8 +43,8 @@ msgstr "32-bit用と64-bit用のパッケージを配布していますが、サ
 msgid "Register Groonga APT repository"
 msgstr "GroongaのAPTリポジトリー登録"
 
-msgid "APT Repository (packages.groonga.org)"
-msgstr "APTリポジトリー（packages.groonga.org）"
+msgid "Groonga APT Repository (packages.groonga.org)"
+msgstr "Groonga APTリポジトリー（packages.groonga.org）"
 
 msgid "Groonga packages are distributed via our Groonga APT repository at https://packages.groonga.org."
 msgstr "Groongaパッケージは、Groonga APTリポジトリー（https://packages.groonga.org）にて配布されています。"
@@ -52,29 +52,11 @@ msgstr "Groongaパッケージは、Groonga APTリポジトリー（https://pack
 msgid "Install `groonga-apt-source` to enable Groonga APT repository."
 msgstr "`groonga-apt-source`をインストールすることで、Groonga APTリポジトリーを登録できます。"
 
-msgid "PPA (Personal Package Archive)"
-msgstr "PPA（Personal Package Archive）"
+msgid "Deprecated Groonga PPA (Personal Package Archive)"
+msgstr "非推奨なPPA（Personal Package Archive）"
 
-msgid "The PPA will be deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building."
-msgstr "PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリー（packages.groonga.org）の利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。"
-
-msgid "The Groonga APT repository for Ubuntu uses PPA (Personal Package Archive) on Launchpad. You can install Groonga by APT from the PPA."
-msgstr "Ubuntu用のGroongaのAPTリポジトリーはLaunchpad上のPPA（Personal Package Archive）を使っています。このPPAからAPTでGroongaをインストールできます。"
-
-msgid "Here are supported Ubuntu versions:"
-msgstr "サポートしているUbuntuのバージョンは次の通りです。"
-
-msgid "22.04 LTS Jammy Jellyfish"
-msgstr ""
-
-msgid "24.04 LTS Noble Numbat"
-msgstr ""
-
-msgid "Enable the universe repository to install Groonga:"
-msgstr "Groongaをインストールするためにuniverseリポジトリを有効にしてください。"
-
-msgid "Add the `ppa:groonga/ppa` PPA to your system:"
-msgstr "`ppa:groonga/ppa` PPAをシステムに登録します。"
+msgid "The PPA is deprecated. We strongly recommend using our Groonga APT repository (packages.groonga.org) because packages from that repository are built with Apache Arrow enabled. This configuration unlocks extra features, such as parallel offline index building. If you are currently using the Groonga PPA, please see [Migration from Groonga PPA to Groonga APT Repository](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org)."
+msgstr "Groonga PPAは非推奨となります。ご利用の場合は、Groonga APTリポジトリーの利用を強くお勧めします。なぜなら、Groonga APTリポジトリーではApache Arrowが有効な状態でビルドされたパッケージが提供されており、これにより並列オフラインインデックス構築などの追加機能が利用可能になるためです。Groonga PPAを利用されている場合は、[Groonga PPAからGroonga APTリポジトリーへの移行](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org)を確認してください。"
 
 msgid "`groonga` package"
 msgstr "`groonga`パッケージ"

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,6 +91,25 @@ myst_enable_extensions = [
   "tasklist",
 ]
 
+# Workaround to suppress warnings for missing cross-reference targets when using
+# internal page links with the MyST parser although we specified the
+# myst_heading_anchors option.
+#
+# When linking to sections within the same document, MyST may generate warnings
+# such as:
+#
+#   WARNING: 'myst' cross-reference target not found: 'link' [myst.xref_missing]
+#
+# This warning occurs because MyST parser could not refer to the heading targets
+# when generating the targets in building steps. Despite the warning, the link
+# targets are correctly rendered in the final documentation.
+#
+# If the behavior of MyST or our handling of anchor generation changes in the
+# future, this workaround may need to be revisited.
+suppress_warnings = [
+  "myst.xref_missing"
+]
+
 # The encoding of source files.
 #source_encoding = 'utf-8'
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -91,25 +91,6 @@ myst_enable_extensions = [
   "tasklist",
 ]
 
-# Workaround to suppress warnings for missing cross-reference targets when using
-# internal page links with the MyST parser although we specified the
-# myst_heading_anchors option.
-#
-# When linking to sections within the same document, MyST may generate warnings
-# such as:
-#
-#   WARNING: 'myst' cross-reference target not found: 'link' [myst.xref_missing]
-#
-# This warning occurs because MyST parser could not refer to the heading targets
-# when generating the targets in building steps. Despite the warning, the link
-# targets are correctly rendered in the final documentation.
-#
-# If the behavior of MyST or our handling of anchor generation changes in the
-# future, this workaround may need to be revisited.
-suppress_warnings = [
-  "myst.xref_missing"
-]
-
 # The encoding of source files.
 #source_encoding = 'utf-8'
 

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -29,10 +29,10 @@ sudo apt update
 ### Deprecated Groonga PPA (Personal Package Archive)
 
 ```{note}
-The PPA is deprecated. We strongly recommend using our Groonga APT
-repository (packages.groonga.org) because packages from that repository are built
-with Apache Arrow enabled. This configuration unlocks extra features, such as
-parallel offline index building.
+The Grppmga PPA (Personal Package Archive, ppa:groonga/ppa) is deprecated. We
+strongly recommend using our Groonga APT repository (packages.groonga.org)
+because packages from that repository are built with Apache Arrow enabled. This
+configuration unlocks extra features, such as parallel offline index building.
 If you are currently using the Groonga PPA, please see
 {ref}`migrate-from-ppa-to-apt-repository`.
 ```

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -11,7 +11,7 @@ size data.
 
 ## Register Groonga APT repository
 
-### APT Repository (packages.groonga.org)
+### Groonga APT Repository (packages.groonga.org)
 
 Groonga packages are distributed via our Groonga APT repository at
 https://packages.groonga.org.
@@ -26,35 +26,15 @@ sudo apt install -y -V ./groonga-apt-source-latest-$(lsb_release --codename --sh
 sudo apt update
 ```
 
-### PPA (Personal Package Archive)
+### Deprecated Groonga PPA (Personal Package Archive)
 
 ```{note}
-The PPA will be deprecated. We strongly recommend using our Groonga APT
+The PPA is deprecated. We strongly recommend using our Groonga APT
 repository (packages.groonga.org) because packages from that repository are built
 with Apache Arrow enabled. This configuration unlocks extra features, such as
 parallel offline index building.
-```
-
-The Groonga APT repository for Ubuntu uses PPA (Personal Package
-Archive) on Launchpad. You can install Groonga by APT from the PPA.
-
-Here are supported Ubuntu versions:
-
-- 22.04 LTS Jammy Jellyfish
-- 24.04 LTS Noble Numbat
-
-Enable the universe repository to install Groonga:
-
-```bash
-sudo apt -V -y install software-properties-common
-sudo add-apt-repository -y universe
-```
-
-Add the `ppa:groonga/ppa` PPA to your system:
-
-```bash
-sudo add-apt-repository -y ppa:groonga/ppa
-sudo apt update
+If you are currently using the Groonga PPA, please see [Migration from Groonga
+PPA to Groonga APT Repository](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org).
 ```
 
 ## `groonga` package

--- a/doc/source/install/ubuntu.md
+++ b/doc/source/install/ubuntu.md
@@ -33,8 +33,8 @@ The PPA is deprecated. We strongly recommend using our Groonga APT
 repository (packages.groonga.org) because packages from that repository are built
 with Apache Arrow enabled. This configuration unlocks extra features, such as
 parallel offline index building.
-If you are currently using the Groonga PPA, please see [Migration from Groonga
-PPA to Groonga APT Repository](#migration-from-groonga-ppa-ppa-groonga-ppa-to-groonga-apt-repository-packages-groonga-org).
+If you are currently using the Groonga PPA, please see
+{ref}`migrate-from-ppa-to-apt-repository`.
 ```
 
 ## `groonga` package
@@ -100,6 +100,8 @@ sudo apt -V -y install groonga-normalizer-mysql
 Build from source is for developers.
 
 See {doc}`/install/cmake` .
+
+(migrate-from-ppa-to-apt-repository)=
 
 ## Migration from Groonga PPA (ppa:groonga/ppa) to Groonga APT Repository (packages.groonga.org)
 


### PR DESCRIPTION
GitHub: GH-2253

We plan to gradually migrate Ubuntu package provisioning from the old PPA (ppa:groonga/ppa) to the new repository at packages.groonga.org. So we want to update our documentation to recommend using packages.groonga.org instead of the PPA.

- [x] Remove PPA section from ubuntu.md and add link to migration step documentation.