### PR TITLE
ci cmake: run daily

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -60,6 +60,9 @@ on:
       - 'test/command_line/**'
       - 'test/mruby/**'
       - 'vendor/mruby/**'
+  schedule:
+    - cron: |
+        0 0 * * *
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -62,7 +62,7 @@ on:
       - 'vendor/mruby/**'
   schedule:
     - cron: |
-        0 0 * * *
+        0 21 * * *
 concurrency:
   group: ${{ github.head_ref || github.sha }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
During the last release flow, our CMake build job failed and blocked the Groonga release.
This change makes the CMake workflow run daily, preventing it from silently becoming a blocker.

We’ve scheduled the CMake build to run daily at 23:00 UTC (which finishes around 08:00 JST).
This timing also helps us catch any breakages early on release day.