### PR TITLE
ci build: archlinux: fix mecab ipadic build failure

### DIFF
--- a/dockerfiles/arch-linux.dockerfile
+++ b/dockerfiles/arch-linux.dockerfile
@@ -19,6 +19,7 @@ FROM archlinux
 RUN \
   pacman --sync --noconfirm --refresh --sysupgrade && \
   pacman --sync --noconfirm \
+    autoconf \
     binutils \
     ccache \
     debugedit \

--- a/dockerfiles/arch-linux.dockerfile
+++ b/dockerfiles/arch-linux.dockerfile
@@ -19,6 +19,8 @@ FROM archlinux
 RUN \
   pacman --sync --noconfirm --refresh --sysupgrade && \
   pacman --sync --noconfirm \
+    # mecab-ipadic must have this but it doesn't have it.
+    # So we install this in base environment.
     autoconf \
     binutils \
     ccache \


### PR DESCRIPTION
Fix the following errors:

```
  /usr/libexec/mecab/mecab-dict-index -d . -o . -f EUC-JP -t utf-8
  make: /usr/libexec/mecab/mecab-dict-index: No such file or directory
  make: *** [Makefile:253: matrix.bin] Error 127
```

https://aur.archlinux.org/cgit/aur.git/commit/?h=mecab-ipadic&id=b8615a7971376441d4954362e8209b1ee4f9c60e

```
sed -i "s|^MECAB_DICT_INDEX=.*|MECAB_DICT_INDEX=/usr/lib/mecab/mecab-dict-index|g" configure.in
```

Use the replaced `configure.in`.