### PR TITLE
output: apache-arrow: Support for multiple metadata

### DIFF
--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -2012,6 +2012,7 @@ namespace grnarrow {
     StreamWriter(grn_ctx *ctx, grn_obj *bulk)
       : ctx_(ctx),
         output_(ctx, bulk),
+        metadata_(),
         schema_builder_(),
         schema_(),
         writer_(),
@@ -2036,9 +2037,8 @@ namespace grnarrow {
     void
     add_metadata(const char *key, const char *value)
     {
-      arrow::KeyValueMetadata metadata;
-      metadata.Append(key, value);
-      auto status = schema_builder_.AddMetadata(metadata);
+      metadata_.Append(key, value);
+      auto status = schema_builder_.AddMetadata(metadata_);
       if (!status.ok()) {
         std::stringstream context;
         check(ctx_,
@@ -2526,6 +2526,7 @@ namespace grnarrow {
   private:
     grn_ctx *ctx_;
     BulkOutputStream output_;
+    arrow::KeyValueMetadata metadata_;
     arrow::SchemaBuilder schema_builder_;
     std::shared_ptr<arrow::Schema> schema_;
     std::shared_ptr<arrow::ipc::RecordBatchWriter> writer_;

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -2039,6 +2039,8 @@ namespace grnarrow {
     {
       metadata_.Append(key, value);
       // It is named AddMetadata(), but it "set" metadata, not "add" it.
+      // This behavior may be changed.
+      // See also: https://github.com/apache/arrow/issues/46146
       auto status = schema_builder_.AddMetadata(metadata_);
       if (!status.ok()) {
         std::stringstream context;

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -2038,6 +2038,7 @@ namespace grnarrow {
     add_metadata(const char *key, const char *value)
     {
       metadata_.Append(key, value);
+      // It is named AddMetadata(), but it "set" metadata, not "add" it.
       auto status = schema_builder_.AddMetadata(metadata_);
       if (!status.ok()) {
         std::stringstream context;


### PR DESCRIPTION
Currently only one metadata can be set.
Change it so that multiple metadata can be set.

Related: GitHub GH-2274