### PR TITLE
ci release: fix gem load error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,15 +139,12 @@ jobs:
           echo "trusted-key ${LAUNCHPAD_UPLOADER_PGP_KEY}" > ~/.gnupg/gpg.conf
           rake -C packages ubuntu
       - uses: ruby/setup-ruby@v1
-        if: |
-          github.ref_type == 'tag'
         with:
           ruby-version: ruby
           bundler-cache: true
       - name: Post Announcement
-        if: |
-          github.ref_type == 'tag'
         env:
+          DRY_RUN: ${{ github.ref_type != 'tag' }}
           X_API_KEY: ${{ secrets.X_API_KEY }}
           X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,4 +153,4 @@ jobs:
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
         run: |
-          VERSION=${GITHUB_REF_NAME#v} rake release:announce
+          VERSION=${GITHUB_REF_NAME#v} bundle exec rake release:announce

--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,5 @@
 
 source "https://rubygems.org"
 
+gem "rake"
 gem "x"

--- a/Rakefile
+++ b/Rakefile
@@ -246,17 +246,18 @@ Groonga #{version} (#{latest_release_date}) has been released!
 #{latest_release_note_summary}
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE
-    puts latest_release_announce
 
-    unless ENV["DRY_RUN"]
-      x_credentials = {
-        api_key: ENV["X_API_KEY"],
-        api_key_secret: ENV["X_API_KEY_SECRET"],
-        access_token: ENV["X_ACCESS_TOKEN"],
-        access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
-      }
-      x_client = X::Client.new(**x_credentials)
-      tweet_body = { text: latest_release_announce }
+    x_credentials = {
+      api_key: ENV["X_API_KEY"],
+      api_key_secret: ENV["X_API_KEY_SECRET"],
+      access_token: ENV["X_ACCESS_TOKEN"],
+      access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
+    }
+    x_client = X::Client.new(**x_credentials)
+    tweet_body = { text: latest_release_announce }
+    if ENV["DRY_RUN"]
+      puts tweet_body
+    else
       x_client.post("tweets", tweet_body.to_json)
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -233,8 +233,8 @@ namespace :release do
     latest_release_note_title = latest_release_note.lines.first
     latest_release_note_content = latest_release_note.lines[1..-1].join
     latest_release_note_version = latest_release_note_title[/[\d.]+/]
-    if !dry_run? && (latest_release_note_version != version)
-      raise "release note isn't written"
+    if latest_release_note_version != version
+      raise "release note isn't written" unless dry_run?
     end
     latest_release_note_summary =
       latest_release_note_content.split(/^### /, 2)[0].strip

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ def env_var(name, default=nil)
 end
 
 def dry_run?
-  env_var("DRY_RUN", default="true") == "true"
+  env_var("DRY_RUN", "false") == "true"
 end
 
 def git_user_name

--- a/Rakefile
+++ b/Rakefile
@@ -229,7 +229,7 @@ namespace :release do
     latest_release_note_title = latest_release_note.lines.first
     latest_release_note_content = latest_release_note.lines[1..-1].join
     latest_release_note_version = latest_release_note_title[/[\d.]+/]
-    if latest_release_note_version != version
+    if !ENV["DRY_RUN"] && (latest_release_note_version != version)
       raise "release note isn't written"
     end
     latest_release_note_summary =
@@ -246,16 +246,19 @@ Groonga #{version} (#{latest_release_date}) has been released!
 #{latest_release_note_summary}
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE
+    puts latest_release_announce
 
-    x_credentials = {
-      api_key: ENV["X_API_KEY"],
-      api_key_secret: ENV["X_API_KEY_SECRET"],
-      access_token: ENV["X_ACCESS_TOKEN"],
-      access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
-    }
-    x_client = X::Client.new(**x_credentials)
-    tweet_body = { text: latest_release_announce }
-    x_client.post("tweets", tweet_body.to_json)
+    unless ENV["DRY_RUN"]
+      x_credentials = {
+        api_key: ENV["X_API_KEY"],
+        api_key_secret: ENV["X_API_KEY_SECRET"],
+        access_token: ENV["X_ACCESS_TOKEN"],
+        access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
+      }
+      x_client = X::Client.new(**x_credentials)
+      tweet_body = { text: latest_release_announce }
+      x_client.post("tweets", tweet_body.to_json)
+    end
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -61,6 +61,10 @@ def env_var(name, default=nil)
   value
 end
 
+def dry_run?
+  env_var("DRY_RUN", default="true") == "true"
+end
+
 def git_user_name
   sh_capture_output("git", "config", "--get", "user.name").chomp
 end
@@ -229,7 +233,7 @@ namespace :release do
     latest_release_note_title = latest_release_note.lines.first
     latest_release_note_content = latest_release_note.lines[1..-1].join
     latest_release_note_version = latest_release_note_title[/[\d.]+/]
-    if !ENV["DRY_RUN"] && (latest_release_note_version != version)
+    if !dry_run? && (latest_release_note_version != version)
       raise "release note isn't written"
     end
     latest_release_note_summary =
@@ -255,7 +259,7 @@ See: #{latest_release_url}#{latest_release_anchor}
     }
     x_client = X::Client.new(**x_credentials)
     tweet_body = { text: latest_release_announce }
-    if ENV["DRY_RUN"]
+    if dry_run?
       puts tweet_body
     else
       x_client.post("tweets", tweet_body.to_json)


### PR DESCRIPTION
GitHub: GH-2315

## Problem

In release workflow, the following error happened
because gem `x` isn't loaded.

```
Run VERSION=${GITHUB_REF_NAME#v} rake release:announce
  VERSION=${GITHUB_REF_NAME#v} rake release:announce
  shell: /usr/bin/bash -e {0}
  env:
    X_API_KEY: ***
    X_API_KEY_SECRET: ***
    X_ACCESS_TOKEN: ***
    X_ACCESS_TOKEN_SECRET: ***
git ls-files
rake aborted!
LoadError: cannot load such file -- x (LoadError)
<internal:/opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
<internal:/opt/hostedtoolcache/Ruby/3.4.3/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:136:in 'Kernel#require'
/home/runner/work/groonga/groonga/Rakefile:223:in 'block (2 levels) in <top (required)>'
Tasks: TOP => release:announce
(See full trace by running task with --trace)
```

## Solution

Using `bundle exec` loads gems including gem `x` in Gemfile.
And also we added the dry-run mode to check whether the announcement works or not.