### PR TITLE
table_tokenize: add `--output_style` option

### DIFF
--- a/lib/proc/proc_tokenize.c
+++ b/lib/proc/proc_tokenize.c
@@ -416,12 +416,11 @@ command_table_tokenize(grn_ctx *ctx,
   return NULL;
 }
 
-#define TABLE_TOKENIZE_N_ARGS 6
-
 void
 grn_proc_init_table_tokenize(grn_ctx *ctx)
 {
-  grn_expr_var vars[TABLE_TOKENIZE_N_ARGS];
+#define N_ARGS 6
+  grn_expr_var vars[N_ARGS];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "table", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "string", -1);
@@ -433,8 +432,9 @@ grn_proc_init_table_tokenize(grn_ctx *ctx)
                             "table_tokenize",
                             -1,
                             command_table_tokenize,
-                            TABLE_TOKENIZE_N_ARGS,
+                            N_ARGS,
                             vars);
+#undef N_ARGS
 }
 
 static grn_obj *
@@ -536,12 +536,11 @@ command_tokenize(grn_ctx *ctx,
   return NULL;
 }
 
-#define TOKENIZE_N_ARGS 7
-
 void
 grn_proc_init_tokenize(grn_ctx *ctx)
 {
-  grn_expr_var vars[TOKENIZE_N_ARGS];
+#define N_ARGS 7
+  grn_expr_var vars[N_ARGS];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "tokenizer", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "string", -1);
@@ -554,6 +553,7 @@ grn_proc_init_tokenize(grn_ctx *ctx)
                             "tokenize",
                             -1,
                             command_tokenize,
-                            TOKENIZE_N_ARGS,
+                            N_ARGS,
                             vars);
+#undef N_ARGS
 }

--- a/lib/proc/proc_tokenize.c
+++ b/lib/proc/proc_tokenize.c
@@ -416,10 +416,12 @@ command_table_tokenize(grn_ctx *ctx,
   return NULL;
 }
 
+#define TABLE_TOKENIZE_N_ARGS 6
+
 void
 grn_proc_init_table_tokenize(grn_ctx *ctx)
 {
-  grn_expr_var vars[6];
+  grn_expr_var vars[TABLE_TOKENIZE_N_ARGS];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "table", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "string", -1);
@@ -431,7 +433,7 @@ grn_proc_init_table_tokenize(grn_ctx *ctx)
                             "table_tokenize",
                             -1,
                             command_table_tokenize,
-                            6,
+                            TABLE_TOKENIZE_N_ARGS,
                             vars);
 }
 
@@ -534,10 +536,12 @@ command_tokenize(grn_ctx *ctx,
   return NULL;
 }
 
+#define TOKENIZE_N_ARGS 7
+
 void
 grn_proc_init_tokenize(grn_ctx *ctx)
 {
-  grn_expr_var vars[7];
+  grn_expr_var vars[TOKENIZE_N_ARGS];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "tokenizer", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "string", -1);
@@ -546,5 +550,10 @@ grn_proc_init_tokenize(grn_ctx *ctx)
   grn_plugin_expr_var_init(ctx, &(vars[4]), "mode", -1);
   grn_plugin_expr_var_init(ctx, &(vars[5]), "token_filters", -1);
   grn_plugin_expr_var_init(ctx, &(vars[6]), "output_style", -1);
-  grn_plugin_command_create(ctx, "tokenize", -1, command_tokenize, 7, vars);
+  grn_plugin_command_create(ctx,
+                            "tokenize",
+                            -1,
+                            command_tokenize,
+                            TOKENIZE_N_ARGS,
+                            vars);
 }

--- a/lib/proc/proc_tokenize.c
+++ b/lib/proc/proc_tokenize.c
@@ -307,6 +307,7 @@ command_table_tokenize(grn_ctx *ctx,
   grn_obj *flags_raw;
   grn_obj *mode_raw;
   grn_raw_string index_column_raw;
+  grn_raw_string output_style_raw;
 
 #define GET_VALUE(name)                                                        \
   name##_raw.value = grn_plugin_proc_get_var_string(ctx,                       \
@@ -320,6 +321,7 @@ command_table_tokenize(grn_ctx *ctx,
   flags_raw = grn_plugin_proc_get_var(ctx, user_data, "flags", strlen("flags"));
   mode_raw = grn_plugin_proc_get_var(ctx, user_data, "mode", strlen("mode"));
   GET_VALUE(index_column);
+  GET_VALUE(output_style);
 
 #undef GET_VALUE
 
@@ -394,7 +396,11 @@ command_table_tokenize(grn_ctx *ctx,
                                          "[table_tokenize][mode]");
       if (ctx->rc == GRN_SUCCESS) {
         tokenize(ctx, lexicon, &string_raw, mode, flags, &tokens);
-        output_tokens(ctx, &tokens, lexicon, index_column);
+        if (GRN_RAW_STRING_EQUAL_CSTRING(output_style_raw, "simple")) {
+          output_tokens_simple(ctx, &tokens, lexicon);
+        } else {
+          output_tokens(ctx, &tokens, lexicon, index_column);
+        }
       }
       fin_tokens(ctx, &tokens);
     }
@@ -413,18 +419,19 @@ command_table_tokenize(grn_ctx *ctx,
 void
 grn_proc_init_table_tokenize(grn_ctx *ctx)
 {
-  grn_expr_var vars[5];
+  grn_expr_var vars[6];
 
   grn_plugin_expr_var_init(ctx, &(vars[0]), "table", -1);
   grn_plugin_expr_var_init(ctx, &(vars[1]), "string", -1);
   grn_plugin_expr_var_init(ctx, &(vars[2]), "flags", -1);
   grn_plugin_expr_var_init(ctx, &(vars[3]), "mode", -1);
   grn_plugin_expr_var_init(ctx, &(vars[4]), "index_column", -1);
+  grn_plugin_expr_var_init(ctx, &(vars[5]), "output_style", -1);
   grn_plugin_command_create(ctx,
                             "table_tokenize",
                             -1,
                             command_table_tokenize,
-                            5,
+                            6,
                             vars);
 }
 

--- a/test/command/suite/table_tokenize/output_style/full.expected
+++ b/test/command/suite/table_tokenize/output_style/full.expected
@@ -1,0 +1,24 @@
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenNgram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+table_tokenize Terms "aBcDe 123" --mode ADD --output_style full
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "abcde",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "123",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/table_tokenize/output_style/full.test
+++ b/test/command/suite/table_tokenize/output_style/full.test
@@ -1,0 +1,5 @@
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenNgram \
+  --normalizer NormalizerAuto
+
+table_tokenize Terms "aBcDe 123" --mode ADD --output_style full

--- a/test/command/suite/table_tokenize/output_style/simple.expected
+++ b/test/command/suite/table_tokenize/output_style/simple.expected
@@ -1,0 +1,4 @@
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenNgram   --normalizer NormalizerAuto
+[[0,0.0,0.0],true]
+table_tokenize Terms "aBcDe 123" --mode ADD --output_style simple
+[[0,0.0,0.0],["abcde","123"]]

--- a/test/command/suite/table_tokenize/output_style/simple.test
+++ b/test/command/suite/table_tokenize/output_style/simple.test
@@ -1,0 +1,5 @@
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenNgram \
+  --normalizer NormalizerAuto
+
+table_tokenize Terms "aBcDe 123" --mode ADD --output_style simple


### PR DESCRIPTION
This change introduces a `output_style` option to the `table_tokenize` command. It will get easier for users to know only tokenized tokens when they want to focus on them.

- **full** (default): preserves the existing behavior.
- **simple**: shows only tokens like `["We","are", …]` for readability.