### PR TITLE
docs: grn_expr/script_syntax: Fix an unbalanced inline literal markup

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/reference/grn_expr/script_syntax.po
+++ b/doc/locale/ja/LC_MESSAGES/reference/grn_expr/script_syntax.po
@@ -102,7 +102,7 @@ msgstr "浮動小数点数リテラルは ``3.14`` のように、まず ``0`` �
 msgid "String"
 msgstr "文字列"
 
-msgid "String literal is ``\"...\"``. You need to escape ``\"`` in literal by prepending ``\\\\'' such as ``\\\"``. For example, ``\"Say \\\"Hello!\\\".\"`` is a literal for ``Say \"Hello!\".`` string."
+msgid "String literal is ``\"...\"``. You need to escape ``\"`` in literal by prepending ``\\`` such as ``\\\"``. For example, ``\"Say \\\"Hello!\\\".\"`` is a literal for ``Say \"Hello!\".`` string."
 msgstr "文字列リテラルは ``\"...\"`` です。リテラル中の ``\"`` は ``\\\"`` というように ``\\`` を前につけてエスケープします。例えば、 ``\"Say \\\"Hello!\\\".\"`` は ``Say \"Hello!\".`` という文字列のリテラルです。"
 
 msgid "String encoding must be the same as encoding of database. The default encoding is UTF-8. It can be changed by ``--with-default-encoding`` configure option, ``--encoding`` :doc:`/reference/executables/groonga` option and so on."

--- a/doc/source/reference/grn_expr/script_syntax.rst
+++ b/doc/source/reference/grn_expr/script_syntax.rst
@@ -150,7 +150,7 @@ String
 ^^^^^^
 
 String literal is ``"..."``. You need to escape ``"`` in literal by
-prepending ``\\'' such as ``\"``. For example, ``"Say \"Hello!\"."`` is
+prepending ``\`` such as ``\"``. For example, ``"Say \"Hello!\"."`` is
 a literal for ``Say "Hello!".`` string.
 
 String encoding must be the same as encoding of database. The default


### PR DESCRIPTION
Fix errors found in GitHub GH-2365.

```
BAD:  ``\\''
GOOD: ``\``
```

* In BAD, inline literal is closed with a single quote
* If we need to display a backslash in an inline literal, we only need one