### PR TITLE
Fix Apache Arrow output for slice and drilldown

### DIFF
--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4602,6 +4602,9 @@ static grn_select_output_formatter grn_select_output_formatter_v1 = {
 static void
 grn_select_output_slices_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_CSTR("slices");
 }
 
@@ -4630,6 +4633,9 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
 static void
 grn_select_output_drilldowns_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_CSTR("drilldowns");
 }
 
@@ -4652,6 +4658,9 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
 }
 

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4627,6 +4627,9 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
                                  grn_select_data *data,
                                  Slice *slice)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 

--- a/test/command/suite/select/command_version/3/apache_arrow/drilldowns.expected
+++ b/test/command/suite/select/command_version/3/apache_arrow/drilldowns.expected
@@ -1,0 +1,52 @@
+table_create Documents TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Documents tag1 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Documents tag2 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+[[0,0.0,0.0],1]
+select Documents   --drilldown tag1,tag2   --command_version 3   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+tag1: string
+tag2: string
+-- metadata --
+GROONGA:n_hits: 1
+	     _id	  tag1	  tag2
+	(uint32)	(utf8)	(utf8)
+0	       1	1     	2     
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	1     	        1
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	2     	        1

--- a/test/command/suite/select/command_version/3/apache_arrow/drilldowns.test
+++ b/test/command/suite/select/command_version/3/apache_arrow/drilldowns.test
@@ -1,0 +1,19 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/command_version/3/drilldown/multiple.test at output_type=apache-arrow
+
+table_create Documents TABLE_NO_KEY
+column_create Documents tag1 COLUMN_SCALAR ShortText
+column_create Documents tag2 COLUMN_SCALAR ShortText
+
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+
+select Documents \
+  --drilldown tag1,tag2 \
+  --command_version 3 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/3/apache_arrow/slice.expected
+++ b/test/command/suite/select/command_version/3/apache_arrow/slice.expected
@@ -1,0 +1,65 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --slices[groonga].filter 'tag == "Groonga"'   --slices[groonga].sort_keys 'date'   --slices[groonga].output_columns '_key, date'   --slices[groonga].columns[date_day].stage filtered   --slices[groonga].columns[date_day].type Time   --slices[groonga].columns[date_day].value 'time_classify_day(date)'   --slices[groonga].drilldowns[day].keys 'date_day'   --command_version 3   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+_key: string
+date: timestamp[ns]
+tag: dictionary<values=string, indices=int32, ordered=0>
+-- metadata --
+GROONGA:n_hits: 4
+	     _id	  _key	                     date	         tag
+	(uint32)	(utf8)	              (timestamp)	(dictionary)
+0	       1	Groonga is fast!	2016-05-19T12:00:00+09:00	Groonga     
+1	       2	Mroonga is fast!	2016-05-19T12:00:01+09:00	Mroonga     
+2	       3	Groonga sticker!	2016-05-20T12:00:02+09:00	Groonga     
+3	       4	Rroonga is fast!	2016-05-21T12:00:03+09:00	Rroonga     
+========================================
+_key: string
+date: timestamp[ns]
+-- metadata --
+GROONGA:n_hits: 2
+	  _key	                     date
+	(utf8)	              (timestamp)
+0	Groonga is fast!	2016-05-19T12:00:00+09:00
+1	Groonga sticker!	2016-05-20T12:00:02+09:00
+========================================
+_key: timestamp[ns]
+_nsubrecs: int32
+-- metadata --
+GROONGA:n_hits: 2
+	                     _key	_nsubrecs
+	              (timestamp)	  (int32)
+0	2016-05-19T00:00:00+09:00	        1
+1	2016-05-20T00:00:00+09:00	        1

--- a/test/command/suite/select/command_version/3/apache_arrow/slice.test
+++ b/test/command/suite/select/command_version/3/apache_arrow/slice.test
@@ -1,0 +1,32 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/slices/command_version_3.test at output_type=apache-arrow
+
+plugin_register functions/time
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos date COLUMN_SCALAR Time
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+
+select Memos \
+  --slices[groonga].filter 'tag == "Groonga"' \
+  --slices[groonga].sort_keys 'date' \
+  --slices[groonga].output_columns '_key, date' \
+  --slices[groonga].columns[date_day].stage filtered \
+  --slices[groonga].columns[date_day].type Time \
+  --slices[groonga].columns[date_day].value 'time_classify_day(date)' \
+  --slices[groonga].drilldowns[day].keys 'date_day' \
+  --command_version 3 \
+  --output_type apache-arrow


### PR DESCRIPTION
(drilldown or slice) + output_type=apache-arrow + command_version=3 combination will cause a crash.

The reason is that the label is set.
So, for output_type=apache-arrow, do not set the label.

Reference:
https://github.com/groonga/groonga/blob/a112f73d9bdd1151796d3923f7524fa1dc56c609/lib/output.c#L2504-L2518