### PR TITLE
docs: api/grn_expr move grn_expr_syntax_escape_query reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_expr.po
@@ -15,12 +15,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgid "パラメータ"
-msgstr ""
-
-msgid "戻り値"
-msgstr ""
-
 msgid "grn_expr"
 msgstr "grn_expr"
 
@@ -53,21 +47,3 @@ msgstr "TODO..."
 
 msgid "Reference"
 msgstr "リファレンス"
-
-msgid "Escapes special characters in :doc:`/reference/grn_expr/query_syntax`."
-msgstr ":doc:`/reference/grn_expr/query_syntax` にある特別な文字をエスケープします。"
-
-msgid "Its encoding must be the same encoding of ``query``. It is used for allocating buffer for ``escaped_query``."
-msgstr "このエンコーディングは ``query`` のエンコーディングと同じでなければなりません。 ``escaped_query`` 用のバッファを確保するために使います。"
-
-msgid "String expression representation in :doc:`/reference/grn_expr/query_syntax`."
-msgstr ":doc:`/reference/grn_expr/query_syntax` にある文字列式の表現。"
-
-msgid "The byte size of ``query``. ``-1`` means ``query`` is NULL terminated string."
-msgstr "``query`` のバイトサイズです。 ``-1`` を指定した場合は ``query`` がNULL終端文字列であるという意味になります。"
-
-msgid "The output of escaped ``query``. It should be text typed bulk."
-msgstr "エスケープされた ``query`` の出力。テキスト型用のbulkを返す。"
-
-msgid "``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error."
-msgstr "成功時は ``GRN_SUCCESS`` 、エラー時は ``GRN_SUCCESS`` 以外。"

--- a/doc/source/reference/api/grn_expr.rst
+++ b/doc/source/reference/api/grn_expr.rst
@@ -48,21 +48,6 @@ Reference
 
 .. c:function:: grn_rc grn_expr_append_op(grn_ctx *ctx, grn_obj *expr, grn_operator op, int nargs)
 
-.. c:function:: grn_rc grn_expr_syntax_escape_query(grn_ctx *ctx, const char *query, int query_size, grn_obj *escaped_query)
-
-   Escapes special characters in
-   :doc:`/reference/grn_expr/query_syntax`.
-
-   :param ctx: Its encoding must be the same encoding of ``query``.
-               It is used for allocating buffer for ``escaped_query``.
-   :param query: String expression representation in
-                 :doc:`/reference/grn_expr/query_syntax`.
-   :param query_size: The byte size of ``query``. ``-1`` means ``query``
-                      is NULL terminated string.
-   :param escaped_query: The output of escaped ``query``. It should be
-                         text typed bulk.
-   :return: ``GRN_SUCCESS`` on success, not ``GRN_SUCCESS`` on error.
-
 .. c:function:: grn_rc grn_expr_compile(grn_ctx *ctx, grn_obj *expr)
 
 .. c:function:: grn_obj *grn_expr_exec(grn_ctx *ctx, grn_obj *expr, int nargs)

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -162,6 +162,21 @@ grn_expr_syntax_escape(grn_ctx *ctx,
                        const char *target_characters,
                        char escape_character,
                        grn_obj *escaped_query);
+/**
+ * \brief Escape special characters in a query.
+ *
+ * \param ctx The context object. Its encoding must match that of the input
+ *            \p query. It is used for allocating buffer for \p escaped_query.
+ * \param query The input query to be escaped.
+ * \param query_size The byte size of \p query. A value of -1 indicates that
+ *                   the query is null-terminated.
+ * \param escaped_query The buffer where the escaped query is stored.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
+ *
+ * \see
+ * https://groonga.org/docs/reference/grn_expr/query_syntax.html
+ */
 GRN_API grn_rc
 grn_expr_syntax_escape_query(grn_ctx *ctx,
                              const char *query,

--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -137,6 +137,9 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
 /**
  * \brief Escape target characters in a query by a specified escape character.
  *
+ * \note For general query syntax escaping, it is recommended to use
+ *       \ref grn_expr_syntax_escape_query instead.
+ *
  * \param ctx The context object. Its encoding must match that of the input
  *            \p query.
  * \param query The input query to be escaped.
@@ -151,9 +154,6 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
  * \param escaped_query The buffer where the escaped query is stored.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.
- *
- * \see
- * https://groonga.org/docs/reference/grn_expr/query_syntax.html
  */
 GRN_API grn_rc
 grn_expr_syntax_escape(grn_ctx *ctx,


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.