### PR TITLE
package: almalinux8: Add Apache Arrow repository install

### DIFF
--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -11,7 +11,7 @@ RUN \
     epel-release \
     'dnf-command(config-manager)' \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
-    https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
+    https://packages.apache.org/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf config-manager --set-enabled powertools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \

--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -10,7 +10,8 @@ RUN \
   dnf install -y ${quiet} \
     epel-release \
     'dnf-command(config-manager)' \
-    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
+    https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm \
+    https://apache.jfrog.io/artifactory/arrow/almalinux/$(cut -d: -f5 /etc/system-release-cpe | cut -d. -f1)/apache-arrow-release-latest.rpm && \
   dnf config-manager --set-enabled powertools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -16,8 +16,6 @@ esac
 case ${os} in
   amazon-linux)
     DNF="dnf"
-    ${DNF} install -y \
-      https://packages.apache.org/artifactory/arrow/amazon-linux/${version}/apache-arrow-release-latest.rpm
     ;;
   *)
     case ${version} in
@@ -28,12 +26,11 @@ case ${os} in
         DNF="dnf --enablerepo=crb"
         ;;
     esac
-    ${DNF} install -y \
-      https://packages.apache.org/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
     ;;
 esac
 
 ${DNF} install -y \
+  https://packages.apache.org/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm \
   https://packages.groonga.org/${os}/${version}/groonga-release-latest.noarch.rpm
 
 repositories_dir=/groonga/packages/yum/repositories

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -17,22 +17,19 @@ case ${os} in
   amazon-linux)
     DNF="dnf"
     ${DNF} install -y \
-      https://apache.jfrog.io/artifactory/arrow/amazon-linux/${version}/apache-arrow-release-latest.rpm
+      https://packages.apache.org/artifactory/arrow/amazon-linux/${version}/apache-arrow-release-latest.rpm
     ;;
   *)
     case ${version} in
-      7)
-        DNF=yum
-        ;;
       8)
         DNF="dnf --enablerepo=powertools"
         ;;
       *)
         DNF="dnf --enablerepo=crb"
-        ${DNF} install -y \
-          https://apache.jfrog.io/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
         ;;
     esac
+    ${DNF} install -y \
+      https://packages.apache.org/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
     ;;
 esac
 


### PR DESCRIPTION
Error in build because Groonga repository dropped serving arrow-devel-x.x.x.