### PR TITLE
pat:  grn_pat_total_key_size() support KEY_LARGE flag

### DIFF
--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -68,6 +68,7 @@ struct grn_pat_header {
   uint32_t n_entries;
   uint32_t curr_rec;
   uint32_t curr_key;
+  uint64_t curr_key_large;
   uint32_t curr_del;
   uint32_t curr_del2;
   uint32_t curr_del3;
@@ -76,7 +77,7 @@ struct grn_pat_header {
   uint32_t truncated;
   uint32_t n_dirty_opens;
   uint64_t wal_id;
-  uint32_t reserved[1000];
+  uint32_t reserved[998];
   grn_pat_delinfo delinfos[GRN_PAT_NDELINFOS];
   grn_id garbages[GRN_PAT_MAX_KEY_SIZE + 1];
 };

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -136,7 +136,7 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
                      grn_fuzzy_search_optarg *args,
                      grn_hash *h);
 
-uint32_t
+uint64_t
 grn_pat_total_key_size(grn_ctx *ctx, grn_pat *pat);
 
 bool

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -68,7 +68,6 @@ struct grn_pat_header {
   uint32_t n_entries;
   uint32_t curr_rec;
   uint32_t curr_key;
-  uint64_t curr_key_large;
   uint32_t curr_del;
   uint32_t curr_del2;
   uint32_t curr_del3;
@@ -77,6 +76,7 @@ struct grn_pat_header {
   uint32_t truncated;
   uint32_t n_dirty_opens;
   uint64_t wal_id;
+  uint64_t curr_key_large;
   uint32_t reserved[998];
   grn_pat_delinfo delinfos[GRN_PAT_NDELINFOS];
   grn_id garbages[GRN_PAT_MAX_KEY_SIZE + 1];

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5269,15 +5269,20 @@ grn_pat_inspect_nodes(grn_ctx *ctx, grn_pat *pat, grn_obj *buf)
 {
   pat_node *node;
   grn_obj key_buf;
+  bool is_large_mode = pat_key_is_large_total_key_size(pat);
 
   GRN_TEXT_PUTS(ctx, buf, "{");
   PAT_AT(pat, GRN_ID_NIL, node);
-  if (node->lr[1] != GRN_ID_NIL) {
-    GRN_TEXT_PUTS(ctx, buf, "\n");
-    GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
-    grn_pat_inspect_node(ctx, pat, node->lr[1], -1, &key_buf, 0, "", buf);
-    GRN_OBJ_FIN(ctx, &key_buf);
-    GRN_TEXT_PUTS(ctx, buf, "\n");
+  if (is_large_mode) {
+    ; //TODO: implement if pat node have large key
+  } else {
+    if (node->lr[1] != GRN_ID_NIL) {
+      GRN_TEXT_PUTS(ctx, buf, "\n");
+      GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
+      grn_pat_inspect_node(ctx, pat, node->lr[1], -1, &key_buf, 0, "", buf);
+      GRN_OBJ_FIN(ctx, &key_buf);
+      GRN_TEXT_PUTS(ctx, buf, "\n");
+    }
   }
   GRN_TEXT_PUTS(ctx, buf, "}");
 }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5831,10 +5831,14 @@ set_cursor_rk(grn_ctx *ctx,
   return ctx->rc;
 }
 
-uint32_t
+uint64_t
 grn_pat_total_key_size(grn_ctx *ctx, grn_pat *pat)
 {
-  return pat->header->curr_key;
+  if (pat_is_key_large(pat)) {
+    return pat->header->curr_key_large;
+  } else {
+    return pat->header->curr_key;
+  }
 }
 
 bool

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -94,7 +94,7 @@ typedef struct {
 #define PAT_IMMEDIATE (1 << 2)
 
 static inline bool
-pat_key_is_large_total_key_size(grn_pat *pat)
+pat_is_key_large(grn_pat *pat)
 {
   return (pat->header->flags & GRN_OBJ_KEY_LARGE) == GRN_OBJ_KEY_LARGE;
 }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1,6 +1,7 @@
 /*
   Copyright (C) 2009-2018  Brazil
   Copyright (C) 2018-2023  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2025  Horimoto Yasuhiro <horimoto@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -91,6 +92,12 @@ typedef struct {
 
 #define PAT_DELETING  (1 << 1)
 #define PAT_IMMEDIATE (1 << 2)
+
+static inline bool
+pat_key_is_large_total_key_size(grn_pat *pat)
+{
+  return (pat->header->flags & GRN_OBJ_KEY_LARGE) == GRN_OBJ_KEY_LARGE;
+}
 
 static inline bool
 pat_key_is_embeddable(uint32_t key_size)

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5269,20 +5269,15 @@ grn_pat_inspect_nodes(grn_ctx *ctx, grn_pat *pat, grn_obj *buf)
 {
   pat_node *node;
   grn_obj key_buf;
-  bool is_large_mode = pat_is_key_large(pat);
 
   GRN_TEXT_PUTS(ctx, buf, "{");
   PAT_AT(pat, GRN_ID_NIL, node);
-  if (is_large_mode) {
-    ; // TODO: implement if pat node have large key
-  } else {
-    if (node->lr[1] != GRN_ID_NIL) {
-      GRN_TEXT_PUTS(ctx, buf, "\n");
-      GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
-      grn_pat_inspect_node(ctx, pat, node->lr[1], -1, &key_buf, 0, "", buf);
-      GRN_OBJ_FIN(ctx, &key_buf);
-      GRN_TEXT_PUTS(ctx, buf, "\n");
-    }
+  if (node->lr[1] != GRN_ID_NIL) {
+    GRN_TEXT_PUTS(ctx, buf, "\n");
+    GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
+    grn_pat_inspect_node(ctx, pat, node->lr[1], -1, &key_buf, 0, "", buf);
+    GRN_OBJ_FIN(ctx, &key_buf);
+    GRN_TEXT_PUTS(ctx, buf, "\n");
   }
   GRN_TEXT_PUTS(ctx, buf, "}");
 }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5274,7 +5274,7 @@ grn_pat_inspect_nodes(grn_ctx *ctx, grn_pat *pat, grn_obj *buf)
   GRN_TEXT_PUTS(ctx, buf, "{");
   PAT_AT(pat, GRN_ID_NIL, node);
   if (is_large_mode) {
-    ; //TODO: implement if pat node have large key
+    ; // TODO: implement if pat node have large key
   } else {
     if (node->lr[1] != GRN_ID_NIL) {
       GRN_TEXT_PUTS(ctx, buf, "\n");

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1555,6 +1555,7 @@ _grn_pat_create(grn_ctx *ctx,
   header->n_entries = 0;
   header->curr_rec = 0;
   header->curr_key = 0;
+  header->curr_key_large = 0;
   header->curr_del = 0;
   header->curr_del2 = 0;
   header->curr_del3 = 0;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5269,7 +5269,7 @@ grn_pat_inspect_nodes(grn_ctx *ctx, grn_pat *pat, grn_obj *buf)
 {
   pat_node *node;
   grn_obj key_buf;
-  bool is_large_mode = pat_key_is_large_total_key_size(pat);
+  bool is_large_mode = pat_is_key_large(pat);
 
   GRN_TEXT_PUTS(ctx, buf, "{");
   PAT_AT(pat, GRN_ID_NIL, node);


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

I also modify the return value type of `grn_pat_total_key_size()`.
However, no problem that the return value type of `grn_pat_total_key_size()` is change to `uint64_t` from `uint32_t`.

Because the following two reasons.

1. Currently, `grn_pat_total_key_size()` use only as argument of `grn_ctx_output_uint64()` as below.

```c
grn_ctx_output_uint64(ctx, grn_pat_total_key_size(ctx, pat));
```

2. The second argument type of `grn_ctx_output_uint64()` is uint64_t as below. 

```c
void
grn_ctx_output_uint64(grn_ctx *ctx, uint64_t value)
{
  grn_output_uint64(ctx, ctx->impl->output.buf, ctx->impl->output.type, value);
}
``` 