### PR TITLE
pat: remove a needless prefix

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -111,7 +111,7 @@ typedef struct {
 } pat_node_large;
 
 typedef union {
-  pat_node default_node;
+  pat_node node;
   pat_node_large large_node;
 } pat_node_common;
 


### PR DESCRIPTION
Because this prefix redundant.
This commit is part of the work to implement #2349.