### PR TITLE
packages windows: add support for specifying custom repository in artifact downloader

### DIFF
--- a/packages/windows/download_github_actions_artifact.rb
+++ b/packages/windows/download_github_actions_artifact.rb
@@ -5,24 +5,26 @@ require "open-uri"
 
 require "octokit"
 
-if ARGV.size != 3
-  $stderr.puts("Usage: #{$0} TAG OUTPUT_DIRECTORY TYPE")
+if ARGV.size < 3 || ARGV.size > 4
+  $stderr.puts("Usage: #{$0} TAG OUTPUT_DIRECTORY TYPE [REPOSITORY]")
   $stderr.puts(" e.g.: #{$0} v9.0.6 files all")
+  $stderr.puts(" e.g.: #{$0} v9.0.6 files all groonga/groonga")
   exit(false)
 end
 
-tag, output_directory, target_type = ARGV
+tag, output_directory, target_type, repository = ARGV
+repository ||= "groonga/groonga"
 
 client = Octokit::Client.new
 client.access_token = ENV["GITHUB_ACCESS_TOKEN"]
 artifacts_response = nil
-workflow_runs_response = client.workflow_runs("groonga/groonga",
+workflow_runs_response = client.workflow_runs(repository,
                                               "cmake.yml",
                                               branch: tag)
 downloaded = false
 workflow_runs_response.workflow_runs.each do |workflow_run|
   artifacts_response =
-    client.get("/repos/groonga/groonga/actions/runs/#{workflow_run.id}/artifacts")
+    client.get("/repos/#{repository}/actions/runs/#{workflow_run.id}/artifacts")
   next if artifacts_response.total_count.zero?
 
   artifacts_response.artifacts.each do |artifact|
@@ -34,7 +36,7 @@ workflow_runs_response.workflow_runs.each do |workflow_run|
     FileUtils.mkdir_p(output_directory)
     puts("Downloading #{name}...")
     File.open("#{output_directory}/#{name}.zip", "wb") do |output|
-      uri = URI.parse(client.artifact_download_url('groonga/groonga', id))
+      uri = URI.parse(client.artifact_download_url(repository, id))
       uri.open do |input|
         IO.copy_stream(input, output)
       end

--- a/packages/windows/download_github_actions_artifact.rb
+++ b/packages/windows/download_github_actions_artifact.rb
@@ -6,14 +6,15 @@ require "open-uri"
 require "octokit"
 
 if ARGV.size < 3 || ARGV.size > 4
-  $stderr.puts("Usage: #{$0} TAG OUTPUT_DIRECTORY TYPE [REPOSITORY]")
+  $stderr.puts("Usage: #{$0} TAG OUTPUT_DIRECTORY TYPE [OWNER]")
   $stderr.puts(" e.g.: #{$0} v9.0.6 files all")
-  $stderr.puts(" e.g.: #{$0} v9.0.6 files all groonga/groonga")
+  $stderr.puts(" e.g.: #{$0} v9.0.6 files all groonga")
   exit(false)
 end
 
-tag, output_directory, target_type, repository = ARGV
-repository ||= "groonga/groonga"
+tag, output_directory, target_type, owner = ARGV
+owner ||= "groonga"
+repository = "#{owner}/groonga"
 
 client = Octokit::Client.new
 client.access_token = ENV["GITHUB_ACCESS_TOKEN"]


### PR DESCRIPTION
Allow downloading GitHub Actions artifacts from
repositories other than the default 'groonga/groonga' by accepting an optional REPOSITORY parameter.

This enables downloading artifacts from forks or
other related repositories.