### PR TITLE
ci release: fix contributors generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          set -opipefail
+          set -o pipefail
 
           latest_news_md=$(cd doc/source/news && \
                              ls *.md | sort --human-numeric-sort | tail -n1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     environment: release
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Download artifacts
         if: |
           github.ref_type == 'tag'
@@ -52,6 +54,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -opipefail
+
           latest_news_md=$(cd doc/source/news && \
                              ls *.md | sort --human-numeric-sort | tail -n1)
           (cd doc/source/news && \


### PR DESCRIPTION
https://github.com/groonga/groonga/actions/runs/14903554778/job/41867597413#step:4:111

```text
$ git shortlog -sn v15.0.4..
fatal: ambiguous argument 'v15.0.4..': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```