### PR TITLE
ci alpine-linux: add missing trailing "::" for "::endgroup"

### DIFF
--- a/dockerfiles/run.sh
+++ b/dockerfiles/run.sh
@@ -29,7 +29,7 @@ cmake \
 cmake --build build
 cmake --install build
 set +x
-echo "::endgroup"
+echo "::endgroup::"
 
 echo "::group::Test"
 set -x
@@ -45,4 +45,4 @@ grntest \
   --reporter=mark \
   test/suite
 set +x
-echo "::endgroup"
+echo "::endgroup::"


### PR DESCRIPTION
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines

```text
::group::{title}
::endgroup::
```