### PR TITLE
ci: cmake: Utilize `rubygems-requirements-system`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -168,8 +168,8 @@ jobs:
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          echo "LD_LIBRARY_PATH=$PWD/install/lib" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=$PWD/lib/pkgconfig" >> ${GITHUB_ENV}
+          echo "LD_LIBRARY_PATH=${PWD}/install/lib" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \
                "${{ matrix.mruby }}" == "" ]; then
@@ -179,10 +179,11 @@ jobs:
             echo "GRN_TEST_RUN_COMMAND_LINE=yes" >> ${GITHUB_ENV}
           fi
 
-          echo "$PWD/install/bin" >> ${GITHUB_PATH}
+          echo "${PWD}/install/bin" >> ${GITHUB_PATH}
       - name: Install test dependencies
         run: |
-          sudo env MAKEFLAGS=-j$(nproc) gem install \
+          sudo gem install rubygems-requirements-system
+          sudo --preserve-env env MAKEFLAGS=-j$(nproc) gem install \
             grntest \
             pkg-config \
             red-arrow \


### PR DESCRIPTION
Related: GitHub GH-2353

It automatically installs dependent libraries.