### PR TITLE
docs: api/grn_inspect move grn_inspect_query_log_flags reference to the header file

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/api/grn_inspect.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/api/grn_inspect.po
@@ -18,9 +18,6 @@ msgstr ""
 msgid "パラメータ"
 msgstr ""
 
-msgid "戻り値"
-msgstr ""
-
 msgid "``grn_inspect``"
 msgstr ""
 
@@ -75,27 +72,11 @@ msgstr "以下はオブジェクトを調査する例です。"
 msgid "Reference"
 msgstr "リファレンス"
 
-msgid "Inspect specified target ``obj`` object."
-msgstr "指定した ``obj`` オブジェクトを調査します。"
+msgid "Inspect specified target ``obj`` object. It prints inspected text."
+msgstr "指定した ``obj`` を調査し、その内容を出力します。"
 
 msgid "The context object"
 msgstr "その時点のコンテキスト。"
-
-
-msgid "Inspect specified target ``flag``."
-msgstr "指定した ``flag`` を調査します。"
-
-msgid "The buffer object which is flag name will be stored."
-msgstr "フラグの名前が設定されるオブジェクト"
-
-msgid "``buffer`` object which is flag name is set. If invalid ``flags`` is given, empty string is set to ``buffer``."
-msgstr "フラグの名前が設定される ``buffer`` オブジェクト。不正な ``flags`` が与えられた場合、空の文字列が ``buffer`` に設定されます。"
-
-msgid "The query logger flags are printed like the following::"
-msgstr "クエリーログのフラグは次のように表示されます::"
-
-msgid "Inspect specified target ``obj`` object. It prints inspected text."
-msgstr "指定した ``obj`` を調査し、その内容を出力します。"
 
 msgid "The inspect target object."
 msgstr "対象のオブジェクト"

--- a/doc/source/reference/api/grn_inspect.rst
+++ b/doc/source/reference/api/grn_inspect.rst
@@ -40,30 +40,6 @@ Here is an example which inspects specified target object.
 Reference
 ---------
 
-.. c:function:: grn_obj *grn_inspect_query_log_flags(grn_ctx *ctx, grn_obj *buffer, unsigned int flags)
-
-   .. versionadded:: 7.0.4
-
-   Inspect specified target ``flag``.
-
-   :param ctx: The context object
-   :param buffer: The buffer object which is flag name will be stored.
-   :param flags: The inspect target type.
-   :return: ``buffer`` object which is flag name is set.
-            If invalid ``flags`` is given, empty string is set to ``buffer``.
-
-   .. code-block:: c
-
-       grn_obj buffer;
-       GRN_TEXT_INIT(&buffer, 0);
-       int current_flags = grn_query_logger_get_flags(&context);
-       grn_inspect_query_log_flags(&context, &buffer, current_flags);
-       printf("%.*s\n", (int)GRN_TEXT_LEN(&buffer), GRN_TEXT_VALUE(&buffer));
-
-   The query logger flags are printed like the following::
-
-     COMMAND|RESULT_CODE|DESTINATION|CACHE|SIZE|SCORE
-
 .. c:function:: void grn_p(grn_ctx *ctx, grn_obj *obj)
 
    .. versionadded:: 4.0.8

--- a/include/groonga/util.h
+++ b/include/groonga/util.h
@@ -306,7 +306,7 @@ grn_inspect_type(grn_ctx *ctx, grn_obj *buffer, unsigned char type);
  * ```c
  * grn_obj flags;
  * GRN_TEXT_INIT(&flags, 0);
- * int current_flags = grn_query_logger_get_flags(ctx);
+ * unsigned int current_flags = grn_query_logger_get_flags(ctx);
  * grn_inspect_query_log_flags(ctx, &flags, current_flags);
  * printf("%.*s\n",
  *        (int)GRN_TEXT_LEN(&flags),

--- a/include/groonga/util.h
+++ b/include/groonga/util.h
@@ -297,6 +297,55 @@ grn_inspect_encoding(grn_ctx *ctx, grn_obj *buffer, grn_encoding encoding);
  */
 GRN_API grn_obj *
 grn_inspect_type(grn_ctx *ctx, grn_obj *buffer, unsigned char type);
+/**
+ * \brief Inspect the given query log flags and produce their names.
+ *
+ * \since 7.0.4
+ *
+ * For example usage:
+ * ```c
+ * grn_obj flags;
+ * GRN_TEXT_INIT(&flags, 0);
+ * int current_flags = grn_query_logger_get_flags(ctx);
+ * grn_inspect_query_log_flags(ctx, &flags, current_flags);
+ * printf("%.*s\n",
+ *        (int)GRN_TEXT_LEN(&flags),
+ *        GRN_TEXT_VALUE(&flags));
+ * GRN_OBJ_FIN(ctx, &flags);
+ * ```
+ *
+ * For example output:
+ * Depending on \p flags, it will output one of the following:
+ * ```
+ * NONE
+ * CACHE
+ * COMMAND
+ * DESTINATION
+ * RESULT_CODE
+ * SCORE
+ * SIZE
+ * ```
+ *
+ * When multiple flags are set, they are displayed separated by "|".
+ * ```
+ * CACHE|COMMAND|DESTINATION|RESULT_CODE|SCORE|SIZE
+ * ```
+ *
+ * Available flags:
+ * - \ref GRN_QUERY_LOG_NONE
+ * - \ref GRN_QUERY_LOG_CACHE
+ * - \ref GRN_QUERY_LOG_COMMAND
+ * - \ref GRN_QUERY_LOG_DESTINATION
+ * - \ref GRN_QUERY_LOG_RESULT_CODE
+ * - \ref GRN_QUERY_LOG_SCORE
+ * - \ref GRN_QUERY_LOG_SIZE
+ *
+ * \param ctx The context object.
+ * \param buffer The buffer where the flag names will be stored.
+ * \param flags The query log flags to inspect.
+ *
+ * \return The inspected query log flags' names in text.
+ */
 GRN_API grn_obj *
 grn_inspect_query_log_flags(grn_ctx *ctx, grn_obj *buffer, unsigned int flags);
 GRN_API grn_obj *

--- a/include/groonga/util.h
+++ b/include/groonga/util.h
@@ -344,7 +344,7 @@ grn_inspect_type(grn_ctx *ctx, grn_obj *buffer, unsigned char type);
  * \param buffer The buffer where the flag names will be stored.
  * \param flags The query log flags to inspect.
  *
- * \return The inspected query log flags' names in text.
+ * \return The names of the inspected query log flags as text.
  */
 GRN_API grn_obj *
 grn_inspect_query_log_flags(grn_ctx *ctx, grn_obj *buffer, unsigned int flags);


### PR DESCRIPTION
GitHub: GH-1817

Prepare to switch to documents automatically generated by Doxygen.