### PR TITLE
ci make: support UBSAN

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -194,7 +194,7 @@ jobs:
           key: red-datasets-ubuntu
       - name: "Test: command line"
         if: env.GRN_TEST_RUN_COMMAND_LINE == 'yes'
-        continue-on-error: true
+        continue-on-error: ${{ matrix.ubsan == 'ON' }}
         run: |
           test/command_line/run-test.rb --groonga-install-prefix=$PWD/install
       - name: "Test: mruby"
@@ -202,7 +202,7 @@ jobs:
         run: |
           USE_SYSTEM=yes test/mruby/run-test.rb
       - name: "Test: stdio"
-        continue-on-error: true
+        continue-on-error: ${{ matrix.ubsan == 'ON' }}
         run: |
           grntest \
             --base-dir test/command \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -168,11 +168,12 @@ jobs:
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
-          if [ "${{ matrix.ubsan }}" == "ON" ] ; then
+          if [ "${{ matrix.ubsan }}" == "ON" ]; then
             CLANG_VER=$(clang -dumpversion | cut -d. -f1)
             CLANG_LIBRARY_PATH="/usr/lib/clang/${CLANG_VER}/lib/linux"
-            echo "LD_LIBRARY_PATH=${CLANG_LIBRARY_PATH}:${env.LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
+            echo "LD_LIBRARY_PATH=$PWD/install/lib:${CLANG_LIBRARY_PATH}" >> ${GITHUB_ENV}
+          else
+            echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
           fi
           echo "PKG_CONFIG_PATH=$PWD/lib/pkgconfig" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,9 +77,12 @@ jobs:
             mruby: "OFF"
           - cc: clang
             cxx: clang++
-          - cc: clang
-            cxx: clang++
-            ubsan: "ON"
+          # TODO: Temporarily disable UBSAN checks in our CI matrix due to
+          # current error noise. Once all UBSAN failures have been addressed,
+          # we will enable UBSAN checks.
+          # - cc: clang
+          #   cxx: clang++
+          #   ubsan: "ON"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -168,13 +168,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          if [ "${{ matrix.ubsan }}" == "ON" ]; then
-            CLANG_VER=$(clang -dumpversion | cut -d. -f1)
-            CLANG_LIBRARY_PATH="/usr/lib/clang/${CLANG_VER}/lib/linux"
-            echo "LD_LIBRARY_PATH=$PWD/install/lib:${CLANG_LIBRARY_PATH}" >> ${GITHUB_ENV}
-          else
-            echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
-          fi
+          echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
           echo "PKG_CONFIG_PATH=$PWD/lib/pkgconfig" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,12 +77,16 @@ jobs:
             mruby: "OFF"
           - cc: clang
             cxx: clang++
+          - cc: clang
+            cxx: clang++
+            ubsan: "ON"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
       GRN_WITH_MRUBY: ${{ matrix.mruby }}
+      GRN_WITH_UBSAN: ${{ matrix.ubsan }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -152,7 +156,8 @@ jobs:
             -DGRN_ALLOW_WARNING=OFF \
             -DGRN_WITH_APACHE_ARROW=ON \
             -DGRN_WITH_BLOSC=auto \
-            -DGRN_WITH_MRUBY=${GRN_WITH_MRUBY:-ON}
+            -DGRN_WITH_MRUBY=${GRN_WITH_MRUBY:-ON} \
+            -DGRN_WITH_UBSAN=${GRN_WITH_UBSAN:-OFF}
       - name: Build
         run: |
           ninja -C ../groonga.build
@@ -164,6 +169,11 @@ jobs:
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
           echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
+          if [ "${{ matrix.ubsan }}" == "ON" ] ; then
+            CLANG_VER=$(clang -dumpversion | cut -d. -f1)
+            CLANG_LIBRARY_PATH="/usr/lib/clang/${CLANG_VER}/lib/linux"
+            echo "LD_LIBRARY_PATH=${CLANG_LIBRARY_PATH}:${env.LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
+          fi
           echo "PKG_CONFIG_PATH=$PWD/lib/pkgconfig" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,12 +77,9 @@ jobs:
             mruby: "OFF"
           - cc: clang
             cxx: clang++
-          # TODO: Temporarily disable UBSAN checks in our CI matrix due to
-          # current error noise. Once all UBSAN failures have been addressed,
-          # we will enable UBSAN checks.
-          # - cc: clang
-          #   cxx: clang++
-          #   ubsan: "ON"
+          - cc: clang
+            cxx: clang++
+            ubsan: "ON"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
@@ -197,6 +194,7 @@ jobs:
           key: red-datasets-ubuntu
       - name: "Test: command line"
         if: env.GRN_TEST_RUN_COMMAND_LINE == 'yes'
+        continue-on-error: true
         run: |
           test/command_line/run-test.rb --groonga-install-prefix=$PWD/install
       - name: "Test: mruby"
@@ -204,6 +202,7 @@ jobs:
         run: |
           USE_SYSTEM=yes test/mruby/run-test.rb
       - name: "Test: stdio"
+        continue-on-error: true
         run: |
           grntest \
             --base-dir test/command \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -521,6 +521,30 @@ option(GRN_WITH_NFKC "use NFKC based UTF8 normalization." ON)
 
 option(GRN_WITH_MEMORY_DEBUG "use debug memory management" OFF)
 
+option(GRN_WITH_UBSAN "Enable Undefined Behavior Sanitizer (UBSAN) checking"
+       OFF)
+if(GRN_WITH_UBSAN)
+  if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(GRN_UBSAN_FLAGS "-fsanitize=undefined -fno-sanitize=alignment")
+    string(APPEND CMAKE_C_FLAGS " ${GRN_UBSAN_FLAGS}")
+    string(APPEND CMAKE_CXX_FLAGS " ${GRN_UBSAN_FLAGS}")
+    message(STATUS "UBSAN flags: ${GRN_UBSAN_FLAGS}")
+    execute_process(
+      COMMAND ${CMAKE_C_COMPILER}
+              -print-file-name=libclang_rt.ubsan_standalone-x86_64.so
+      OUTPUT_VARIABLE GRN_UBSAN_LIB_PATH
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(GRN_UBSAN_LIB_PATH)
+      string(APPEND CMAKE_EXE_LINKER_FLAGS " ${GRN_UBSAN_LIB_PATH}")
+      message(STATUS "Found UBSAN runtime library: ${GRN_UBSAN_LIB_PATH}")
+    else()
+      message(FATAL_ERROR "No UBSAN runtime library found")
+    endif()
+  else()
+    message(FATAL_ERROR "UBSAN support is available only for Clang")
+  endif()
+endif()
+
 if(WIN32)
   target_link_libraries(grn_dependencies INTERFACE dbghelp.lib)
   target_link_libraries(grn_dependencies INTERFACE psapi.lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,6 +524,12 @@ option(GRN_WITH_MEMORY_DEBUG "use debug memory management" OFF)
 option(GRN_WITH_UBSAN "Enable Undefined Behavior Sanitizer (UBSAN) checking"
        OFF)
 if(GRN_WITH_UBSAN)
+  # UBSAN support requires Clang.
+  # GCC does not currently support `-fno-sanitize=alignment`, which is needed to
+  # suppress alignment-related sanitizer errors. Enabling UBSAN with GCC without
+  # this flag produces excessive misalignment errors. Once GCC adds support for
+  # `-fno-sanitize=alignment`, we can consider enabling UBSAN for GCC here as
+  # well.
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     set(GRN_UBSAN_FLAGS "-fsanitize=undefined -fno-sanitize=alignment,vptr")
     string(APPEND CMAKE_C_FLAGS " ${GRN_UBSAN_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,21 +525,10 @@ option(GRN_WITH_UBSAN "Enable Undefined Behavior Sanitizer (UBSAN) checking"
        OFF)
 if(GRN_WITH_UBSAN)
   if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-    set(GRN_UBSAN_FLAGS "-fsanitize=undefined -fno-sanitize=alignment")
+    set(GRN_UBSAN_FLAGS "-fsanitize=undefined -fno-sanitize=alignment,vptr")
     string(APPEND CMAKE_C_FLAGS " ${GRN_UBSAN_FLAGS}")
     string(APPEND CMAKE_CXX_FLAGS " ${GRN_UBSAN_FLAGS}")
     message(STATUS "UBSAN flags: ${GRN_UBSAN_FLAGS}")
-    execute_process(
-      COMMAND ${CMAKE_C_COMPILER}
-              -print-file-name=libclang_rt.ubsan_standalone-x86_64.so
-      OUTPUT_VARIABLE GRN_UBSAN_LIB_PATH
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(GRN_UBSAN_LIB_PATH)
-      string(APPEND CMAKE_EXE_LINKER_FLAGS " ${GRN_UBSAN_LIB_PATH}")
-      message(STATUS "Found UBSAN runtime library: ${GRN_UBSAN_LIB_PATH}")
-    else()
-      message(FATAL_ERROR "No UBSAN runtime library found")
-    endif()
   else()
     message(FATAL_ERROR "UBSAN support is available only for Clang")
   endif()


### PR DESCRIPTION
GitHub: GH-2273
GitHub: ref https://github.com/groonga/groonga/pull/2270#issuecomment-2785257730

MariaDB bundles Groonga. With the recent UBSAN improvements in MariaDB,
UBSAN errors are detected in the Groonga layer. To catch undefined behavior
issues and ensure robust integration, this change adds a new UBSAN build configuration.

## For reviewers

This UBSAN support is implemented only with Clang because GCC doesn't support the `-fno-sanitize=alignment` option,
leading to numerous misalignment errors. And also, MariaDB is using this option too.

ref: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#usage
ref: https://github.com/MariaDB/server/blob/22efc2c784e1b7199fb5804e6330168277ea7dce/CMakeLists.txt#L239