### PR TITLE
docs commands/table_tokenize|tokenize: fix `versionadded`

### DIFF
--- a/doc/source/reference/commands/table_tokenize.rst
+++ b/doc/source/reference/commands/table_tokenize.rst
@@ -108,7 +108,7 @@ The ``estimated_size`` is useful for checking estimated frequency of tokens.
 ``output_style``
 """"""""""""""""
 
-.. versionadded:: 15.0.7
+.. versionadded:: 15.0.8
 
 Specifies the output style of the ``table_tokenize`` command.
 

--- a/doc/source/reference/commands/tokenize.rst
+++ b/doc/source/reference/commands/tokenize.rst
@@ -216,7 +216,7 @@ See :doc:`/reference/token_filters` about token filters.
 ``output_style``
 """"""""""""""""
 
-.. versionadded:: 15.0.7
+.. versionadded:: 15.0.8
 
 Specifies the output style of the ``tokenize`` command.
 


### PR DESCRIPTION
This changes fix the `versionadded` because the next version isn't 15.0.7 but 15.0.8.