### PR TITLE
db: enable fulltext search on `_key` when using a reference column's index

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -15518,6 +15518,7 @@ grn_column_find_index_data_accessor_is_key_search(grn_ctx *ctx,
             (accessor->obj->header.flags & GRN_OBJ_KEY_WITH_SIS));
   case GRN_OP_EQUAL:
   case GRN_OP_NOT_EQUAL:
+  case GRN_OP_MATCH:
     switch (accessor->obj->header.type) {
     case GRN_TABLE_HASH_KEY:
     case GRN_TABLE_PAT_KEY:

--- a/test/command/suite/select/filter/no_index/match/key_text.expected
+++ b/test/command/suite/select/filter/no_index/match/key_text.expected
@@ -6,4 +6,4 @@ load --table Memos
 ]
 [[0,0.0,0.0],1]
 select Memos --filter '_key @ "gROONGA"'
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[1,"Groonga"]]]]
+[[0,0.0,0.0],[[[0],[["_id","UInt32"],["_key","ShortText"]]]]]

--- a/test/command/suite/select/match_columns/index/key/reference_dat.expected
+++ b/test/command/suite/select/match_columns/index/key/reference_dat.expected
@@ -1,0 +1,46 @@
+table_create ProductNames TABLE_DAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_DAT_KEY ProductNames
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "products_key",
+          "Products"
+        ]
+      ],
+      [
+        2,
+        "Groonga",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/match_columns/index/key/reference_dat.test
+++ b/test/command/suite/select/match_columns/index/key/reference_dat.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_DAT_KEY ShortText
+table_create Products TABLE_DAT_KEY ProductNames
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/match_columns/index/key/reference_hash.expected
+++ b/test/command/suite/select/match_columns/index/key/reference_hash.expected
@@ -1,0 +1,46 @@
+table_create ProductNames TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_HASH_KEY ProductNames
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "products_key",
+          "Products"
+        ]
+      ],
+      [
+        2,
+        "Groonga",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/match_columns/index/key/reference_hash.test
+++ b/test/command/suite/select/match_columns/index/key/reference_hash.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_HASH_KEY ShortText
+table_create Products TABLE_HASH_KEY ProductNames
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/match_columns/index/key/reference_pat.expected
+++ b/test/command/suite/select/match_columns/index/key/reference_pat.expected
@@ -1,0 +1,46 @@
+table_create ProductNames TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_PAT_KEY ProductNames
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "products_key",
+          "Products"
+        ]
+      ],
+      [
+        2,
+        "Groonga",
+        1
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/select/match_columns/index/key/reference_pat.test
+++ b/test/command/suite/select/match_columns/index/key/reference_pat.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_PAT_KEY ShortText
+table_create Products TABLE_PAT_KEY ProductNames
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/match_columns/index/key/text_dat.expected
+++ b/test/command/suite/select/match_columns/index/key/text_dat.expected
@@ -1,0 +1,14 @@
+table_create ProductNames TABLE_DAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_DAT_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[2,"Groonga"]]]]

--- a/test/command/suite/select/match_columns/index/key/text_dat.test
+++ b/test/command/suite/select/match_columns/index/key/text_dat.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_DAT_KEY ShortText
+table_create Products TABLE_DAT_KEY ShortText
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/match_columns/index/key/text_hash.expected
+++ b/test/command/suite/select/match_columns/index/key/text_hash.expected
@@ -1,0 +1,14 @@
+table_create ProductNames TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[2,"Groonga"]]]]

--- a/test/command/suite/select/match_columns/index/key/text_hash.test
+++ b/test/command/suite/select/match_columns/index/key/text_hash.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_HASH_KEY ShortText
+table_create Products TABLE_HASH_KEY ShortText
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/match_columns/index/key/text_pat.expected
+++ b/test/command/suite/select/match_columns/index/key/text_pat.expected
@@ -1,0 +1,14 @@
+table_create ProductNames TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Products TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+[[0,0.0,0.0],2]
+column_create ProductNames products_key COLUMN_INDEX Products _key
+[[0,0.0,0.0],true]
+select Products --match_columns _key --query "Groonga"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[2,"Groonga"]]]]

--- a/test/command/suite/select/match_columns/index/key/text_pat.test
+++ b/test/command/suite/select/match_columns/index/key/text_pat.test
@@ -1,0 +1,12 @@
+table_create ProductNames TABLE_PAT_KEY ShortText
+table_create Products TABLE_PAT_KEY ShortText
+
+load --table Products
+[
+  {"_key": "PGroonga"},
+  {"_key": "Groonga"}
+]
+
+column_create ProductNames products_key COLUMN_INDEX Products _key
+
+select Products --match_columns _key --query "Groonga"

--- a/test/command/suite/select/query_flags/disable_and_not/around_space.expected
+++ b/test/command/suite/select/query_flags/disable_and_not/around_space.expected
@@ -1,11 +1,17 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("n", 1)'
+[[0,0.0,0.0],true]
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "bob"},
-{"_key": "cab-"}
+{"name": "alice"},
+{"name": "bob"},
+{"name": "cab-"}
 ]
 [[0,0.0,0.0],3]
-select Users   --match_columns "_key"   --query "b - a"   --query_flags "DISABLE_AND_NOT"
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[3,"cab-"]]]]
+column_create Names user_name COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+select Users   --match_columns "name"   --query "b - a"   --query_flags "DISABLE_AND_NOT"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["name","ShortText"]],[3,"cab-"]]]]

--- a/test/command/suite/select/query_flags/disable_and_not/around_space.test
+++ b/test/command/suite/select/query_flags/disable_and_not/around_space.test
@@ -1,13 +1,19 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("n", 1)'
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "bob"},
-{"_key": "cab-"}
+{"name": "alice"},
+{"name": "bob"},
+{"name": "cab-"}
 ]
 
+column_create Names user_name COLUMN_INDEX Users name
+
 select Users \
-  --match_columns "_key" \
+  --match_columns "name" \
   --query "b - a" \
   --query_flags "DISABLE_AND_NOT"

--- a/test/command/suite/select/query_flags/disable_and_not/before_space.expected
+++ b/test/command/suite/select/query_flags/disable_and_not/before_space.expected
@@ -1,11 +1,17 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("n", 2)'
+[[0,0.0,0.0],true]
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "bob"},
-{"_key": "c-ab"}
+{"name": "alice"},
+{"name": "bob"},
+{"name": "c-ab"}
 ]
 [[0,0.0,0.0],3]
-select Users   --match_columns "_key"   --query "b -a"   --query_flags "DISABLE_AND_NOT"
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[3,"c-ab"]]]]
+column_create Names user_name COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+select Users   --match_columns "name"   --query "b -a"   --query_flags "DISABLE_AND_NOT"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["name","ShortText"]],[3,"c-ab"]]]]

--- a/test/command/suite/select/query_flags/disable_and_not/before_space.test
+++ b/test/command/suite/select/query_flags/disable_and_not/before_space.test
@@ -1,13 +1,19 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("n", 2)'
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "bob"},
-{"_key": "c-ab"}
+{"name": "alice"},
+{"name": "bob"},
+{"name": "c-ab"}
 ]
 
+column_create Names user_name COLUMN_INDEX Users name
+
 select Users \
-  --match_columns "_key" \
+  --match_columns "name" \
   --query "b -a" \
   --query_flags "DISABLE_AND_NOT"

--- a/test/command/suite/select/query_flags/disable_and_not/leading_not.expected
+++ b/test/command/suite/select/query_flags/disable_and_not/leading_not.expected
@@ -1,10 +1,16 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("n", 2)'
+[[0,0.0,0.0],true]
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "b-a"}
+{"name": "alice"},
+{"name": "b-a"}
 ]
 [[0,0.0,0.0],2]
-select Users   --match_columns "_key"   --query "-a"   --query_flags "DISABLE_AND_NOT"
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[2,"b-a"]]]]
+column_create Names user_name COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+select Users   --match_columns "name"   --query "-a"   --query_flags "DISABLE_AND_NOT"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["name","ShortText"]],[2,"b-a"]]]]

--- a/test/command/suite/select/query_flags/disable_and_not/leading_not.test
+++ b/test/command/suite/select/query_flags/disable_and_not/leading_not.test
@@ -1,12 +1,18 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("n", 2)'
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "b-a"}
+{"name": "alice"},
+{"name": "b-a"}
 ]
 
+column_create Names user_name COLUMN_INDEX Users name
+
 select Users \
-  --match_columns "_key" \
+  --match_columns "name" \
   --query "-a" \
   --query_flags "DISABLE_AND_NOT"

--- a/test/command/suite/select/query_flags/disable_prefix_search/allow_column.expected
+++ b/test/command/suite/select/query_flags/disable_prefix_search/allow_column.expected
@@ -1,11 +1,17 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("n", 2)'
+[[0,0.0,0.0],true]
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "alan"},
-{"_key": "^a"}
+{"name": "alice"},
+{"name": "alan"},
+{"name": "^a"}
 ]
 [[0,0.0,0.0],3]
-select Users   --query "_key:^a"   --query_flags "ALLOW_COLUMN|DISABLE_PREFIX_SEARCH"
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[3,"^a"]]]]
+column_create Names user_name COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+select Users   --query "name:^a"   --query_flags "ALLOW_COLUMN|DISABLE_PREFIX_SEARCH"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["name","ShortText"]],[3,"^a"]]]]

--- a/test/command/suite/select/query_flags/disable_prefix_search/allow_column.test
+++ b/test/command/suite/select/query_flags/disable_prefix_search/allow_column.test
@@ -1,12 +1,18 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("n", 2)'
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "alan"},
-{"_key": "^a"}
+{"name": "alice"},
+{"name": "alan"},
+{"name": "^a"}
 ]
 
+column_create Names user_name COLUMN_INDEX Users name
+
 select Users \
-  --query "_key:^a" \
+  --query "name:^a" \
   --query_flags "ALLOW_COLUMN|DISABLE_PREFIX_SEARCH"

--- a/test/command/suite/select/query_flags/disable_prefix_search/asterisk.expected
+++ b/test/command/suite/select/query_flags/disable_prefix_search/asterisk.expected
@@ -1,11 +1,17 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText   --default_tokenizer 'TokenNgram("n", 2)'
+[[0,0.0,0.0],true]
+table_create Users TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Users name COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "alan"},
-{"_key": "ba*"}
+{"name": "alice"},
+{"name": "alan"},
+{"name": "ba*"}
 ]
 [[0,0.0,0.0],3]
-select Users   --match_columns "_key"   --query "a*"   --query_flags "DISABLE_PREFIX_SEARCH"
-[[0,0.0,0.0],[[[1],[["_id","UInt32"],["_key","ShortText"]],[3,"ba*"]]]]
+column_create Names user_name COLUMN_INDEX Users name
+[[0,0.0,0.0],true]
+select Users   --match_columns "name"   --query "a*"   --query_flags "DISABLE_PREFIX_SEARCH"
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["name","ShortText"]],[3,"ba*"]]]]

--- a/test/command/suite/select/query_flags/disable_prefix_search/asterisk.test
+++ b/test/command/suite/select/query_flags/disable_prefix_search/asterisk.test
@@ -1,13 +1,19 @@
-table_create Users TABLE_PAT_KEY ShortText
+table_create Names TABLE_PAT_KEY ShortText \
+  --default_tokenizer 'TokenNgram("n", 2)'
+
+table_create Users TABLE_NO_KEY
+column_create Users name COLUMN_SCALAR ShortText
 
 load --table Users
 [
-{"_key": "alice"},
-{"_key": "alan"},
-{"_key": "ba*"}
+{"name": "alice"},
+{"name": "alan"},
+{"name": "ba*"}
 ]
 
+column_create Names user_name COLUMN_INDEX Users name
+
 select Users \
-  --match_columns "_key" \
+  --match_columns "name" \
   --query "a*" \
   --query_flags "DISABLE_PREFIX_SEARCH"

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
@@ -136,7 +136,7 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
       ],
       "start": [
         [
-          2
+          1
         ],
         [
           [
@@ -146,9 +146,6 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
         ],
         [
           "Start"
-        ],
-        [
-          "Restart"
         ]
       ]
     }
@@ -163,12 +160,12 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
 #:000000000000000 drilldowns[restart].filter(1)
 #:000000000000000 drilldowns[action](1)
 #:000000000000000 drilldowns[start](3)
-#:000000000000000 filter(2): #<accessor _key(anonymous)> match "Start"
-#:000000000000000 drilldowns[start].filter(2)
+#:000000000000000 filter(1): #<accessor _key(anonymous)> match "Start"
+#:000000000000000 drilldowns[start].filter(1)
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action](1)
 #:000000000000000 output.drilldowns[restart](1)
-#:000000000000000 output.drilldowns[start](2)
+#:000000000000000 output.drilldowns[start](1)
 #:000000000000000 send(0)
 #<000000000000000 rc=0
 logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id   --drilldowns[action].table start   --drilldowns[action].keys _key   --drilldowns[restart].stage initial   --drilldowns[restart].keys 'action'   --drilldowns[restart].filter "_key @ 'Restart'"   --drilldowns[restart].output_columns _key   --drilldowns[start].stage initial   --drilldowns[start].keys 'action'   --drilldowns[start].filter "_key @ 'Start'"   --drilldowns[start].output_columns _key
@@ -193,7 +190,7 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
     {
       "action": [
         [
-          2
+          1
         ],
         [
           [
@@ -207,10 +204,6 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
         ],
         [
           "Start",
-          1
-        ],
-        [
-          "Restart",
           1
         ]
       ],
@@ -230,7 +223,7 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
       ],
       "start": [
         [
-          2
+          1
         ],
         [
           [
@@ -240,9 +233,6 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
         ],
         [
           "Start"
-        ],
-        [
-          "Restart"
         ]
       ]
     }
@@ -253,15 +243,15 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
 #:000000000000000 drilldowns[start](3)
-#:000000000000000 filter(2): #<accessor _key(anonymous)> match "Start"
-#:000000000000000 drilldowns[start].filter(2)
-#:000000000000000 drilldowns[action](2)
+#:000000000000000 filter(1): #<accessor _key(anonymous)> match "Start"
+#:000000000000000 drilldowns[start].filter(1)
+#:000000000000000 drilldowns[action](1)
 #:000000000000000 drilldowns[restart](3)
 #:000000000000000 filter(1): #<accessor _key(anonymous)> match "Restart"
 #:000000000000000 drilldowns[restart].filter(1)
 #:000000000000000 output(0)
-#:000000000000000 output.drilldowns[action](2)
+#:000000000000000 output.drilldowns[action](1)
 #:000000000000000 output.drilldowns[restart](1)
-#:000000000000000 output.drilldowns[start](2)
+#:000000000000000 output.drilldowns[start](1)
 #:000000000000000 send(0)
 #<000000000000000 rc=0


### PR DESCRIPTION
GitHub: GH-1896

## Problem

Fulltext search on a table's `_key` column was not using the index when the index was defined via a reference column.
It means the following query with reference columns always falls back to a sequential scan with the reference column's index.

As a result, the following case, which was expected to return index‐based behavior, returned unexpected results (e.g. matching both "fr1" and "fr10" instead of only "fr1").

```
table_create CouponNames TABLE_HASH_KEY ShortText
table_create Coupons TABLE_HASH_KEY CouponNames

load --table Coupons
[
  {"_key": "fr1"},
  {"_key": "fr10"}
]

column_create CouponNames coupons_key COLUMN_INDEX Coupons _key

select Coupons --match_columns "_key" --query fr1
```
```
[
  [
    0,
    0.0,
    0.0
  ],
  [
    [
      [
        2
      ],
      [
        [
          "_id",
          "UInt32"
        ],
        [
          "_key",
          "ShortText"
        ],
        [
          "coupons_key",
          "Coupons"
        ]
      ],
      [
        1,
        "fr1",
        1
      ],
      [
        2,
        "fr10",
        1
      ]
    ]
  ]
]
```

## Cause

In the codepath that determines whether a key‐based search could use an index, the `GRN_OP_MATCH` operator
(fulltext search uses this operator) was not being treated as a "key search".

## Solution

We updated the logic so that `GRN_OP_MATCH` is treated as a key search when `_key` has been indexed
through a reference column.

Also, we updated some test cases to reflect index‐scan behavior instead of sequential‐scan behavior because
fulltext search for `_key` now leverages the index.
