### PR TITLE
ii near-phrase/near-phrase-product: fix interval caclulation

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -13092,13 +13092,15 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
       n = n_max_element_intervals + 1;
     }
     int32_t previous_pos = data->check_element_intervals_btree->min->pos;
+    int32_t previous_n_tokens_in_phrase =
+      data->check_element_intervals_btree->min->n_tokens_in_phrase;
     for (i = 1; i < n; i++) {
       bt_pop(data->check_element_intervals_btree);
       token_info *min = data->check_element_intervals_btree->min;
       int32_t pos = min->pos;
       int32_t max_element_interval =
         GRN_INT32_VALUE_AT(data->max_element_intervals, i - 1);
-      int32_t interval = pos - previous_pos - min->n_tokens_in_phrase;
+      int32_t interval = pos - previous_pos - previous_n_tokens_in_phrase;
       if (max_element_interval >= 0 && interval > max_element_interval) {
         return false;
       }
@@ -13106,6 +13108,7 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
         return false;
       }
       previous_pos = pos;
+      previous_n_tokens_in_phrase = min->n_tokens_in_phrase;
     }
     return true;
   } else if (data->mode == GRN_OP_ORDERED_NEAR_PHRASE) {

--- a/test/command/suite/select/filter/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/filter/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,8 +8,8 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc123456789defg"}
 ]
 [[0,0.0,0.0],1]
-select Entries   --filter 'content *NP-1,0,10,9"abc ef"'   --output_columns '_score, content'
+select Entries   --filter 'content *NP-1,0,10,9"abc fg"'   --output_columns '_score, content'
 [[0,0.0,0.0],[[[0],[["_score","Int32"],["content","Text"]]]]]

--- a/test/command/suite/select/filter/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/filter/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,9 +9,9 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc123456789defg"}
 ]
 
 select Entries \
-  --filter 'content *NP-1,0,10,9"abc ef"' \
+  --filter 'content *NP-1,0,10,9"abc fg"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/filter/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/filter/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --filter 'content *NPP-1,0,10,9"(abc bcd) (ef)"'   --output_columns '_score, content'

--- a/test/command/suite/select/filter/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/filter/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \

--- a/test/command/suite/select/query/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/query/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc12345678901def"}
+{"content": "abc123456789012def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --match_columns content   --query '*NP-1,0,12,11"abc ef"'   --output_columns '_score, content'

--- a/test/command/suite/select/query/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/query/near_phrase/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc12345678901def"}
+{"content": "abc123456789012def"}
 ]
 
 select Entries \

--- a/test/command/suite/select/query/near_phrase_product/min_interval/with_additional_last_interval/not_match_more_max.expected
+++ b/test/command/suite/select/query/near_phrase_product/min_interval/with_additional_last_interval/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --match_columns content   --query '*NPP12,0,10,9"(abc bcd) (ef$)"'   --output_columns '_score, content'

--- a/test/command/suite/select/query/near_phrase_product/min_interval/with_additional_last_interval/not_match_more_max.test
+++ b/test/command/suite/select/query/near_phrase_product/min_interval/with_additional_last_interval/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \

--- a/test/command/suite/select/query/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/query/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,7 +8,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
 select Entries   --match_columns content   --query '*NPP-1,0,10,9"(abc bcd) (ef)"'   --output_columns '_score, content'

--- a/test/command/suite/select/query/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/query/near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,7 +9,7 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \


### PR DESCRIPTION
This problem is similar problem to GH-2407.

Currently, we can not calculate correctly interval between phrase in `*NP` and `*NPP` operator too.
`*N` operator also include this problem. However, `*N` operator doesn't occur this problem basiaully.
Because `*N` doesn't process phrases basically.


We should use the number of tokens in phrase of previous phrase in `*NP` and `*NPP` operator too.
However, `*NP` and `*NPP` operator use the number of tokens in phrase of current phrase currently in caculating interval between phrases.

So, we modify that use it of previous phrase in this commit.