### PR TITLE
ci: set `env:` before `run:`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -222,39 +222,30 @@ jobs:
             test/command/suite
       - name: "Test: stdio: NFKC121"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "12.1.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: NFKC130"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "13.0.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: NFKC150"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "15.0.0"
-      - name: "Test: stdio: NFKC: 16.0.0"
-        if: env.GRN_TEST_RUN_ALL == 'yes'
         run: |
           grntest \
             --base-dir test/command \
@@ -262,8 +253,17 @@ jobs:
             --read-timeout=30 \
             --reporter=mark \
             test/command/suite/normalizers/nfkc/
+      - name: "Test: stdio: NFKC: 16.0.0"
+        if: env.GRN_TEST_RUN_ALL == 'yes'
         env:
           NFKC: "16.0.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: n_workers"
         if: env.GRN_TEST_RUN_ALL == 'yes'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download artifacts
         timeout-minutes: 60
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           workflows=(cmake.yml document.yml package.yml)
           for workflow in "${workflows[@]}"; do
@@ -37,8 +39,6 @@ jobs:
               --dir release-artifacts \
               --pattern "release-*"
           done
-        env:
-          GH_TOKEN: ${{ github.token }}
       - name: Extract release note
         run: |
           (cd doc/source/news && \
@@ -65,6 +65,8 @@ jobs:
           version_hyphen=$(echo ${version} | tr . -)
           echo "  * [Japanese](https://groonga.org/ja/docs/news/${major_version}.html#release-${version_hyphen})" >> release-note.md
       - name: Publish release page
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           title="$(head -n1 release-note.md | sed -e 's/^## //')"
           tail -n +2 release-note.md > release-note-without-version.md
@@ -73,8 +75,6 @@ jobs:
             --notes-file release-note-without-version.md \
             --title "${title}" \
             release-artifacts/*/*
-        env:
-          GH_TOKEN: ${{ github.token }}
       - name: Prepare for Launchpad publishing
         run: |
           cp release-artifacts/release-source/groonga-*.tar.gz ./
@@ -101,10 +101,10 @@ jobs:
           ruby-version: ruby
           bundler-cache: true
       - name: Post Announcement
-        run: |
-          VERSION=${GITHUB_REF_NAME#v} rake release:announce
         env:
           X_API_KEY: ${{ secrets.X_API_KEY }}
           X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: |
+          VERSION=${GITHUB_REF_NAME#v} rake release:announce


### PR DESCRIPTION
It's for readability. `env:` is used in `run:`. If we have `env:` before `run:`, we can read `run:` with "what environment variables are used in this `run:`" information.