### PR TITLE
TokenMecab: add `internal_delimiter` option

### DIFF
--- a/lib/grn_str.h
+++ b/lib/grn_str.h
@@ -53,6 +53,8 @@ grn_str_len(grn_ctx *ctx,
 #define GRN_STR_CTYPE(c)   (c & 0x7f)
 
 GRN_API int
+grn_istab(const char *str);
+GRN_API int
 grn_isspace(const char *s, grn_encoding encoding);
 int8_t
 grn_atoi8(const char *nptr, const char *end, const char **rest);

--- a/lib/str.c
+++ b/lib/str.c
@@ -1515,6 +1515,12 @@ grn_str_len(grn_ctx *ctx,
 }
 
 int
+grn_istab(const char *str)
+{
+  return (str[0] == '\t') ? 1 : 0;
+}
+
+int
 grn_isspace(const char *str, grn_encoding encoding)
 {
   const unsigned char *s = (const unsigned char *)str;

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/space.expected
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/space.expected
@@ -1,0 +1,22 @@
+tokenize   'TokenMecab("internal_delimiter",               "space")'   '聞き 糺せん'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "聞き",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "糺せん",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/space.test
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/space.test
@@ -1,0 +1,6 @@
+#@require-feature mecab
+
+tokenize \
+  'TokenMecab("internal_delimiter", \
+              "space")' \
+  '聞き 糺せん'

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab.expected
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab.expected
@@ -1,0 +1,16 @@
+tokenize   'TokenMecab("internal_delimiter",               "tab")'   '聞き 糺せん'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "聞き 糺せん",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab.test
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab.test
@@ -1,0 +1,6 @@
+#@require-feature mecab
+
+tokenize \
+  'TokenMecab("internal_delimiter", \
+              "tab")' \
+  '聞き 糺せん'

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab_with_sentence.expected
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab_with_sentence.expected
@@ -1,0 +1,40 @@
+tokenize   'TokenMecab("internal_delimiter",               "tab")'   '真相は聞き 糺せん。'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "真相",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "は",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "聞き 糺せ",
+      "position": 2,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "ん",
+      "position": 3,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "。",
+      "position": 4,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab_with_sentence.test
+++ b/test/command/suite/tokenizers/mecab/options/internal_delimiter/tab_with_sentence.test
@@ -1,0 +1,6 @@
+#@require-feature mecab
+
+tokenize \
+  'TokenMecab("internal_delimiter", \
+              "tab")' \
+  '真相は聞き 糺せん。'


### PR DESCRIPTION
## Problem

User-defined dictionary entries with embedded spaces (e.g. “search engine”) are correctly recognized by MeCab itself. But when using TokenMecab in `-Owakati` mode we split on every space. As a result,
“search engine” ends up as two tokens (“search” and “engine”) instead of one.

## Cause

TokenMecab passes the `-Owakati` flag to MeCab and then treats the output as space-delimited. Any
internal spaces in dictionary entries are therefore mis-interpreted as token boundaries.

## Solution

Introduce a new `internal_delimiter` option. When set to `"tab"`, TokenMecab invokes MeCab with `-F%m\t` to emit tab-delimited tokens, and uses a tab to split the tokens. This preserves entries containing spaces as single tokens while retaining backward compatibility with the default space-delimited behavior.