### PR TITLE
docs: news/*: Remove trailing-whitespace

### DIFF
--- a/doc/source/news/10.rst
+++ b/doc/source/news/10.rst
@@ -2382,7 +2382,7 @@ Improvements
 
 * [:doc:`/reference/log`] Outputted a path of opened or closed file into a log of dump level on Linux.
 
-* [:doc:`/reference/log`] Outputted a path of closed file into a log of debug level on Windows.  
+* [:doc:`/reference/log`] Outputted a path of closed file into a log of debug level on Windows.
 
 * Added following API and macros
 

--- a/doc/source/news/11.rst
+++ b/doc/source/news/11.rst
@@ -976,7 +976,7 @@ Improvements
   Groonga stores query cache to internally table.
   The maximum total size of keys of this table is 4GiB. Because this table is hash table.
   Therefore, If we execute many huge queries, Groonga may be unable to store query cache, because the maximum total size of keys may be over 4GiB.
-  In such cases, We can clear the table for query cache by using ``cache_limit 0``, and Groonga can store query cache 
+  In such cases, We can clear the table for query cache by using ``cache_limit 0``, and Groonga can store query cache
 
 Fixes
 ^^^^^
@@ -987,7 +987,7 @@ Fixes
   At this time, threads that wait for an opening object take locks, but these locks are not released.
   Therefore, these locks remain until Groonga's process is restarted in the above case, and a new thread can't also open the object all the time until Groonga's process is restarted.
 
-  However, this bug rarely happens. Because a time of a thread open the object is a very short time. 
+  However, this bug rarely happens. Because a time of a thread open the object is a very short time.
 
 * [:doc:`/reference/functions/query_parallel_or`] Fixed a bug that result may be different from the ``query()``.
 

--- a/doc/source/news/2.rst
+++ b/doc/source/news/2.rst
@@ -171,7 +171,7 @@ Fixes
   on startup by groonga command. [#1532] [Patch by Akio Tajima]
 * [windows] Fixed a bug that data stored in column couldn't be read when total amount of data
   stored in column exceeds 128MB. [groonga-dev,01088] [Reported by ongaeshi]
-* Fixed a bug that searching with indexed column for ``Int*`` and ``UInt*`` 
+* Fixed a bug that searching with indexed column for ``Int*`` and ``UInt*``
   except ``Int32/Uint32`` returns invalid results.
 * Fixed a bug that deleting record can be found.
 * Fixed a bug that latin1 and koi8r normalizations could not process all string data

--- a/doc/source/news/3.rst
+++ b/doc/source/news/3.rst
@@ -131,7 +131,7 @@ Improvements
 
 * [doc][httpd] Added documentation about :ref:`groonga-httpd-groonga-database-auto-create` directive.
 * [httpd] Added :ref:`groonga-httpd-groonga-cache-limit` directive.
-* [doc] Added description why zlib/lzo compression are disabled by default. [groonga-dev, 01845] [Suggested by Naoya Murakami]  
+* [doc] Added description why zlib/lzo compression are disabled by default. [groonga-dev, 01845] [Suggested by Naoya Murakami]
 * Remove a restriction related to RLIMIT_NOFILE on HTTP server.
   It enables HTTP server process to handle over 4096 files.
 * [experimental] Added some API to integrate mruby into groonga. [GitHub#109, #110, #111, #112, #113, #114, #115, #116, #117, #118] [Patch by wanabe]

--- a/doc/source/news/4.rst
+++ b/doc/source/news/4.rst
@@ -617,7 +617,7 @@ Improvements
   It shows more details about data which is failed to load.
 * Added ``adjuster`` option to select command.
   adjuster options accepts following syntax: INDEX_COLUMN @ STRING_LITERAL (* FACTOR).
-* Supported :ref:`weight-vector-column`. You need to specify 'COLUMN_VECTOR|WITH_WEIGHT' flags 
+* Supported :ref:`weight-vector-column`. You need to specify 'COLUMN_VECTOR|WITH_WEIGHT' flags
   to create weight vector column.
 * Added missing MIN/MAX macros on SunOS. [GitHub#154] [Patch by Sebastian Wiedenroth]
 * Improved recycling garbage data. It suppress to increase database size.

--- a/doc/source/news/6.rst
+++ b/doc/source/news/6.rst
@@ -302,7 +302,7 @@ Improvements
   Studio.
 
 * [httpd] Updated bundled nginx to 1.11.4.
-  
+
 Fixes
 ^^^^^
 
@@ -573,7 +573,6 @@ Thanks
 * Soichiro Kiyokawa
 * IWAI, Masaharu
 * cafedomancer
-  
 
 .. _release-6-0-4:
 
@@ -858,7 +857,7 @@ Improvements
   raw JSON instead of parameter value::
 
     POST /d/load?table=XXX&request_id=x
-    
+
     load --table XXX --request_id x
     [
       ...

--- a/doc/source/news/9.rst
+++ b/doc/source/news/9.rst
@@ -14,7 +14,7 @@ Improvements
   * This script name is copy-related-files.rb.
   * This script is useful if we want to extract specifying tables or columns from a huge database.
   * Related files of specific tables or columns may need for reproducing fault.
-  * If we difficult to offer a database whole, we can extract related files of target tables or columns by this tool. 
+  * If we difficult to offer a database whole, we can extract related files of target tables or columns by this tool.
 
 * [:doc:`/reference/commands/shutdown`] Accept ``/d/shutdown?mode=immediate`` immediately even when all threads are used.
 
@@ -389,7 +389,7 @@ Improvements
 
   * We can specify a scope of an inspection.
 
-* [:doc:`/reference/executables/grndb`] Added document about new option ``--since``    
+* [:doc:`/reference/executables/grndb`] Added document about new option ``--since``
 
 * Bundle RapidJSON
 


### PR DESCRIPTION
Fix errors found in GitHub GH-2365.