### PR TITLE
docs: requirements: Specify the version of snowballstemmer

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,3 +19,6 @@ Sphinx
 myst-parser[linkify]
 pydata_sphinx_theme
 sphinx-markdown-builder
+
+# Document build fails when snowballstemmer 3.0.0 or later is installed.
+snowballstemmer==2.2.0


### PR DESCRIPTION
This is a workaround.
Document build fails when snowballstemmer 3.0.0 or later is installed.

Error example:
```
Traceback
=========

      File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/snowballstemmer/__init__.py", line 27, in stemmer
        raise KeyError("Stemming algorithm '%s' not found" % lang)
    KeyError: "Stemming algorithm 'porter' not found"
```