### PR TITLE
packages windows: drop support for windows-2019

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -633,9 +633,6 @@ jobs:
           - runs-on: windows-2022
             vc-toolset-version: 143
             vs-version: 2022
-          - runs-on: windows-2019
-            vc-toolset-version: 142
-            vs-version: 2019
     env:
       VC_ARCHITECTURE: x64
     runs-on: ${{ matrix.runs-on }}
@@ -824,14 +821,6 @@ jobs:
 
           $VC_REDIST_VERSION = (Get-Content "${Env:VC_PREFIX}\Auxiliary\Build\Microsoft.VCRedistVersion.default.txt")
           $VC_REDIST_DIR = "${Env:VC_PREFIX}\Redist\MSVC\${VC_REDIST_VERSION}\${Env:VC_ARCHITECTURE}\Microsoft.VC${{ matrix.vc-toolset-version }}.CRT"
-          # Workaround: This is only needed for the current
-          # windows-2019 runner. Should we use
-          # Microsoft.VCToolsVersion.default.txt instead of
-          # Microsoft.VCRedistVersion.default.txt?
-          if (-not (Test-Path "${VC_REDIST_DIR}")) {
-            $VC_REDIST_VERSION = "14.29.30133"
-            $VC_REDIST_DIR = "${Env:VC_PREFIX}\Redist\MSVC\${VC_REDIST_VERSION}\${Env:VC_ARCHITECTURE}\Microsoft.VC${{ matrix.vc-toolset-version }}.CRT"
-          }
           $VC_REDIST_DIR_OPEN_MP = "${Env:VC_PREFIX}\Redist\MSVC\${VC_REDIST_VERSION}\${Env:VC_ARCHITECTURE}\Microsoft.VC${{ matrix.vc-toolset-version }}.OpenMP"
           $VC_REDIST_VCRUNTIME = "${VC_REDIST_DIR}\vcruntime140.dll"
           $VC_REDIST_VCRUNTIME_1 = "${VC_REDIST_DIR}\vcruntime140_1.dll"

--- a/doc/locale/ja/LC_MESSAGES/install/windows.po
+++ b/doc/locale/ja/LC_MESSAGES/install/windows.po
@@ -28,29 +28,20 @@ msgstr "32-bit用と64-bit用のパッケージを配布していますが、サ
 msgid "zip"
 msgstr ""
 
-msgid "For 32-bit environment, download x86 zip archive from packages.groonga.org:"
-msgstr "32-bit環境の場合は、x86のzipアーカイブをpackages.groonga.orgからダウンロードしてください。"
+msgid "For 64-bit environment, download x64 zip archive from packages.groonga.org:"
+msgstr "64-bit環境の場合は、x64のzipアーカイブをpackages.groonga.orgからダウンロードしてください。"
 
-msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x86-vs2019-with-vcruntime.zip"
+msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2022-with-vcruntime.zip"
 msgstr ""
 
 msgid "If we don't need Microsoft Visual C++ Runtime Library, we download from the following URL:"
 msgstr "Microsoft Visual C++ ランタイムライブラリーが不要な場合は、以下のURLからダウンロードしてください。"
 
-msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x86-vs2019.zip"
+msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2022.zip"
 msgstr ""
 
 msgid "Then extract it."
 msgstr "その後、アーカイブを展開します。"
-
-msgid "For 64-bit environment, download x64 zip archive from packages.groonga.org:"
-msgstr "64-bit環境の場合は、x64のzipアーカイブをpackages.groonga.orgからダウンロードしてください。"
-
-msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2019-with-vcruntime.zip"
-msgstr ""
-
-msgid "https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2019.zip"
-msgstr ""
 
 msgid "You can find :doc:`/reference/executables/groonga` in ``bin`` folder."
 msgstr "``bin`` フォルダーに :doc:`/reference/executables/groonga` があるのでそれを起動してください。"

--- a/doc/source/install/windows.rst
+++ b/doc/source/install/windows.rst
@@ -16,25 +16,14 @@ size data.
 zip
 ---
 
-For 32-bit environment, download x86 zip archive from
-packages.groonga.org:
-
-  * https://packages.groonga.org/windows/groonga/groonga-latest-x86-vs2019-with-vcruntime.zip
-
-If we don't need Microsoft Visual C++ Runtime Library, we download from the following URL:
-
-  * https://packages.groonga.org/windows/groonga/groonga-latest-x86-vs2019.zip
-
-Then extract it.
-
 For 64-bit environment, download x64 zip archive from
 packages.groonga.org:
 
-  * https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2019-with-vcruntime.zip
+  * https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2022-with-vcruntime.zip
 
 If we don't need Microsoft Visual C++ Runtime Library, we download from the following URL:
 
-  * https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2019.zip
+  * https://packages.groonga.org/windows/groonga/groonga-latest-x64-vs2022.zip
 
 Then extract it.
 

--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -94,8 +94,6 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
     [
       "#{@package}-#{@version}-x64-vs2022.zip",
       "#{@package}-#{@version}-x64-vs2022-with-vcruntime.zip",
-      "#{@package}-#{@version}-x64-vs2019.zip",
-      "#{@package}-#{@version}-x64-vs2019-with-vcruntime.zip",
     ]
   end
 


### PR DESCRIPTION
windows-2019's runner image has reached EOL on GitHub Actions.
See: https://github.com/actions/runner-images/issues/12045