### PR TITLE
release: post announce to X

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           ./setup.sh
           pip install -r doc/requirements.txt
+          bundle install
           (cd doc && bundle install)
       - name: Build document
         run: |

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           ./setup.sh
           pip install -r doc/requirements.txt
-          bundle install
           (cd doc && bundle install)
       - name: Build document
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,15 @@ jobs:
           echo "${LAUNCHPAD_DEPLOY_KEY}" | gpg --import
           echo "trusted-key ${LAUNCHPAD_UPLOADER_PGP_KEY}" > ~/.gnupg/gpg.conf
           rake -C packages ubuntu
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+      - name: Post Announcement
+        run: |
+          bundle install
+          VERSION=${GITHUB_REF_NAME#v} rake release:announce
+        env:
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,6 @@ jobs:
           bundler-cache: true
       - name: Post Announcement
         run: |
-          bundle install
           VERSION=${GITHUB_REF_NAME#v} rake release:announce
         env:
           X_API_KEY: ${{ secrets.X_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
+          bundler-cache: true
       - name: Post Announcement
         run: |
           bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@
 /vendor/xxHash-*
 /vendor/zstd-*
 CMakeFiles
+Gemfile.lock
 Makefile
 Makefile.in
 cmake_install.cmake

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,19 @@
+# Copyright (C) 2025  Kodama Takuya <otegami@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+source "https://rubygems.org"
+
+gem "x"

--- a/Rakefile
+++ b/Rakefile
@@ -254,7 +254,7 @@ See: #{latest_release_url}#{latest_release_anchor}
       access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
     }
     x_client = X::Client.new(**x_credentials)
-    tweet_body = { test: latest_release_announce }
+    tweet_body = { text: latest_release_announce }
     x_client.post("tweets", tweet_body.to_json)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@
 require "date"
 require "open-uri"
 require "tmpdir"
+require "x"
 
 BASE_VERSION = File.read(File.join(__dir__, "base_version"))
 
@@ -244,6 +245,16 @@ Groonga #{version} (#{latest_release_date}) has been released!
 #{latest_release_note_summary}
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE
+
+    x_credentials = {
+      api_key: ENV["X_API_KEY"],
+      api_key_secret: ENV["X_API_KEY_SECRET"],
+      access_token: ENV["X_ACCESS_TOKEN"],
+      access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
+    }
+    x_client = X::Client.new(**x_credentials)
+    tweet_body = { test: latest_release_announce }
+    x_client.post("tweets", tweet_body.to_json)
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@
 require "date"
 require "open-uri"
 require "tmpdir"
-require "x"
 
 BASE_VERSION = File.read(File.join(__dir__, "base_version"))
 
@@ -221,6 +220,8 @@ namespace :release do
 
   desc "Post release announces"
   task :announce do
+    require "x"
+
     latest_news = Dir.glob("doc/source/news/*.*").max do |a, b|
       File.basename(a).to_i - File.basename(b).to_i
     end


### PR DESCRIPTION
GitHub: GH-2286

This change will post the release summary from News (Release notes) to X.