### PR TITLE
Add `/vendor/usearch-*` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@
 /vendor/rapidjson-*
 /vendor/simdjson-*
 /vendor/simsimd-*
+/vendor/usearch-*
 /vendor/xsimd-*
 /vendor/xxHash-*
 /vendor/zstd-*


### PR DESCRIPTION
Because the downloaded `vendor/usearch-x.x.x.tar.gz` is listed in `Untracked files:`.