### PR TITLE
release: extract release announce from News

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -234,10 +234,9 @@ namespace :release do
       raise "release summary isn't written"
     end
     latest_release_date = latest_release_note.lines.first[/\d{4}-\d{2}-\d{2}/]
-    latest_release_major = version.split(".").first
     latest_release_anchor = "#release-#{version.gsub(".", "-")}"
     latest_release_url =
-      "https://groonga.org/docs/news/#{latest_release_major}.html"
+      "https://groonga.org/docs/news/#{File.basename(latest_news, ".*")}.html"
     latest_release_announce = <<-ANNOUNCE.gsub(/\n+/, " ").strip
 Groonga #{version} has been released!(#{latest_release_date})
 #{latest_release_summary}

--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ namespace :release do
       raise "release note isn't written"
     end
     latest_release_summary =
-      latest_release_note[/^### Summary\s*(.+?)(?=^###|\z)/m, 1]
+      latest_release_note[/^[^\n]+\n\n(.+?)(?=\n###|\z)/m, 1]
     unless latest_release_summary
       raise "release summary isn't written"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -230,9 +230,9 @@ namespace :release do
     if latest_release_note_version != version
       raise "release note isn't written"
     end
-    latest_release_summary =
-      latest_release_note_content.split(/^### /, 2)[0].gsub(/\A.*\n/, "").strip
-    unless latest_release_summary
+    latest_release_note_summary =
+      latest_release_note_content.split(/^### /, 2)[0].strip
+    unless latest_release_note_summary
       raise "release summary isn't written"
     end
     latest_release_date = latest_release_note_title[/\d{4}-\d{2}-\d{2}/]
@@ -241,7 +241,7 @@ namespace :release do
       "https://groonga.org/docs/news/#{File.basename(latest_news, ".*")}.html"
     latest_release_announce = <<-ANNOUNCE.gsub(/\n+/, " ").strip
 Groonga #{version} (#{latest_release_date}) has been released!
-#{latest_release_summary}
+#{latest_release_note_summary}
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE
   end

--- a/Rakefile
+++ b/Rakefile
@@ -221,7 +221,7 @@ namespace :release do
   desc "Post release announces"
   task :announce do
     latest_news = Dir.glob("doc/source/news/*.*").max do |a, b|
-      File.basename(a).to_f - File.basename(b).to_f
+      File.basename(a).to_i - File.basename(b).to_i
     end
     latest_release_note = File.read(latest_news).split(/^## /)[1]
     latest_release_note_version = latest_release_note.lines.first[/[\d.]+/]

--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ namespace :release do
       raise "release note isn't written"
     end
     latest_release_summary =
-      latest_release_note[/^[^\n]+\n\n(.+?)(?=\n###|\z)/m, 1]
+      latest_release_note.split(/^### /, 2)[0].gsub(/\A.*\n/, "").strip
     unless latest_release_summary
       raise "release summary isn't written"
     end

--- a/Rakefile
+++ b/Rakefile
@@ -224,16 +224,18 @@ namespace :release do
       File.basename(a).to_i - File.basename(b).to_i
     end
     latest_release_note = File.read(latest_news).split(/^## /)[1]
-    latest_release_note_version = latest_release_note.lines.first[/[\d.]+/]
+    latest_release_note_title = latest_release_note.lines.first
+    latest_release_note_content = latest_release_note.lines[1..-1].join
+    latest_release_note_version = latest_release_note_title[/[\d.]+/]
     if latest_release_note_version != version
       raise "release note isn't written"
     end
     latest_release_summary =
-      latest_release_note.split(/^### /, 2)[0].gsub(/\A.*\n/, "").strip
+      latest_release_note_content.split(/^### /, 2)[0].gsub(/\A.*\n/, "").strip
     unless latest_release_summary
       raise "release summary isn't written"
     end
-    latest_release_date = latest_release_note.lines.first[/\d{4}-\d{2}-\d{2}/]
+    latest_release_date = latest_release_note_title[/\d{4}-\d{2}-\d{2}/]
     latest_release_anchor = "#release-#{version.gsub(".", "-")}"
     latest_release_url =
       "https://groonga.org/docs/news/#{File.basename(latest_news, ".*")}.html"

--- a/Rakefile
+++ b/Rakefile
@@ -217,6 +217,33 @@ namespace :release do
        "Groonga #{version}!!!")
     sh("git", "push", "origin", "v#{version}")
   end
+
+  desc "Post release announces"
+  task :announce do
+    latest_news = Dir.glob("doc/source/news/*.*").max do |a, b|
+      File.basename(a).to_f - File.basename(b).to_f
+    end
+    latest_release_note = File.read(latest_news).split(/^## /)[1]
+    latest_release_note_version = latest_release_note.lines.first[/[\d.]+/]
+    if latest_release_note_version != version
+      raise "release note isn't written"
+    end
+    latest_release_summary =
+      latest_release_note[/^### Summary\s*(.+?)(?=^###|\z)/m, 1]
+    unless latest_release_summary
+      raise "release summary isn't written"
+    end
+    latest_release_date = latest_release_note.lines.first[/\d{4}-\d{2}-\d{2}/]
+    latest_release_major = version.split(".").first
+    latest_release_anchor = "#release-#{version.gsub(".", "-")}"
+    latest_release_url =
+      "https://groonga.org/docs/news/#{latest_release_major}.html"
+    latest_release_announce = <<-ANNOUNCE.gsub(/\n+/, " ").strip
+Groonga #{version} has been released!(#{latest_release_date})
+#{latest_release_summary}
+See: #{latest_release_url}#{latest_release_anchor}
+    ANNOUNCE
+  end
 end
 
 desc "Release"

--- a/Rakefile
+++ b/Rakefile
@@ -238,7 +238,7 @@ namespace :release do
     latest_release_url =
       "https://groonga.org/docs/news/#{File.basename(latest_news, ".*")}.html"
     latest_release_announce = <<-ANNOUNCE.gsub(/\n+/, " ").strip
-Groonga #{version} has been released!(#{latest_release_date})
+Groonga #{version} (#{latest_release_date}) has been released!
 #{latest_release_summary}
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE


### PR DESCRIPTION
GitHub: GH-2286

This change will extracts the summary from News (
Release notes) for posting it to SNS as release
announces.

```console
$ VERSION=15.0.4 rake release:announce
```