### PR TITLE
docs: reference/commands/index_column_diff: Replace horizontal-tab with spaces

### DIFF
--- a/doc/source/reference/commands/index_column_diff.rst
+++ b/doc/source/reference/commands/index_column_diff.rst
@@ -127,8 +127,8 @@ execute as below::
       },
       "remains": [
         {
-	  "record_id": RECORD_ID
-	}
+          "record_id": RECORD_ID
+        }
       ],
       "missings": [
         {


### PR DESCRIPTION
Fix errors found in GitHub GH-2365.