### PR TITLE
Revert "package: update version info to 15.0.5 (2025-05-08)"

### DIFF
--- a/packages/debian/changelog
+++ b/packages/debian/changelog
@@ -1,9 +1,3 @@
-groonga (15.0.5-1) unstable; urgency=low
-
-  * New upstream release.
-
- -- Abe Tomoaki <abe@clear-code.com>  Thu, 08 May 2025 06:47:14 -0000
-
 groonga (15.0.4-1) unstable; urgency=low
 
   * New upstream release.

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -463,9 +463,6 @@ exit 0
 %endif
 
 %changelog
-* Thu May 08 2025 Abe Tomoaki <abe@clear-code.com> - 15.0.5-1
-- New upstream release.
-
 * Fri Mar 28 2025 Sutou Kouhei <kou@clear-code.com> - 15.0.4-1
 - New upstream release.
 


### PR DESCRIPTION
This reverts commit be4c85460ae076115e10a225fe44b49c2c2a88fc.

Wrong version.
Correct version is 15.0.8.