### PR TITLE
docs: tokenizers/token_delimit: Fix an unbalanced inline literal markup

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/tokenizers/token_delimit.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/tokenizers/token_delimit.po
@@ -84,7 +84,7 @@ msgstr "高度な使い方"
 msgid "``delimiter`` option can also specify multiple delimiters."
 msgstr "``delimiter`` オプションは、複数の区切り文字を指定することもできます。"
 
-msgid "For example, ``Hello, World`` is tokenized to ``Hello`` and ``World``. ``,`` and `` `` are delimiters in below example."
+msgid "For example, ``Hello, World`` is tokenized to ``Hello`` and ``World``. ``\",\"`` and ``\" \"`` are delimiters in below example."
 msgstr "例えば、以下のように ``Hello, World`` は、``Hello`` と ``World`` にトークナイズされます。"
 
 msgid "You can extract token in complex conditions by ``pattern`` option."

--- a/doc/locale/ja/LC_MESSAGES/reference/tokenizers/token_delimit.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/tokenizers/token_delimit.po
@@ -85,7 +85,7 @@ msgid "``delimiter`` option can also specify multiple delimiters."
 msgstr "``delimiter`` オプションは、複数の区切り文字を指定することもできます。"
 
 msgid "For example, ``Hello, World`` is tokenized to ``Hello`` and ``World``. ``\",\"`` and ``\" \"`` are delimiters in below example."
-msgstr "例えば、以下のように ``Hello, World`` は、``Hello`` と ``World`` にトークナイズされます。"
+msgstr "例えば、以下のように ``Hello, World`` は、``Hello`` と ``World`` にトークナイズされます。以下の例では、``\",\"`` と ``\" \"`` が区切り文字です。"
 
 msgid "You can extract token in complex conditions by ``pattern`` option."
 msgstr "``pattern`` オプションを使って複雑な条件でトークンを抽出できます。"

--- a/doc/source/reference/tokenizers/token_delimit.rst
+++ b/doc/source/reference/tokenizers/token_delimit.rst
@@ -83,7 +83,7 @@ Advanced usage
 ``delimiter`` option can also specify multiple delimiters.
 
 For example, ``Hello, World`` is tokenized to ``Hello`` and ``World``.
-``,`` and `` `` are delimiters in below example.
+``","`` and ``" "`` are delimiters in below example.
 
 .. groonga-command
 .. include:: ../../example/reference/tokenizers/token-delimit-delimiter-option-multiple-delimiters.log


### PR DESCRIPTION
Fix errors found in GitHub GH-2365.

Space is not allowed just after "``", so HTML is not generated as expected.
Enclosing in double quotes avoids this issue.

In addition to enclosing a space with `"`, `,` is also enclosed in the same way.