### PR TITLE
ii order-near-phrase: fix interval caclulation

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -13118,6 +13118,8 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
     }
     uint32_t previous_phrase_id = data->token_infos[0]->phrase_id;
     int32_t previous_pos = data->token_infos[0]->pos;
+    int32_t previous_n_tokens_in_phrase =
+      data->token_infos[0]->n_tokens_in_phrase;
     for (i_token_info = 1, i_interval = 0;
          i_token_info < n_token_infos && i_interval < n_intervals;
          i_token_info++) {
@@ -13129,7 +13131,7 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
       int32_t pos = token_info->pos;
       int32_t max_element_interval =
         GRN_INT32_VALUE_AT(data->max_element_intervals, i_interval);
-      int32_t interval = pos - previous_pos - token_info->n_tokens_in_phrase;
+      int32_t interval = pos - previous_pos - previous_n_tokens_in_phrase;
       if (max_element_interval >= 0 && interval > max_element_interval) {
         return false;
       }
@@ -13137,6 +13139,7 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
         return false;
       }
       previous_pos = pos;
+      previous_n_tokens_in_phrase = token_info->n_tokens_in_phrase;
       i_interval++;
     }
     return true;

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/all.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/all.expected
@@ -8,13 +8,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 [[0,0.0,0.0],4]
-select Entries --filter 'content *ONP-1,0,5|6 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5|6 "abc defghi jklmnop"' --output_columns '_score, content'
 [
   [
     0,
@@ -38,7 +38,7 @@ select Entries --filter 'content *ONP-1,0,5|6 "abc def ghi"' --output_columns '_
       ],
       [
         1,
-        "abc12345def123456ghi"
+        "abc12345defghi123456jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/all.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/all.test
@@ -9,10 +9,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 
-select Entries --filter 'content *ONP-1,0,5|6 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5|6 "abc defghi jklmnop"' --output_columns '_score, content'

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/less.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/less.expected
@@ -8,11 +8,11 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc123456def123456ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc123456defghi123456jklmnop"}
 ]
 [[0,0.0,0.0],2]
-select Entries --filter 'content *ONP-1,0,5 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5 "abc defghi jklmnop"' --output_columns '_score, content'
 [
   [
     0,
@@ -36,7 +36,7 @@ select Entries --filter 'content *ONP-1,0,5 "abc def ghi"' --output_columns '_sc
       ],
       [
         1,
-        "abc12345def123456ghi"
+        "abc12345defghi123456jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/less.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/less.test
@@ -9,8 +9,8 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc123456def123456ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc123456defghi123456jklmnop"}
 ]
 
-select Entries --filter 'content *ONP-1,0,5 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5 "abc defghi jklmnop"' --output_columns '_score, content'

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/more.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/more.expected
@@ -8,13 +8,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 [[0,0.0,0.0],4]
-select Entries --filter 'content *ONP-1,0,5|6|3 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5|6|3 "abc defghi jklmnop"' --output_columns '_score, content'
 [
   [
     0,
@@ -38,7 +38,7 @@ select Entries --filter 'content *ONP-1,0,5|6|3 "abc def ghi"' --output_columns 
       ],
       [
         1,
-        "abc12345def123456ghi"
+        "abc12345defghi123456jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/more.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/max_element_intervals/multi_tokens/more.test
@@ -9,10 +9,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 
-select Entries --filter 'content *ONP-1,0,5|6|3 "abc def ghi"' --output_columns '_score, content'
+select Entries --filter 'content *ONP-1,0,5|6|3 "abc defghi jklmnop"' --output_columns '_score, content'

--- a/test/command/suite/select/filter/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --filter 'content *ONP-1,0,10,8"abc ef"'   --output_columns '_score, content'

--- a/test/command/suite/select/filter/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/filter/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/all.expected
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/all.expected
@@ -8,13 +8,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 [[0,0.0,0.0],4]
-select Entries   --match_columns content   --query '*ONP-1,0,5|6"abc def ghi"'   --output_columns '_score, content'
+select Entries   --match_columns content   --query '*ONP-1,0,5|6"abc defghi jklmnop"'   --output_columns '_score, content'
 [
   [
     0,
@@ -38,7 +38,7 @@ select Entries   --match_columns content   --query '*ONP-1,0,5|6"abc def ghi"'  
       ],
       [
         1,
-        "abc12345def123456ghi"
+        "abc12345defghi123456jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/all.test
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/all.test
@@ -9,13 +9,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 
 select Entries \
   --match_columns content \
-  --query '*ONP-1,0,5|6"abc def ghi"' \
+  --query '*ONP-1,0,5|6"abc defghi jklmnop"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/less.expected
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/less.expected
@@ -8,11 +8,11 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def12ghi"},
-{"content": "abc123456def12ghi"}
+{"content": "abc12345defghi12jklmnop"},
+{"content": "abc123456defghi12jklmnop"}
 ]
 [[0,0.0,0.0],2]
-select Entries   --match_columns content   --query '*ONP-1,0,5"abc def ghi"'   --output_columns '_score, content'
+select Entries   --match_columns content   --query '*ONP-1,0,5"abc defghi jklmnop"'   --output_columns '_score, content'
 [
   [
     0,
@@ -36,7 +36,7 @@ select Entries   --match_columns content   --query '*ONP-1,0,5"abc def ghi"'   -
       ],
       [
         1,
-        "abc12345def12ghi"
+        "abc12345defghi12jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/less.test
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/less.test
@@ -9,11 +9,11 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def12ghi"},
-{"content": "abc123456def12ghi"}
+{"content": "abc12345defghi12jklmnop"},
+{"content": "abc123456defghi12jklmnop"}
 ]
 
 select Entries \
   --match_columns content \
-  --query '*ONP-1,0,5"abc def ghi"' \
+  --query '*ONP-1,0,5"abc defghi jklmnop"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/more.expected
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/more.expected
@@ -8,13 +8,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 [[0,0.0,0.0],4]
-select Entries   --match_columns content   --query '*ONP-1,0,5|6|3"abc def ghi"'   --output_columns '_score, content'
+select Entries   --match_columns content   --query '*ONP-1,0,5|6|3"abc defghi jklmnop"'   --output_columns '_score, content'
 [
   [
     0,
@@ -38,7 +38,7 @@ select Entries   --match_columns content   --query '*ONP-1,0,5|6|3"abc def ghi"'
       ],
       [
         1,
-        "abc12345def123456ghi"
+        "abc12345defghi123456jklmnop"
       ]
     ]
   ]

--- a/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/more.test
+++ b/test/command/suite/select/query/ordered_near_phrase/max_element_intervals/multi_tokens/more.test
@@ -9,13 +9,13 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345def123456ghi"},
-{"content": "abc12345def1234567ghi"},
-{"content": "abc123456def123456ghi"},
-{"content": "abc123456def1234567ghi"}
+{"content": "abc12345defghi123456jklmnop"},
+{"content": "abc12345defghi1234567jklmnop"},
+{"content": "abc123456defghi123456jklmnop"},
+{"content": "abc123456defghi1234567jklmnop"}
 ]
 
 select Entries \
   --match_columns content \
-  --query '*ONP-1,0,5|6|3"abc def ghi"' \
+  --query '*ONP-1,0,5|6|3"abc defghi jklmnop"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/query/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --match_columns content   --query '*ONP-1,0,10,9"abc ef"'   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/query/ordered_near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \


### PR DESCRIPTION
## Problem

Currently, we can not calculate correctly interval between phrase.
We calculate interval between phrase as below expression.

```
interval = pos - previous_pos - token_info->n_tokens_in_phrase;
```

However, the avobe expression can not calculate correctly interval.
Because we use token_info->n_tokens_in_phrase.
We should use the n_tokens_in_phrase of previous phrase.

This problem only occurs when we use max element intervals.
Because if we don't use max element intervals, Groonga does not reach posint that cause the problem.

---

For example, if we calculate interval between phrase "abc defghi jklmnop" in "abc123456defghi".
(We use `TokenNgram("unify_alphabet", false, "unify_digit", false)` and `NormalizerNFKC121` in this case.)

### Calculate interval between "abc" and "defghi":

Curretnnly:

```
interval = pos - previous_pos - token_info->n_tokens_in_phrase;
```

pos is position of first token of second phrase.(So, the head position of "defghi".)
Therefore, pos is 9.

previous_pos is position of first token of first phrase.(So, the head position of "abc".)
Therefore, previous_pos is 0.

token_info->n_tokens_in_phrase is the number of tokens in second phrase.(So, the number of tokens in "defghi".)
Therefore, token_info->n_tokens_in_phrase is 6.
Because "defghi" is tokenized as below.

```
"defghi" -> "de/ef/fg/gh/hi/i"
```

Therefore the interval between "abc" and "defghi" is 9 - 0 - 6 = 3.

"abc123456defghi" is hit.
However, correctly the interval between"abc" and "defghi" is 6.
We expect "abc123456defghi" is not hit.


Revision:

```
interval = pos - previous_pos - previous_n_tokens_in_phrase;
```

pos is position of first token of second phrase.(So, the head position of "defghi".)
Therefore, pos is 9.

previous_pos is position of first token of first phrase.(So, the head position of "abc".)
Therefore, previous_pos is 0.

previous_n_tokens_in_phrase is the number of tokens in first phrase.(So, the number of tokens in "abc".)
Therefore, token_info->n_tokens_in_phrase is 3.
Because "abc" is tokenized as below.

```
"abc" -> "ab/bc/c"
```

Therefore the interval between "abc" and "defghi" is 9 - 0 - 3 = 6.
"abc123456defghi" is not hit.

We can get expected value by using the n_tokens_in_phrase of previous phrase instead of token_info->n_tokens_in_phrase.

This problem does not detect current tests.
Because the number of tokens in phrase are same value in all phrase like "abc def ghi".
So, I update current tests.