### PR TITLE
ci: set `env:` before `run:`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -222,39 +222,30 @@ jobs:
             test/command/suite
       - name: "Test: stdio: NFKC121"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "12.1.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: NFKC130"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "13.0.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: NFKC150"
         if: env.GRN_TEST_RUN_ALL == 'yes'
-        run: |
-          grntest \
-            --base-dir test/command \
-            --n-retries=2 \
-            --read-timeout=30 \
-            --reporter=mark \
-            test/command/suite/normalizers/nfkc/
         env:
           NFKC: "15.0.0"
-      - name: "Test: stdio: NFKC: 16.0.0"
-        if: env.GRN_TEST_RUN_ALL == 'yes'
         run: |
           grntest \
             --base-dir test/command \
@@ -262,8 +253,17 @@ jobs:
             --read-timeout=30 \
             --reporter=mark \
             test/command/suite/normalizers/nfkc/
+      - name: "Test: stdio: NFKC: 16.0.0"
+        if: env.GRN_TEST_RUN_ALL == 'yes'
         env:
           NFKC: "16.0.0"
+        run: |
+          grntest \
+            --base-dir test/command \
+            --n-retries=2 \
+            --read-timeout=30 \
+            --reporter=mark \
+            test/command/suite/normalizers/nfkc/
       - name: "Test: stdio: n_workers"
         if: env.GRN_TEST_RUN_ALL == 'yes'
         run: |


### PR DESCRIPTION
It's for readability. `env:` is used in `run:`. If we have `env:` before `run:`, we can read `run:` with "what environment variables are used in this `run:`" information.