### PR TITLE
db: handle empty names and null pointers

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1271,10 +1271,13 @@ grn_rc
 grn_db_check_name(grn_ctx *ctx, const char *name, unsigned int name_size)
 {
   int len;
-  const char *name_end = name + name_size;
-  if (name_size > 0 && *name == GRN_DB_PSEUDO_COLUMN_PREFIX) {
+  if (name_size == 0) {
+    return GRN_SUCCESS;
+  }
+  if (name == NULL || (name_size > 0 && *name == GRN_DB_PSEUDO_COLUMN_PREFIX)) {
     return GRN_INVALID_ARGUMENT;
   }
+  const char *name_end = name + name_size;
   while (name < name_end) {
     char c = *name;
     if ((unsigned int)((c | 0x20) - 'a') >= 26u &&

--- a/lib/db.c
+++ b/lib/db.c
@@ -1274,7 +1274,7 @@ grn_db_check_name(grn_ctx *ctx, const char *name, unsigned int name_size)
   if (name_size == 0) {
     return GRN_SUCCESS;
   }
-  if (name == NULL || (name_size > 0 && *name == GRN_DB_PSEUDO_COLUMN_PREFIX)) {
+  if (!name || *name == GRN_DB_PSEUDO_COLUMN_PREFIX) {
     return GRN_INVALID_ARGUMENT;
   }
   const char *name_end = name + name_size;


### PR DESCRIPTION
## Problem

Using UBSAN raised the following error.

```
/home/runner/work/groonga/groonga/lib/db.c:1274:31: runtime error: applying zero offset to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/runner/work/groonga/groonga/lib/db.c:1274:31
```

## Cause

We tried to calculate the offset by adding name_size to null pointer in `name = NULL` case.