### PR TITLE
docs: remove needless prettier-ignore

### DIFF
--- a/doc/source/contribution/documentation/introduction.md
+++ b/doc/source/contribution/documentation/introduction.md
@@ -77,10 +77,9 @@ Each page of the documentation corresponds to a `.rst` file or a `.md` file. By 
 For Example, if you want to edit this {doc}`introduction` page, you should edit the `doc/source/contribution/documentation/introduction.rst` file.
 Please find the file you wish to edit and make your changes.
 
-<!-- prettier-ignore-start -->
 (how-to-add-new-documentation)=
+
 ## How to add a new documentation
-<!-- prettier-ignore-end -->
 
 If you want to add a new documentation, you need to add the new documentation into `doc/files.am` and `doc/files.cmake` by the following command lines.
 

--- a/doc/source/news/13.md
+++ b/doc/source/news/13.md
@@ -1,9 +1,8 @@
 # News - 13 series
 
-<!-- prettier-ignore-start -->
 (release-13-1-1)=
+
 ## Release 13.1.1 - 2024-01-09
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -18,10 +17,9 @@
   Groonga 13.1.0 for Windows didn't include `groonga-normalizer-mysql`.
   This problem only occured in Groonga 13.1.0.
 
-<!-- prettier-ignore-start -->
 (release-13-1-0)=
+
 ## Release 13.1.0 - 2023-12-26
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -136,10 +134,9 @@
     --match_escalation_threshold -1
   ```
 
-<!-- prettier-ignore-start -->
 (release-13-0-9)=
+
 ## Release 13.0.9 - 2023-10-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -419,10 +416,9 @@
 
 - yssrku
 
-<!-- prettier-ignore-start -->
 (release-13-0-8)=
+
 ## Release 13.0.8 - 2023-09-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -481,10 +477,9 @@
     --output_columns '_score, content'
   ```
 
-<!-- prettier-ignore-start -->
 (release-13-0-7)=
+
 ## Release 13.0.7 - 2023-09-12
-<!-- prettier-ignore-end -->
 
 ### Fixes
 
@@ -650,10 +645,9 @@
   ]
   ```
 
-<!-- prettier-ignore-start -->
 (release-13-0-6)=
+
 ## Release 13.0.6 - 2023-08-31
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -765,10 +759,9 @@
 
   For example, this bug occures when we specify as highlight target both of keyword with the number of characters is one and keyword with the number of characters is two.
 
-<!-- prettier-ignore-start -->
 (release-13-0-5)=
+
 ## Release 13.0.5 - 2023-08-02
-<!-- prettier-ignore-end -->
 
 ### Fixes
 
@@ -799,10 +792,9 @@
   select Entries   --match_columns content   --query '*NPP2"(a b))"'   --output_columns '_score, content'
   ```
 
-<!-- prettier-ignore-start -->
 (release-13-0-4)=
+
 ## Release 13.0.4 - 2023-07-26
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -816,10 +808,9 @@
 - [CMake] Fixed a bug that some errors may be reported when CMake 3.16
   or 3.17 are used.
 
-<!-- prettier-ignore-start -->
 (release-13-0-3)=
+
 ## Release 13.0.3 - 2023-07-24
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -852,10 +843,9 @@
 
 - Fixed a bug that the source archive can't be built with CMake.
 
-<!-- prettier-ignore-start -->
 (release-13-0-2)=
+
 ## Release 13.0.2 - 2023-07-12
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -978,10 +968,9 @@
 
 - ZangRuochen
 
-<!-- prettier-ignore-start -->
 (release-13-0-1)=
+
 ## Release 13.0.1 - 2023-03-24
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -1577,10 +1566,9 @@
 
 - Carlo Cabrera
 
-<!-- prettier-ignore-start -->
 (release-13-0-0)=
+
 ## Release 13.0.0 - 2023-02-09
-<!-- prettier-ignore-end -->
 
 This is a major version up!
 But It keeps backward compatibility. We can upgrade to 13.0.0 without rebuilding database.

--- a/doc/source/news/14.md
+++ b/doc/source/news/14.md
@@ -1,9 +1,8 @@
 # News - 14 series
 
-<!-- prettier-ignore-start -->
 (release-14-1-3)=
+
 ## Release 14.1.3 - 2025-01-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -125,10 +124,9 @@ This bug exists since {ref}`release-10-1-1`.
 
 - Yuki Shira
 
-<!-- prettier-ignore-start -->
 (release-14-1-2)=
+
 ## Release 14.1.2 - 2024-12-24
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -157,10 +155,9 @@ If a reference vector column uses 32-bit floating number weight and a
 new value is a no weight reference vector, Groonga must cast the new
 value. But it was not done.
 
-<!-- prettier-ignore-start -->
 (release-14-1-1)=
+
 ## Release 14.1.1 - 2024-12-03
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -227,10 +224,9 @@ If the given pattern is an empty string, there were some problems:
 
 Now, Groonga returns an empty result for an empty pattern.
 
-<!-- prettier-ignore-start -->
 (release-14-1-0)=
+
 ## Release 14.1.0 - 2024-11-05
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -367,19 +363,17 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
 
 {doc}`/reference/commands/index_column_diff` reports a missing record when a single record contains more than 131,072 instances of the same token. This release fixed this problem.
 
-<!-- prettier-ignore-start -->
 (release-14-0-9)=
+
 ## Release 14.0.9 - 2024-09-27
-<!-- prettier-ignore-end -->
 
 ### Fixes
 
 - Fixed build error when we build from source on Alpine Linux 3.20.
 
-<!-- prettier-ignore-start -->
 (release-14-0-8)=
+
 ## Release 14.0.8 - 2024-09-25
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -400,10 +394,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
 - takoyaki-nyokki
 - Watson
 
-<!-- prettier-ignore-start -->
 (release-14-0-7)=
+
 ## Release 14.0.7 - 2024-09-03
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -523,10 +516,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
 - Man Hoang
 - Biswapriyo Nath
 
-<!-- prettier-ignore-start -->
 (release-14-0-6)=
+
 ## Release 14.0.6 - 2024-07-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -592,10 +584,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
 
 - [{doc}`/install/debian`] Dropped support for Debian 11 (bullseye).
 
-<!-- prettier-ignore-start -->
 (release-14-0-5)=
+
 ## Release 14.0.5 - 2024-07-04
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -730,10 +721,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
   ]
   ```
 
-<!-- prettier-ignore-start -->
 (release-14-0-4)=
+
 ## Release 14.0.4 - 2024-05-29
-<!-- prettier-ignore-end -->
 
 ### Fixes
 
@@ -840,10 +830,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
   ]
   ```
 
-<!-- prettier-ignore-start -->
 (release-14-0-3)=
+
 ## Release 14.0.3 - 2024-05-09
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -1225,10 +1214,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
     ]
     ```
 
-<!-- prettier-ignore-start -->
 (release-14-0-2)=
+
 ## Release 14.0.2 - 2024-03-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -1246,10 +1234,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
   Therefore, we reduce log level to `debug` for the log since this release.
   Thus, this log does not output when PGroonga start in default.
 
-<!-- prettier-ignore-start -->
 (release-14-0-1)=
+
 ## Release 14.0.1 - 2024-03-14
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -1355,10 +1342,9 @@ You can use {doc}`/reference/commands/index_column_diff` to detect index corrupt
 
 - windymelt
 
-<!-- prettier-ignore-start -->
 (release-14-0-0)=
+
 ## Release 14.0.0 - 2024-02-29
-<!-- prettier-ignore-end -->
 
 This is a major version up!
 But It keeps backward compatibility. We can upgrade to 14.0.0 without rebuilding database.

--- a/doc/source/news/15.md
+++ b/doc/source/news/15.md
@@ -1,9 +1,8 @@
 # News - 15 series
 
-<!-- prettier-ignore-start -->
 (release-15-0-4)=
+
 ## Release 15.0.4 - 2025-03-29
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -17,10 +16,9 @@ may not return `-X` when `X` is unsigned integer.
 This is a backward incompatible change but we assume that no user
 depends on this behavior.
 
-<!-- prettier-ignore-start -->
 (release-15-0-3)=
+
 ## Release 15.0.3 - 2025-03-10
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -41,10 +39,9 @@ not so effective. Parallel offline index construction with
 sequential offline index construction with {ref}`table-hash-key`
 lexicon.
 
-<!-- prettier-ignore-start -->
 (release-15-0-2)=
+
 ## Release 15.0.2 - 2025-02-21
-<!-- prettier-ignore-end -->
 
 ### Fixes
 
@@ -66,10 +63,9 @@ happens, the offline index construction is failed. Because
 {doc}`/reference/normalizers/normalizer_table` has a required
 parameter. If options are ignored, the required parameter is missing.
 
-<!-- prettier-ignore-start -->
 (release-15-0-1)=
+
 ## Release 15.0.1 - 2025-02-20
-<!-- prettier-ignore-end -->
 
 ### Improvements
 
@@ -78,10 +74,9 @@ parameter. If options are ignored, the required parameter is missing.
 Ubuntu 20.04 will reach EOL in May 2025, so support for it has been dropped
 starting with this release.
 
-<!-- prettier-ignore-start -->
 (release-15-0-0)=
+
 ## Release 15.0.0 - 2025-02-09
-<!-- prettier-ignore-end -->
 
 This is our annual major release! This release doesn't have any
 backward incompatible changes! So you can upgrade Groonga without


### PR DESCRIPTION
GitHub: https://github.com/groonga/groonga/pull/2271#discussion_r2034482549

It seems that recent MyST-Parser accepts the following Prettier style format as reference directive(?):

```markdown
(XXX)=

# XXX
```

So we can remove these `prettier-ignore`. 