### PR TITLE
docs: reference/functions/*: Remove trailing-whitespace

### DIFF
--- a/doc/source/reference/functions/between.rst
+++ b/doc/source/reference/functions/between.rst
@@ -68,7 +68,7 @@ Currently, you can only specify ``too_many_index_match_ratio``. The type of this
 
 You can change the value of ``GRN_BETWEEN_TOO_MANY_INDEX_MATCH_RATIO`` with ``too_many_index_match_ratio``.
 The default value of ``GRN_BETWEEN_TOO_MANY_INDEX_MATCH_RATIO`` is ``0.01``.
-``GRN_BETWEEN_TOO_MANY_INDEX_MATCH_RATIO`` is used for deciding whether ``between`` use an index or not. 
+``GRN_BETWEEN_TOO_MANY_INDEX_MATCH_RATIO`` is used for deciding whether ``between`` use an index or not.
 
 There is a case that sequential search is faster than index search when the number of narrowed down records is small enough in contrast to the number of expected records to narrow down by ``between`` with AND operation which use indexes.
 

--- a/doc/source/reference/functions/in_values.rst
+++ b/doc/source/reference/functions/in_values.rst
@@ -63,7 +63,7 @@ Currently, you can only specify ``too_many_index_match_ratio``. The type of this
 
 You can change the value of ``GRN_IN_VALUES_TOO_MANY_INDEX_MATCH_RATIO`` with ``too_many_index_match_ratio``.
 The default value of ``GRN_IN_VALUES_TOO_MANY_INDEX_MATCH_RATIO`` is ``0.01``.
-``GRN_IN_VALUES_TOO_MANY_INDEX_MATCH_RATIO`` is used for deciding whether ``in_values`` use an index or not. 
+``GRN_IN_VALUES_TOO_MANY_INDEX_MATCH_RATIO`` is used for deciding whether ``in_values`` use an index or not.
 
 There is a case that sequential search is faster than index search when the number of narrowed down records is small enough in contrast to the number of expected records to narrow down by ``in_values`` with AND operation which use indexes.
 

--- a/doc/source/reference/functions/string_slice.rst
+++ b/doc/source/reference/functions/string_slice.rst
@@ -43,7 +43,7 @@ Extraction by position
 
 Extraction by regular expression
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 
+
 ::
 
   string_slice(target, regexp, nth[, options])
@@ -146,7 +146,7 @@ Specify the following key.
 
 ``default_value``
   Specify a string to be returned when a substring is an empty string except when specifying 0 for ``length``.
-  
+
   The default is an empty string.
 
 Extraction by regular expression
@@ -186,7 +186,7 @@ Specify either ``nth`` or ``name``.
 
 Specify a name of the named capturing group for ``regexp``.
 
-A captured string of the named capturing group that matches ``name`` is returned 
+A captured string of the named capturing group that matches ``name`` is returned
 when ``regexp`` is matched to ``target``.
 
 Specify either ``nth`` or ``name``.

--- a/doc/source/reference/functions/string_substring.rst
+++ b/doc/source/reference/functions/string_substring.rst
@@ -115,7 +115,7 @@ Specify the following key.
 
 ``default_value``
   Specify a string to be returned when a substring is an empty string except when specifying 0 for ``length``.
-  
+
   The default is an empty string.
 
 Return value


### PR DESCRIPTION
Fix errors found in GitHub GH-2365.