### PR TITLE
pat: allow use KEY_LARGE flag on TABLE_PAT_KEY

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -1598,10 +1598,11 @@ grn_table_create_validate(grn_ctx *ctx,
     return ctx->rc;
   }
 
-  if ((flags & GRN_OBJ_KEY_LARGE) && table_type != GRN_OBJ_TABLE_HASH_KEY) {
+  if ((flags & GRN_OBJ_KEY_LARGE) && (table_type != GRN_OBJ_TABLE_HASH_KEY
+                                      && table_type != GRN_OBJ_TABLE_PAT_KEY) ) {
     ERR(GRN_INVALID_ARGUMENT,
         "[table][create] "
-        "large key support is available only for TABLE_HASH_KEY key table: "
+        "large key support is available for TABLE_HASH_KEY and TABLE_PAT_KEY key table: "
         "<%.*s>(%s)",
         name_size,
         name,

--- a/test/command/suite/dump/schema/table/patricia_trie/key_large_flag.expected
+++ b/test/command/suite/dump/schema/table/patricia_trie/key_large_flag.expected
@@ -1,0 +1,4 @@
+table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+dump
+table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText

--- a/test/command/suite/dump/schema/table/patricia_trie/key_large_flag.test
+++ b/test/command/suite/dump/schema/table/patricia_trie/key_large_flag.test
@@ -1,0 +1,3 @@
+table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText
+
+dump

--- a/test/command/suite/table_create/key_large/double_array_trie.expected
+++ b/test/command/suite/table_create/key_large/double_array_trie.expected
@@ -1,0 +1,13 @@
+table_create Users TABLE_DAT_KEY|KEY_LARGE ShortText
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[table][create] large key support is available for TABLE_HASH_KEY and TABLE_PAT_KEY key table: <Users>(TABLE_DAT_KEY)"
+  ],
+  false
+]
+#|e| [table][create] large key support is available for TABLE_HASH_KEY and TABLE_PAT_KEY key table: <Users>(TABLE_DAT_KEY)

--- a/test/command/suite/table_create/key_large/double_array_trie.test
+++ b/test/command/suite/table_create/key_large/double_array_trie.test
@@ -1,0 +1,2 @@
+table_create Users TABLE_DAT_KEY|KEY_LARGE ShortText
+

--- a/test/command/suite/table_create/key_large/patricia_trie.expected
+++ b/test/command/suite/table_create/key_large/patricia_trie.expected
@@ -1,13 +1,46 @@
 table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+load --table Users
+[
+{"_key": "Alice"},
+{"_key": "Bob"},
+{"_key": "Charlie"}
+]
+[[0,0.0,0.0],3]
+select Users
 [
   [
-    [
-      -22,
-      0.0,
-      0.0
-    ],
-    "[table][create] large key support is available only for TABLE_HASH_KEY key table: <Users>(TABLE_PAT_KEY)"
+    0,
+    0.0,
+    0.0
   ],
-  false
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "_key",
+          "ShortText"
+        ]
+      ],
+      [
+        1,
+        "Alice"
+      ],
+      [
+        2,
+        "Bob"
+      ],
+      [
+        3,
+        "Charlie"
+      ]
+    ]
+  ]
 ]
-#|e| [table][create] large key support is available only for TABLE_HASH_KEY key table: <Users>(TABLE_PAT_KEY)

--- a/test/command/suite/table_create/key_large/patricia_trie.test
+++ b/test/command/suite/table_create/key_large/patricia_trie.test
@@ -1,1 +1,10 @@
 table_create Users TABLE_PAT_KEY|KEY_LARGE ShortText
+
+load --table Users
+[
+{"_key": "Alice"},
+{"_key": "Bob"},
+{"_key": "Charlie"}
+]
+
+select Users


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

Currently, we can only specify KEY_LARGE flag on TABLE_PAT_KEY table. Even if we specify `KEY_LARGE`, behavior is not almost change currently.