### PR TITLE
cmake llama.cpp: fix build error when using system-provided llama.cpp

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -187,15 +187,12 @@ if(GRN_WITH_MESSAGE_PACK)
     target_link_libraries(libgroonga INTERFACE Groonga::msgpackc)
   endif()
 endif()
-if(GRN_WITH_LLAMA_CPP)
-  if(GRN_WITH_LLAMA_CPP_BUNDLED)
-    target_link_libraries(libgroonga
-                          INTERFACE "$<BUILD_INTERFACE:Groonga::llama>")
-    target_link_libraries(libgroonga
-                          INTERFACE "$<BUILD_INTERFACE:Groonga::ggml>")
-    target_link_libraries(libgroonga
-                          INTERFACE "$<BUILD_INTERFACE:Groonga::ggml-base>")
-  endif()
+if(GRN_WITH_LLAMA_CPP_BUNDLED)
+  target_link_libraries(libgroonga
+                        INTERFACE "$<BUILD_INTERFACE:Groonga::llama>")
+  target_link_libraries(libgroonga INTERFACE "$<BUILD_INTERFACE:Groonga::ggml>")
+  target_link_libraries(libgroonga
+                        INTERFACE "$<BUILD_INTERFACE:Groonga::ggml-base>")
 endif()
 if(NOT WASI)
   target_link_libraries(libgroonga PRIVATE Threads::Threads ${CMAKE_DL_LIBS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -188,11 +188,14 @@ if(GRN_WITH_MESSAGE_PACK)
   endif()
 endif()
 if(GRN_WITH_LLAMA_CPP)
-  target_link_libraries(libgroonga
-                        INTERFACE "$<BUILD_INTERFACE:Groonga::llama>")
-  target_link_libraries(libgroonga INTERFACE "$<BUILD_INTERFACE:Groonga::ggml>")
-  target_link_libraries(libgroonga
-                        INTERFACE "$<BUILD_INTERFACE:Groonga::ggml-base>")
+  if(GRN_WITH_LLAMA_CPP_BUNDLED)
+    target_link_libraries(libgroonga
+                          INTERFACE "$<BUILD_INTERFACE:Groonga::llama>")
+    target_link_libraries(libgroonga
+                          INTERFACE "$<BUILD_INTERFACE:Groonga::ggml>")
+    target_link_libraries(libgroonga
+                          INTERFACE "$<BUILD_INTERFACE:Groonga::ggml-base>")
+  endif()
 endif()
 if(NOT WASI)
   target_link_libraries(libgroonga PRIVATE Threads::Threads ${CMAKE_DL_LIBS})


### PR DESCRIPTION
## Problem

Configuring with `-DGRN_WITH_LLAMA_CPP=system` caused CMake error out.

```
cmake -S . -B ../groonga.build --preset=debug-default -DCMAKE_INSTALL_PREFIX=/tmp/local -DGRN_WITH_LLAMA_CPP=system
...
-- Configuring done (9.3s)
CMake Error at lib/CMakeLists.txt:191 (target_link_libraries):
  The link interface of target "libgroonga" contains:

    Groonga::llama

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

-- Generating done (0.0s)
```

## Causes

We were unconditionally injecting INTERFACE links to Groonga::llama, Groonga::ggml and Groonga::ggml-base even when using the system-installed (shared) llama.cpp packages. Those imported targets only exist when we bundle and build llama.cpp ourselves.

## Solution

Wrap the INTERFACE target_link_libraries calls in a `GRN_WITH_LLAMA_CPP_BUNDLED` check so that explicit
linking to Groonga::llama/ggml(-base) only happens when using the bundled sources.