### PR TITLE
packages: test: Utilize `rubygems-requirements-system`

### DIFF
--- a/packages/apt/test.sh
+++ b/packages/apt/test.sh
@@ -63,6 +63,7 @@ apt install -V -y \
   make \
   ruby-dev \
   tzdata
+gem install rubygems-requirements-system
 MAKEFLAGS=-j$(nproc) gem install grntest
 
 if groonga --version | grep -q apache-arrow; then

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -72,6 +72,7 @@ if [ "${run_test}" = "yes" ]; then
   if [ ${os} != "amazon-linux" ]; then
     ${DNF} install -y redhat-rpm-config
   fi
+  gem install rubygems-requirements-system
   MAKEFLAGS=-j$(nproc) gem install grntest
 
   export TZ=Asia/Tokyo


### PR DESCRIPTION
Related: GitHub GH-2353, GH-2355
It automatically installs dependent libraries.