### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_open

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1704,7 +1704,7 @@ grn_pat_open(grn_ctx *ctx, const char *path)
 {
   grn_io *io;
   grn_pat *pat;
-  pat_node *node0;
+  pat_node_common *node0;
   struct grn_pat_header *header;
   uint32_t io_type;
   io = grn_io_open(ctx, path, GRN_IO_AUTO);


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

We want to replace to pat_node_common from all pat_node. However, we use many pat_node in lib/pat.c.
So, I replace them little by little.