### PR TITLE
Fix Apache Arrow output for slice and drilldown

### DIFF
--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -277,6 +277,12 @@ grn_ctx_set_output_type(grn_ctx *ctx, grn_content_type type);
 GRN_API const char *
 grn_ctx_get_mime_type(grn_ctx *ctx);
 
+GRN_API void
+grn_output_arrow_metadata(grn_ctx *ctx,
+                          const char *data_type,
+                          const char *label,
+                          size_t label_length);
+
 /* obsolete */
 GRN_API grn_rc
 grn_text_otoj(grn_ctx *ctx,

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -38,6 +38,9 @@ typedef struct _grn_obj_format grn_obj_format;
    The "1024" value may be changed.
    Since 10.0.3 */
 #define GRN_OBJ_FORMAT_AUTO_FLUSH (0x01 << 6)
+/* Metadata fields for Apache Arrow output
+   Since 15.1.2 */
+#define GRN_OBJ_FORMAT_WITH_METADATA (0x01 << 7)
 
 struct _grn_obj_format {
   grn_obj columns;
@@ -51,6 +54,8 @@ struct _grn_obj_format {
   int hits_offset;
   uint32_t flags;
   grn_obj *expression;
+  const char *metadata_type;
+  grn_raw_string metadata;
 };
 
 GRN_API grn_rc
@@ -69,6 +74,10 @@ grn_output_range_normalize(grn_ctx *ctx, int size, int *offset, int *limit);
     (format)->hits_offset = (format_hits_offset);                              \
     (format)->flags = 0;                                                       \
     (format)->expression = NULL;                                               \
+    if ((format)->flags & GRN_OBJ_FORMAT_WITH_METADATA) {                      \
+      (format)->metadata_type = NULL;                                          \
+      GRN_RAW_STRING_INIT((format)->metadata);                                 \
+    }                                                                          \
   } while (0)
 
 /* Deprecated since 10.0.0. Use grn_obj_format_fin() instead. */

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -278,10 +278,13 @@ GRN_API const char *
 grn_ctx_get_mime_type(grn_ctx *ctx);
 
 GRN_API void
-grn_output_arrow_metadata(grn_ctx *ctx,
-                          const char *data_type,
-                          const char *label,
-                          size_t label_length);
+grn_output_result_set_label(grn_ctx *ctx,
+                            grn_obj *outbuf,
+                            grn_content_type output_type,
+                            const char *label,
+                            size_t label_length,
+                            const char *metadata_type,
+                            bool is_labeled);
 
 /* obsolete */
 GRN_API grn_rc

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -452,12 +452,10 @@ grn_ctx_impl_init(grn_ctx *ctx)
                       grn_msgpack_buffer_write);
 #endif
   grn_timeval_now(ctx, &ctx->impl->tv);
-#ifdef GRN_WITH_APACHE_ARROW
   ctx->impl->output.arrow_stream_writer = NULL;
   ctx->impl->output.arrow_metadata_data_type = NULL;
   GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
   ctx->impl->arrow_stream_loader = NULL;
-#endif
   grn_loader_init(&ctx->impl->loader);
   ctx->impl->plugin_path = NULL;
 
@@ -854,13 +852,11 @@ grn_ctx_impl_fin(grn_ctx *ctx)
   if (ctx->impl->parallel.task_executor) {
     delete static_cast<grn::TaskExecutor *>(ctx->impl->parallel.task_executor);
   }
-#ifdef GRN_WITH_APACHE_ARROW
   if (ctx->impl->output.arrow_stream_writer) {
     grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
   }
   ctx->impl->output.arrow_metadata_data_type = NULL;
   GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
-#endif
   GRN_OBJ_FIN(ctx, &ctx->impl->output.names);
   GRN_OBJ_FIN(ctx, &ctx->impl->output.levels);
   rc = grn_obj_close(ctx, ctx->impl->output.buf);

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -451,9 +451,11 @@ grn_ctx_impl_init(grn_ctx *ctx)
                       ctx,
                       grn_msgpack_buffer_write);
 #endif
-  ctx->impl->output.arrow_stream_writer = NULL;
   grn_timeval_now(ctx, &ctx->impl->tv);
 #ifdef GRN_WITH_APACHE_ARROW
+  ctx->impl->output.arrow_stream_writer = NULL;
+  ctx->impl->output.arrow_metadata_data_type = NULL;
+  GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
   ctx->impl->arrow_stream_loader = NULL;
 #endif
   grn_loader_init(&ctx->impl->loader);
@@ -852,9 +854,13 @@ grn_ctx_impl_fin(grn_ctx *ctx)
   if (ctx->impl->parallel.task_executor) {
     delete static_cast<grn::TaskExecutor *>(ctx->impl->parallel.task_executor);
   }
+#ifdef GRN_WITH_APACHE_ARROW
   if (ctx->impl->output.arrow_stream_writer) {
     grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
   }
+  ctx->impl->output.arrow_metadata_data_type = NULL;
+  GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
+#endif
   GRN_OBJ_FIN(ctx, &ctx->impl->output.names);
   GRN_OBJ_FIN(ctx, &ctx->impl->output.levels);
   rc = grn_obj_close(ctx, ctx->impl->output.buf);

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -856,8 +856,11 @@ grn_ctx_impl_fin(grn_ctx *ctx)
     grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
   }
   ctx->impl->output.arrow_metadata_data_type = NULL;
+  if (ctx->impl->output.arrow_metadata_label.value) {
+    GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
+    ctx->impl->output.arrow_metadata_label.value = NULL;
+  }
   ctx->impl->output.arrow_metadata_label.length = 0;
-  GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
   GRN_OBJ_FIN(ctx, &ctx->impl->output.names);
   GRN_OBJ_FIN(ctx, &ctx->impl->output.levels);
   rc = grn_obj_close(ctx, ctx->impl->output.buf);

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -856,7 +856,8 @@ grn_ctx_impl_fin(grn_ctx *ctx)
     grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
   }
   ctx->impl->output.arrow_metadata_data_type = NULL;
-  GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
+  ctx->impl->output.arrow_metadata_label.length = 0;
+  GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
   GRN_OBJ_FIN(ctx, &ctx->impl->output.names);
   GRN_OBJ_FIN(ctx, &ctx->impl->output.levels);
   rc = grn_obj_close(ctx, ctx->impl->output.buf);

--- a/lib/grn_ctx_impl.h
+++ b/lib/grn_ctx_impl.h
@@ -148,6 +148,8 @@ struct _grn_ctx_impl {
     msgpack_packer msgpacker;
 #endif
     grn_arrow_stream_writer *arrow_stream_writer;
+    const char *arrow_metadata_data_type;
+    grn_raw_string arrow_metadata_label;
   } output;
 
   struct {

--- a/lib/grn_output.h
+++ b/lib/grn_output.h
@@ -90,6 +90,11 @@ grn_obj_format_set_columns(grn_ctx *ctx,
                            const char *columns,
                            unsigned int columns_len);
 
+void
+grn_output_arrow_stream_open_with_metadata(grn_ctx *ctx,
+                                           grn_obj *outbuf,
+                                           grn_content_type output_type);
+
 #define GRN_OUTPUT_ARRAY_OPEN(name, nelements)                                 \
   (grn_ctx_output_array_open(ctx, name, nelements))
 #define GRN_OUTPUT_ARRAY_CLOSE() (grn_ctx_output_array_close(ctx))

--- a/lib/output.c
+++ b/lib/output.c
@@ -2730,8 +2730,6 @@ grn_output_result_set_open_metadata(grn_ctx *ctx,
         "GROONGA:label",
         GRN_TEXT_VALUE(&label_buffer));
       GRN_OBJ_FIN(ctx, &label_buffer);
-      ctx->impl->output.arrow_metadata_data_type = NULL;
-      GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
     }
   }
 

--- a/lib/output.c
+++ b/lib/output.c
@@ -2669,6 +2669,33 @@ grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
                                        grn_obj_format *format,
                                        uint32_t n_additional_elements)
 {
+  if (output_type == GRN_CONTENT_APACHE_ARROW) {
+    if (ctx->impl->output.arrow_metadata_data_type) {
+      grn_arrow_stream_writer_add_metadata(
+        ctx,
+        ctx->impl->output.arrow_stream_writer,
+        "GROONGA:data_type",
+        ctx->impl->output.arrow_metadata_data_type);
+    }
+    if (ctx->impl->output.arrow_metadata_label.length > 0) {
+      grn_obj label_buffer;
+      GRN_TEXT_INIT(&label_buffer, 0);
+      GRN_TEXT_SET(ctx,
+                   &label_buffer,
+                   ctx->impl->output.arrow_metadata_label.value,
+                   ctx->impl->output.arrow_metadata_label.length);
+      GRN_TEXT_PUTC(ctx, &label_buffer, '\0');
+      grn_arrow_stream_writer_add_metadata(
+        ctx,
+        ctx->impl->output.arrow_stream_writer,
+        "GROONGA:label",
+        GRN_TEXT_VALUE(&label_buffer));
+      GRN_OBJ_FIN(ctx, &label_buffer);
+    }
+    ctx->impl->output.arrow_metadata_data_type = NULL;
+    GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
+  }
+
   int n_elements = (int)n_additional_elements;
   if (format) {
     /* result_set: {"n_hits": N, ("columns": COLUMNS,) */

--- a/lib/output.c
+++ b/lib/output.c
@@ -2669,33 +2669,6 @@ grn_output_result_set_open_metadata_v3(grn_ctx *ctx,
                                        grn_obj_format *format,
                                        uint32_t n_additional_elements)
 {
-  if (output_type == GRN_CONTENT_APACHE_ARROW) {
-    if (ctx->impl->output.arrow_metadata_data_type) {
-      grn_arrow_stream_writer_add_metadata(
-        ctx,
-        ctx->impl->output.arrow_stream_writer,
-        "GROONGA:data_type",
-        ctx->impl->output.arrow_metadata_data_type);
-    }
-    if (ctx->impl->output.arrow_metadata_label.length > 0) {
-      grn_obj label_buffer;
-      GRN_TEXT_INIT(&label_buffer, 0);
-      GRN_TEXT_SET(ctx,
-                   &label_buffer,
-                   ctx->impl->output.arrow_metadata_label.value,
-                   ctx->impl->output.arrow_metadata_label.length);
-      GRN_TEXT_PUTC(ctx, &label_buffer, '\0');
-      grn_arrow_stream_writer_add_metadata(
-        ctx,
-        ctx->impl->output.arrow_stream_writer,
-        "GROONGA:label",
-        GRN_TEXT_VALUE(&label_buffer));
-      GRN_OBJ_FIN(ctx, &label_buffer);
-    }
-    ctx->impl->output.arrow_metadata_data_type = NULL;
-    GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
-  }
-
   int n_elements = (int)n_additional_elements;
   if (format) {
     /* result_set: {"n_hits": N, ("columns": COLUMNS,) */
@@ -2737,6 +2710,29 @@ grn_output_result_set_open_metadata(grn_ctx *ctx,
     }
     ctx->impl->output.arrow_stream_writer =
       grn_arrow_stream_writer_open(ctx, outbuf);
+    if (ctx->impl->output.arrow_metadata_data_type &&
+        ctx->impl->output.arrow_metadata_label.value) {
+      grn_obj label_buffer;
+      GRN_TEXT_INIT(&label_buffer, 0);
+      GRN_TEXT_SET(ctx,
+                   &label_buffer,
+                   ctx->impl->output.arrow_metadata_label.value,
+                   ctx->impl->output.arrow_metadata_label.length);
+      GRN_TEXT_PUTC(ctx, &label_buffer, '\0');
+      grn_arrow_stream_writer_add_metadata(
+        ctx,
+        ctx->impl->output.arrow_stream_writer,
+        "GROONGA:data_type",
+        ctx->impl->output.arrow_metadata_data_type);
+      grn_arrow_stream_writer_add_metadata(
+        ctx,
+        ctx->impl->output.arrow_stream_writer,
+        "GROONGA:label",
+        GRN_TEXT_VALUE(&label_buffer));
+      GRN_OBJ_FIN(ctx, &label_buffer);
+      ctx->impl->output.arrow_metadata_data_type = NULL;
+      GRN_RAW_STRING_INIT(ctx->impl->output.arrow_metadata_label);
+    }
   }
 
   if (grn_ctx_get_command_version(ctx) < GRN_COMMAND_VERSION_3) {

--- a/lib/output.c
+++ b/lib/output.c
@@ -929,6 +929,25 @@ grn_output_bool(grn_ctx *ctx,
 }
 
 void
+grn_output_arrow_metadata(grn_ctx *ctx,
+                          const char *data_type,
+                          const char *label,
+                          size_t label_length)
+{
+  ctx->impl->output.arrow_metadata_data_type = data_type;
+  if (label && label_length > 0) {
+    ctx->impl->output.arrow_metadata_label.value =
+      (const char *)GRN_MALLOC(label_length);
+    if (ctx->impl->output.arrow_metadata_label.value) {
+      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                 label,
+                 label_length);
+      ctx->impl->output.arrow_metadata_label.length = label_length;
+    }
+  }
+}
+
+void
 grn_output_null(grn_ctx *ctx, grn_obj *outbuf, grn_content_type output_type)
 {
   put_delimiter(ctx, outbuf, output_type);

--- a/lib/output.c
+++ b/lib/output.c
@@ -934,6 +934,12 @@ grn_output_arrow_metadata(grn_ctx *ctx,
                           const char *label,
                           size_t label_length)
 {
+  if (ctx->impl->output.arrow_metadata_label.value) {
+    GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
+    ctx->impl->output.arrow_metadata_label.value = NULL;
+    ctx->impl->output.arrow_metadata_label.length = 0;
+  }
+
   ctx->impl->output.arrow_metadata_data_type = data_type;
   if (label && label_length > 0) {
     ctx->impl->output.arrow_metadata_label.value =

--- a/lib/output.c
+++ b/lib/output.c
@@ -929,26 +929,39 @@ grn_output_bool(grn_ctx *ctx,
 }
 
 void
-grn_output_arrow_metadata(grn_ctx *ctx,
-                          const char *data_type,
-                          const char *label,
-                          size_t label_length)
+grn_output_result_set_label(grn_ctx *ctx,
+                            grn_obj *outbuf,
+                            grn_content_type output_type,
+                            const char *label,
+                            size_t label_length,
+                            const char *metadata_type,
+                            bool is_labeled)
 {
-  if (ctx->impl->output.arrow_metadata_label.value) {
-    GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
-    ctx->impl->output.arrow_metadata_label.value = NULL;
-    ctx->impl->output.arrow_metadata_label.length = 0;
+  if (!label || label_length == 0) {
+    return;
   }
 
-  ctx->impl->output.arrow_metadata_data_type = data_type;
-  if (label && label_length > 0) {
-    ctx->impl->output.arrow_metadata_label.value =
-      (const char *)GRN_MALLOC(label_length);
+  if (output_type == GRN_CONTENT_APACHE_ARROW) {
     if (ctx->impl->output.arrow_metadata_label.value) {
-      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
-                 label,
-                 label_length);
-      ctx->impl->output.arrow_metadata_label.length = label_length;
+      GRN_FREE((char *)(ctx->impl->output.arrow_metadata_label.value));
+      ctx->impl->output.arrow_metadata_label.value = NULL;
+      ctx->impl->output.arrow_metadata_label.length = 0;
+    }
+
+    ctx->impl->output.arrow_metadata_data_type = metadata_type;
+    if (label && label_length > 0) {
+      ctx->impl->output.arrow_metadata_label.value =
+        (const char *)GRN_MALLOC(label_length);
+      if (ctx->impl->output.arrow_metadata_label.value) {
+        grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                   label,
+                   label_length);
+        ctx->impl->output.arrow_metadata_label.length = label_length;
+      }
+    }
+  } else {
+    if (is_labeled) {
+      grn_output_str(ctx, outbuf, output_type, label, label_length);
     }
   }
 }

--- a/lib/output.c
+++ b/lib/output.c
@@ -4477,6 +4477,13 @@ grn_obj_format_fin(grn_ctx *ctx, grn_obj_format *format)
   if (format->expression) {
     GRN_OBJ_FIN(ctx, format->expression);
   }
+  if (format->flags & GRN_OBJ_FORMAT_WITH_METADATA) {
+    format->metadata_type = NULL;
+    if (format->metadata.value) {
+      GRN_FREE((char *)(format->metadata.value));
+      format->metadata.value = NULL;
+    }
+  }
 
   GRN_API_RETURN(ctx->rc);
 }

--- a/lib/output.c
+++ b/lib/output.c
@@ -948,6 +948,43 @@ grn_output_arrow_metadata(grn_ctx *ctx,
 }
 
 void
+grn_output_arrow_stream_open_with_metadata(grn_ctx *ctx,
+                                           grn_obj *outbuf,
+                                           grn_content_type output_type)
+{
+  if (output_type != GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
+
+  if (ctx->impl->output.arrow_stream_writer) {
+    grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
+  }
+  ctx->impl->output.arrow_stream_writer =
+    grn_arrow_stream_writer_open(ctx, outbuf);
+
+  if (ctx->impl->output.arrow_metadata_data_type &&
+      ctx->impl->output.arrow_metadata_label.value) {
+    grn_obj label_buffer;
+    GRN_TEXT_INIT(&label_buffer, 0);
+    GRN_TEXT_SET(ctx,
+                 &label_buffer,
+                 ctx->impl->output.arrow_metadata_label.value,
+                 ctx->impl->output.arrow_metadata_label.length);
+    GRN_TEXT_PUTC(ctx, &label_buffer, '\0');
+    grn_arrow_stream_writer_add_metadata(
+      ctx,
+      ctx->impl->output.arrow_stream_writer,
+      "GROONGA:data_type",
+      ctx->impl->output.arrow_metadata_data_type);
+    grn_arrow_stream_writer_add_metadata(ctx,
+                                         ctx->impl->output.arrow_stream_writer,
+                                         "GROONGA:label",
+                                         GRN_TEXT_VALUE(&label_buffer));
+    GRN_OBJ_FIN(ctx, &label_buffer);
+  }
+}
+
+void
 grn_output_null(grn_ctx *ctx, grn_obj *outbuf, grn_content_type output_type)
 {
   put_delimiter(ctx, outbuf, output_type);
@@ -2723,34 +2760,7 @@ grn_output_result_set_open_metadata(grn_ctx *ctx,
                                     grn_obj_format *format,
                                     uint32_t n_additional_elements)
 {
-  if (output_type == GRN_CONTENT_APACHE_ARROW) {
-    if (ctx->impl->output.arrow_stream_writer) {
-      grn_arrow_stream_writer_close(ctx, ctx->impl->output.arrow_stream_writer);
-    }
-    ctx->impl->output.arrow_stream_writer =
-      grn_arrow_stream_writer_open(ctx, outbuf);
-    if (ctx->impl->output.arrow_metadata_data_type &&
-        ctx->impl->output.arrow_metadata_label.value) {
-      grn_obj label_buffer;
-      GRN_TEXT_INIT(&label_buffer, 0);
-      GRN_TEXT_SET(ctx,
-                   &label_buffer,
-                   ctx->impl->output.arrow_metadata_label.value,
-                   ctx->impl->output.arrow_metadata_label.length);
-      GRN_TEXT_PUTC(ctx, &label_buffer, '\0');
-      grn_arrow_stream_writer_add_metadata(
-        ctx,
-        ctx->impl->output.arrow_stream_writer,
-        "GROONGA:data_type",
-        ctx->impl->output.arrow_metadata_data_type);
-      grn_arrow_stream_writer_add_metadata(
-        ctx,
-        ctx->impl->output.arrow_stream_writer,
-        "GROONGA:label",
-        GRN_TEXT_VALUE(&label_buffer));
-      GRN_OBJ_FIN(ctx, &label_buffer);
-    }
-  }
+  grn_output_arrow_stream_open_with_metadata(ctx, outbuf, output_type);
 
   if (grn_ctx_get_command_version(ctx) < GRN_COMMAND_VERSION_3) {
     grn_output_result_set_open_metadata_v1(ctx,

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4553,6 +4553,12 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
                                  grn_select_data *data,
                                  Slice *slice)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    ctx->impl->output.arrow_metadata_data_type = "slice";
+    ctx->impl->output.arrow_metadata_label = slice->label;
+    return;
+  }
+
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
@@ -4584,6 +4590,12 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    ctx->impl->output.arrow_metadata_data_type = "drilldown";
+    ctx->impl->output.arrow_metadata_label = drilldown->label;
+    return;
+  }
+
   if (data->drilldowns.is_labeled()) {
     GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
   }

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4602,6 +4602,9 @@ static grn_select_output_formatter grn_select_output_formatter_v1 = {
 static void
 grn_select_output_slices_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_CSTR("slices");
 }
 
@@ -4624,12 +4627,20 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
                                  grn_select_data *data,
                                  Slice *slice)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    ctx->impl->output.arrow_metadata_data_type = "slice";
+    ctx->impl->output.arrow_metadata_label = slice->label;
+    return;
+  }
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
 static void
 grn_select_output_drilldowns_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    return;
+  }
   GRN_OUTPUT_CSTR("drilldowns");
 }
 
@@ -4652,6 +4663,11 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    ctx->impl->output.arrow_metadata_data_type = "drilldown";
+    ctx->impl->output.arrow_metadata_label = drilldown->label;
+    return;
+  }
   GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
 }
 

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4560,6 +4560,7 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
                               slice->label.length);
     return;
   }
+
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
@@ -4599,9 +4600,9 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                               "drilldown",
                               drilldown->label.value,
                               drilldown->label.length);
-  } else {
-    GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
+    return;
   }
+  GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
 }
 
 static grn_select_output_formatter grn_select_output_formatter_v1 = {

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4558,10 +4558,9 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
                               "slice",
                               slice->label.value,
                               slice->label.length);
-    return;
+  } else {
+    GRN_OUTPUT_STR(slice->label.value, slice->label.length);
   }
-
-  GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
 static void
@@ -4600,9 +4599,9 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                               "drilldown",
                               drilldown->label.value,
                               drilldown->label.length);
-    return;
+  } else {
+    GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
   }
-  GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
 }
 
 static grn_select_output_formatter grn_select_output_formatter_v1 = {
@@ -4648,9 +4647,9 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
                               "slice",
                               slice->label.value,
                               slice->label.length);
-    return;
+  } else {
+    GRN_OUTPUT_STR(slice->label.value, slice->label.length);
   }
-  GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
 static void
@@ -4686,9 +4685,9 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
                               "drilldown",
                               drilldown->label.value,
                               drilldown->label.length);
-    return;
+  } else {
+    GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
   }
-  GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
 }
 
 static grn_select_output_formatter grn_select_output_formatter_v3 = {

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4553,14 +4553,13 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
                                  grn_select_data *data,
                                  Slice *slice)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    grn_output_arrow_metadata(ctx,
-                              "slice",
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
                               slice->label.value,
-                              slice->label.length);
-  } else {
-    GRN_OUTPUT_STR(slice->label.value, slice->label.length);
-  }
+                              slice->label.length,
+                              "slice",
+                              true);
 }
 
 static void
@@ -4591,17 +4590,13 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    grn_output_arrow_metadata(ctx,
-                              "drilldown",
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
                               drilldown->label.value,
-                              drilldown->label.length);
-    return;
-  }
-
-  if (data->drilldowns.is_labeled()) {
-    GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
-  }
+                              drilldown->label.length,
+                              "drilldown",
+                              data->drilldowns.is_labeled());
 }
 
 static grn_select_output_formatter grn_select_output_formatter_v1 = {
@@ -4617,10 +4612,13 @@ static grn_select_output_formatter grn_select_output_formatter_v1 = {
 static void
 grn_select_output_slices_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    return;
-  }
-  GRN_OUTPUT_CSTR("slices");
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
+                              "slices",
+                              strlen("slices"),
+                              "slices",
+                              true);
 }
 
 static void
@@ -4642,23 +4640,25 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
                                  grn_select_data *data,
                                  Slice *slice)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    grn_output_arrow_metadata(ctx,
-                              "slice",
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
                               slice->label.value,
-                              slice->label.length);
-  } else {
-    GRN_OUTPUT_STR(slice->label.value, slice->label.length);
-  }
+                              slice->label.length,
+                              "slice",
+                              true);
 }
 
 static void
 grn_select_output_drilldowns_label_v3(grn_ctx *ctx, grn_select_data *data)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    return;
-  }
-  GRN_OUTPUT_CSTR("drilldowns");
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
+                              "drilldowns",
+                              strlen("drilldowns"),
+                              "drilldowns",
+                              true);
 }
 
 static void
@@ -4680,14 +4680,13 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    grn_output_arrow_metadata(ctx,
-                              "drilldown",
+  grn_output_result_set_label(ctx,
+                              ctx->impl->output.buf,
+                              grn_ctx_get_output_type(ctx),
                               drilldown->label.value,
-                              drilldown->label.length);
-  } else {
-    GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
-  }
+                              drilldown->label.length,
+                              "drilldown",
+                              true);
 }
 
 static grn_select_output_formatter grn_select_output_formatter_v3 = {

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4555,7 +4555,14 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
     ctx->impl->output.arrow_metadata_data_type = "slice";
-    ctx->impl->output.arrow_metadata_label = slice->label;
+    if (slice->label.length > 0) {
+      ctx->impl->output.arrow_metadata_label.value =
+        (const char *)GRN_MALLOC(slice->label.length);
+      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                 slice->label.value,
+                 slice->label.length);
+      ctx->impl->output.arrow_metadata_label.length = slice->label.length;
+    }
     return;
   }
 
@@ -4592,7 +4599,14 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
     ctx->impl->output.arrow_metadata_data_type = "drilldown";
-    ctx->impl->output.arrow_metadata_label = drilldown->label;
+    if (drilldown->label.length > 0) {
+      ctx->impl->output.arrow_metadata_label.value =
+        (const char *)GRN_MALLOC(drilldown->label.length);
+      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                 drilldown->label.value,
+                 drilldown->label.length);
+      ctx->impl->output.arrow_metadata_label.length = drilldown->label.length;
+    }
     return;
   }
 
@@ -4641,7 +4655,14 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
     ctx->impl->output.arrow_metadata_data_type = "slice";
-    ctx->impl->output.arrow_metadata_label = slice->label;
+    if (slice->label.length > 0) {
+      ctx->impl->output.arrow_metadata_label.value =
+        (const char *)GRN_MALLOC(slice->label.length);
+      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                 slice->label.value,
+                 slice->label.length);
+      ctx->impl->output.arrow_metadata_label.length = slice->label.length;
+    }
     return;
   }
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
@@ -4677,7 +4698,14 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
     ctx->impl->output.arrow_metadata_data_type = "drilldown";
-    ctx->impl->output.arrow_metadata_label = drilldown->label;
+    if (drilldown->label.length > 0) {
+      ctx->impl->output.arrow_metadata_label.value =
+        (const char *)GRN_MALLOC(drilldown->label.length);
+      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
+                 drilldown->label.value,
+                 drilldown->label.length);
+      ctx->impl->output.arrow_metadata_label.length = drilldown->label.length;
+    }
     return;
   }
   GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4591,15 +4591,15 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
-  if (!data->drilldowns.is_labeled()) {
-    return;
-  }
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
     grn_output_arrow_metadata(ctx,
                               "drilldown",
                               drilldown->label.value,
                               drilldown->label.length);
-  } else {
+    return;
+  }
+
+  if (data->drilldowns.is_labeled()) {
     GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
   }
 }

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -4554,18 +4554,12 @@ grn_select_output_slice_label_v1(grn_ctx *ctx,
                                  Slice *slice)
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    ctx->impl->output.arrow_metadata_data_type = "slice";
-    if (slice->label.length > 0) {
-      ctx->impl->output.arrow_metadata_label.value =
-        (const char *)GRN_MALLOC(slice->label.length);
-      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
-                 slice->label.value,
-                 slice->label.length);
-      ctx->impl->output.arrow_metadata_label.length = slice->label.length;
-    }
+    grn_output_arrow_metadata(ctx,
+                              "slice",
+                              slice->label.value,
+                              slice->label.length);
     return;
   }
-
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
 }
 
@@ -4597,20 +4591,15 @@ grn_select_output_drilldown_label_v1(grn_ctx *ctx,
                                      grn_select_data *data,
                                      Drilldown *drilldown)
 {
-  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    ctx->impl->output.arrow_metadata_data_type = "drilldown";
-    if (drilldown->label.length > 0) {
-      ctx->impl->output.arrow_metadata_label.value =
-        (const char *)GRN_MALLOC(drilldown->label.length);
-      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
-                 drilldown->label.value,
-                 drilldown->label.length);
-      ctx->impl->output.arrow_metadata_label.length = drilldown->label.length;
-    }
+  if (!data->drilldowns.is_labeled()) {
     return;
   }
-
-  if (data->drilldowns.is_labeled()) {
+  if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
+    grn_output_arrow_metadata(ctx,
+                              "drilldown",
+                              drilldown->label.value,
+                              drilldown->label.length);
+  } else {
     GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);
   }
 }
@@ -4654,15 +4643,10 @@ grn_select_output_slice_label_v3(grn_ctx *ctx,
                                  Slice *slice)
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    ctx->impl->output.arrow_metadata_data_type = "slice";
-    if (slice->label.length > 0) {
-      ctx->impl->output.arrow_metadata_label.value =
-        (const char *)GRN_MALLOC(slice->label.length);
-      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
-                 slice->label.value,
-                 slice->label.length);
-      ctx->impl->output.arrow_metadata_label.length = slice->label.length;
-    }
+    grn_output_arrow_metadata(ctx,
+                              "slice",
+                              slice->label.value,
+                              slice->label.length);
     return;
   }
   GRN_OUTPUT_STR(slice->label.value, slice->label.length);
@@ -4697,15 +4681,10 @@ grn_select_output_drilldown_label_v3(grn_ctx *ctx,
                                      Drilldown *drilldown)
 {
   if (grn_ctx_get_output_type(ctx) == GRN_CONTENT_APACHE_ARROW) {
-    ctx->impl->output.arrow_metadata_data_type = "drilldown";
-    if (drilldown->label.length > 0) {
-      ctx->impl->output.arrow_metadata_label.value =
-        (const char *)GRN_MALLOC(drilldown->label.length);
-      grn_memcpy((char *)(ctx->impl->output.arrow_metadata_label.value),
-                 drilldown->label.value,
-                 drilldown->label.length);
-      ctx->impl->output.arrow_metadata_label.length = drilldown->label.length;
-    }
+    grn_output_arrow_metadata(ctx,
+                              "drilldown",
+                              drilldown->label.value,
+                              drilldown->label.length);
     return;
   }
   GRN_OUTPUT_STR(drilldown->label.value, drilldown->label.length);

--- a/test/command/suite/select/command_version/1/apache_arrow/drilldowns.expected
+++ b/test/command/suite/select/command_version/1/apache_arrow/drilldowns.expected
@@ -1,0 +1,56 @@
+table_create Documents TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Documents tag1 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Documents tag2 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+[[0,0.0,0.0],1]
+select Documents   --drilldown tag1,tag2   --command_version 1   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+tag1: string
+tag2: string
+-- metadata --
+GROONGA:n_hits: 1
+	     _id	  tag1	  tag2
+	(uint32)	(utf8)	(utf8)
+0	       1	1     	2     
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag1
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	1     	        1
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag2
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	2     	        1

--- a/test/command/suite/select/command_version/1/apache_arrow/drilldowns.test
+++ b/test/command/suite/select/command_version/1/apache_arrow/drilldowns.test
@@ -1,0 +1,19 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/command_version/3/drilldown/multiple.test at output_type=apache-arrow
+
+table_create Documents TABLE_NO_KEY
+column_create Documents tag1 COLUMN_SCALAR ShortText
+column_create Documents tag2 COLUMN_SCALAR ShortText
+
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+
+select Documents \
+  --drilldown tag1,tag2 \
+  --command_version 1 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/1/apache_arrow/slice.expected
+++ b/test/command/suite/select/command_version/1/apache_arrow/slice.expected
@@ -1,0 +1,58 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --slices[groonga].filter 'tag == "Groonga"'   --slices[groonga].sort_keys 'date'   --slices[groonga].output_columns '_key, date'   --command_version 1   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+_key: string
+date: timestamp[ns]
+tag: dictionary<values=string, indices=int32, ordered=0>
+-- metadata --
+GROONGA:n_hits: 4
+	     _id	  _key	                     date	         tag
+	(uint32)	(utf8)	              (timestamp)	(dictionary)
+0	       1	Groonga is fast!	2016-05-19T12:00:00+09:00	Groonga     
+1	       2	Mroonga is fast!	2016-05-19T12:00:01+09:00	Mroonga     
+2	       3	Groonga sticker!	2016-05-20T12:00:02+09:00	Groonga     
+3	       4	Rroonga is fast!	2016-05-21T12:00:03+09:00	Rroonga     
+========================================
+_key: string
+date: timestamp[ns]
+-- metadata --
+GROONGA:data_type: slice
+GROONGA:label: groonga
+GROONGA:n_hits: 2
+	  _key	                     date
+	(utf8)	              (timestamp)
+0	Groonga is fast!	2016-05-19T12:00:00+09:00
+1	Groonga sticker!	2016-05-20T12:00:02+09:00

--- a/test/command/suite/select/command_version/1/apache_arrow/slice.test
+++ b/test/command/suite/select/command_version/1/apache_arrow/slice.test
@@ -1,0 +1,28 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/slices/command_version_3.test at output_type=apache-arrow
+
+plugin_register functions/time
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos date COLUMN_SCALAR Time
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+
+select Memos \
+  --slices[groonga].filter 'tag == "Groonga"' \
+  --slices[groonga].sort_keys 'date' \
+  --slices[groonga].output_columns '_key, date' \
+  --command_version 1 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/2/apache_arrow/drilldowns.expected
+++ b/test/command/suite/select/command_version/2/apache_arrow/drilldowns.expected
@@ -1,0 +1,56 @@
+table_create Documents TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Documents tag1 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Documents tag2 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+[[0,0.0,0.0],1]
+select Documents   --drilldown tag1,tag2   --command_version 2   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+tag1: string
+tag2: string
+-- metadata --
+GROONGA:n_hits: 1
+	     _id	  tag1	  tag2
+	(uint32)	(utf8)	(utf8)
+0	       1	1     	2     
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag1
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	1     	        1
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag2
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	2     	        1

--- a/test/command/suite/select/command_version/2/apache_arrow/drilldowns.test
+++ b/test/command/suite/select/command_version/2/apache_arrow/drilldowns.test
@@ -1,0 +1,19 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/command_version/3/drilldown/multiple.test at output_type=apache-arrow
+
+table_create Documents TABLE_NO_KEY
+column_create Documents tag1 COLUMN_SCALAR ShortText
+column_create Documents tag2 COLUMN_SCALAR ShortText
+
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+
+select Documents \
+  --drilldown tag1,tag2 \
+  --command_version 2 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/2/apache_arrow/slice.expected
+++ b/test/command/suite/select/command_version/2/apache_arrow/slice.expected
@@ -1,0 +1,58 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --slices[groonga].filter 'tag == "Groonga"'   --slices[groonga].sort_keys 'date'   --slices[groonga].output_columns '_key, date'   --command_version 2   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+_key: string
+date: timestamp[ns]
+tag: dictionary<values=string, indices=int32, ordered=0>
+-- metadata --
+GROONGA:n_hits: 4
+	     _id	  _key	                     date	         tag
+	(uint32)	(utf8)	              (timestamp)	(dictionary)
+0	       1	Groonga is fast!	2016-05-19T12:00:00+09:00	Groonga     
+1	       2	Mroonga is fast!	2016-05-19T12:00:01+09:00	Mroonga     
+2	       3	Groonga sticker!	2016-05-20T12:00:02+09:00	Groonga     
+3	       4	Rroonga is fast!	2016-05-21T12:00:03+09:00	Rroonga     
+========================================
+_key: string
+date: timestamp[ns]
+-- metadata --
+GROONGA:data_type: slice
+GROONGA:label: groonga
+GROONGA:n_hits: 2
+	  _key	                     date
+	(utf8)	              (timestamp)
+0	Groonga is fast!	2016-05-19T12:00:00+09:00
+1	Groonga sticker!	2016-05-20T12:00:02+09:00

--- a/test/command/suite/select/command_version/2/apache_arrow/slice.test
+++ b/test/command/suite/select/command_version/2/apache_arrow/slice.test
@@ -1,0 +1,28 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/slices/command_version_3.test at output_type=apache-arrow
+
+plugin_register functions/time
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos date COLUMN_SCALAR Time
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+
+select Memos \
+  --slices[groonga].filter 'tag == "Groonga"' \
+  --slices[groonga].sort_keys 'date' \
+  --slices[groonga].output_columns '_key, date' \
+  --command_version 2 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/3/apache_arrow/drilldowns.expected
+++ b/test/command/suite/select/command_version/3/apache_arrow/drilldowns.expected
@@ -1,0 +1,56 @@
+table_create Documents TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Documents tag1 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Documents tag2 COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+[[0,0.0,0.0],1]
+select Documents   --drilldown tag1,tag2   --command_version 3   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+tag1: string
+tag2: string
+-- metadata --
+GROONGA:n_hits: 1
+	     _id	  tag1	  tag2
+	(uint32)	(utf8)	(utf8)
+0	       1	1     	2     
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag1
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	1     	        1
+========================================
+_key: string
+_nsubrecs: int32
+-- metadata --
+GROONGA:data_type: drilldown
+GROONGA:label: tag2
+GROONGA:n_hits: 1
+	  _key	_nsubrecs
+	(utf8)	  (int32)
+0	2     	        1

--- a/test/command/suite/select/command_version/3/apache_arrow/drilldowns.test
+++ b/test/command/suite/select/command_version/3/apache_arrow/drilldowns.test
@@ -1,0 +1,19 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/command_version/3/drilldown/multiple.test at output_type=apache-arrow
+
+table_create Documents TABLE_NO_KEY
+column_create Documents tag1 COLUMN_SCALAR ShortText
+column_create Documents tag2 COLUMN_SCALAR ShortText
+
+load --table Documents
+[
+{"tag1": "1", "tag2": "2"}
+]
+
+select Documents \
+  --drilldown tag1,tag2 \
+  --command_version 3 \
+  --output_type apache-arrow

--- a/test/command/suite/select/command_version/3/apache_arrow/slice.expected
+++ b/test/command/suite/select/command_version/3/apache_arrow/slice.expected
@@ -1,0 +1,58 @@
+plugin_register functions/time
+[[0,0.0,0.0],true]
+table_create Tags TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+table_create Memos TABLE_HASH_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Memos date COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Memos tag COLUMN_SCALAR Tags
+[[0,0.0,0.0],true]
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+[[0,0.0,0.0],4]
+select Memos   --slices[groonga].filter 'tag == "Groonga"'   --slices[groonga].sort_keys 'date'   --slices[groonga].output_columns '_key, date'   --command_version 3   --output_type apache-arrow
+return_code: int32
+start_time: timestamp[ns]
+elapsed_time: double
+error_message: string
+error_file: string
+error_line: uint32
+error_function: string
+error_input_file: string
+error_input_line: int32
+error_input_command: string
+-- metadata --
+GROONGA:data_type: metadata
+	return_code	               start_time	elapsed_time	error_message	error_file	error_line	error_function	error_input_file	error_input_line	error_input_command
+	    (int32)	              (timestamp)	    (double)	       (utf8)	    (utf8)	  (uint32)	        (utf8)	          (utf8)	         (int32)	             (utf8)
+0	          0	1970-01-01T09:00:00+09:00	    0.000000	       (null)	    (null)	    (null)	        (null)	          (null)	          (null)	             (null)
+========================================
+_id: uint32
+_key: string
+date: timestamp[ns]
+tag: dictionary<values=string, indices=int32, ordered=0>
+-- metadata --
+GROONGA:n_hits: 4
+	     _id	  _key	                     date	         tag
+	(uint32)	(utf8)	              (timestamp)	(dictionary)
+0	       1	Groonga is fast!	2016-05-19T12:00:00+09:00	Groonga     
+1	       2	Mroonga is fast!	2016-05-19T12:00:01+09:00	Mroonga     
+2	       3	Groonga sticker!	2016-05-20T12:00:02+09:00	Groonga     
+3	       4	Rroonga is fast!	2016-05-21T12:00:03+09:00	Rroonga     
+========================================
+_key: string
+date: timestamp[ns]
+-- metadata --
+GROONGA:data_type: slice
+GROONGA:label: groonga
+GROONGA:n_hits: 2
+	  _key	                     date
+	(utf8)	              (timestamp)
+0	Groonga is fast!	2016-05-19T12:00:00+09:00
+1	Groonga sticker!	2016-05-20T12:00:02+09:00

--- a/test/command/suite/select/command_version/3/apache_arrow/slice.test
+++ b/test/command/suite/select/command_version/3/apache_arrow/slice.test
@@ -1,0 +1,28 @@
+#@require-apache-arrow
+#@require-interface http
+#@require-testee groonga
+
+# Test for test/command/suite/select/slices/command_version_3.test at output_type=apache-arrow
+
+plugin_register functions/time
+
+table_create Tags TABLE_PAT_KEY ShortText
+
+table_create Memos TABLE_HASH_KEY ShortText
+column_create Memos date COLUMN_SCALAR Time
+column_create Memos tag COLUMN_SCALAR Tags
+
+load --table Memos
+[
+{"_key": "Groonga is fast!", "date": "2016-05-19 12:00:00", "tag": "Groonga"},
+{"_key": "Mroonga is fast!", "date": "2016-05-19 12:00:01", "tag": "Mroonga"},
+{"_key": "Groonga sticker!", "date": "2016-05-20 12:00:02", "tag": "Groonga"},
+{"_key": "Rroonga is fast!", "date": "2016-05-21 12:00:03", "tag": "Rroonga"}
+]
+
+select Memos \
+  --slices[groonga].filter 'tag == "Groonga"' \
+  --slices[groonga].sort_keys 'date' \
+  --slices[groonga].output_columns '_key, date' \
+  --command_version 3 \
+  --output_type apache-arrow


### PR DESCRIPTION
When running slice or drilldown with `output_type=apache-arrow`, Groonga would crash because it attempted to set a label in the Arrow output, which isn’t supported in that context.

To prevent this, we added `GROONGA:data_type` and `GROONGA:label` metadata to the Apache Arrow output for slice and drilldown results.