### PR TITLE
doc news: update release version

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news/15.po
+++ b/doc/locale/ja/LC_MESSAGES/news/15.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "News - 15 series"
 msgstr "お知らせ - 15系"
 
-msgid "Release 15.0.8 - 2025-05-08"
-msgstr "15.0.8リリース - 2025-05-08"
+msgid "Release 15.0.9 - 2025-05-08"
+msgstr "15.0.9リリース - 2025-05-08"
 
 msgid "This release adds the tokenizer's option to make token inspection simpler and improves negative-division semantics for unsigned integer."
 msgstr "このリリースでは、トークナイザのオプションを追加してトークンの確認を簡単にするとともに、符号なし整数を負の数で除算したときのセマンティクスを改善しました。"

--- a/doc/source/news/15.md
+++ b/doc/source/news/15.md
@@ -1,8 +1,8 @@
 # News - 15 series
 
-(release-15-0-8)=
+(release-15-0-9)=
 
-## Release 15.0.8 - 2025-05-08
+## Release 15.0.9 - 2025-05-08
 
 This release adds the tokenizer's option to make token inspection simpler and
 improves negative-division semantics for unsigned integer.


### PR DESCRIPTION
Because we mistake a release of Groonga 15.0.8.
So, we will skip 15.0.8.