### PR TITLE
pat: add support for pat node has large key offset

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -96,6 +96,24 @@ typedef struct {
   uint16_t bits;
 } pat_node;
 
+/* This struct almost the same pat_node.
+   We only use this struct when we specify `KEY_LARGE`
+   This struct is different from pat_node only in that the size of key.
+   The size of pat_node.key is uint32_t.
+   The size of pat_node_large.key is uint64_t.
+ */
+typedef struct {
+  grn_id lr[2];
+  uint64_t key;
+  uint16_t check;
+  uint16_t bits;
+} pat_node_large;
+
+typedef union {
+  pat_node default_node;
+  pat_node_large large_node;
+} pat_node_common;
+
 #define PAT_DELETING  (1 << 1)
 #define PAT_IMMEDIATE (1 << 2)
 

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -96,7 +96,8 @@ typedef struct {
   uint16_t bits;
 } pat_node;
 
-/* This struct almost the same pat_node.
+/*
+   This struct is almost the same as `pat_node`.
    We only use this struct when we specify `KEY_LARGE`
    This struct is different from pat_node only in that the size of key.
    The size of pat_node.key is uint32_t.


### PR DESCRIPTION
This commit is part of the work to implement #2349.

We add a new struct for pat node has large key.
Because we don't allocate a needless memory space when we don't use `KEY_LARGE` flag.

We implement only definition of a new struct and a new union in this commit.
We will implement codes use this struct and union by the other commit.