### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_fuzzy_search

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -3342,7 +3342,7 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     if (node) {
       id = pat_node_get_right(pat, node);
     } else {
-      return GRN_NO_MEMORY_AVAILABLE;
+      return ctx->rc;
     }
   }
   if (id == GRN_ID_NIL) {

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -137,16 +137,13 @@ pat_key_storage_size(uint32_t key_size)
 }
 
 static inline grn_id
-pat_node_get_right(grn_pat *pat, pat_node_common *n)
+pat_node_get_right(grn_pat *pat, pat_node_common *node)
 {
-  if (n) {
-    if (pat_is_key_large(pat)) {
-      return n->node_large.lr[1];
-    } else {
-      return n->node.lr[1];
-    }
+  if (pat_is_key_large(pat)) {
+    return node->node_large.lr[1];
+  } else {
+    return node->node.lr[1];
   }
-  return GRN_ID_NIL;
 }
 
 #define PAT_DEL(x)     ((x)->bits & PAT_DELETING)
@@ -3342,7 +3339,11 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     id = grn_pat_fuzzy_search_find_prefixed_start_node_id(ctx, &data);
   } else {
     PAT_AT(pat, GRN_ID_NIL, node);
-    id = pat_node_get_right(pat, node);
+    if (node) {
+      id = pat_node_get_right(pat, node);
+    } else {
+      return GRN_NO_MEMORY_AVAILABLE;
+    }
   }
   if (id == GRN_ID_NIL) {
     return GRN_END_OF_DATA;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -3265,7 +3265,7 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
                      grn_fuzzy_search_optarg *args,
                      grn_hash *h)
 {
-  pat_node *node;
+  pat_node_common *node;
   grn_id id;
   fuzzy_search_data data;
   uint32_t len, x, y, i;
@@ -3329,7 +3329,14 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     id = grn_pat_fuzzy_search_find_prefixed_start_node_id(ctx, &data);
   } else {
     PAT_AT(pat, GRN_ID_NIL, node);
-    id = node->lr[1];
+    if (!node) {
+      return GRN_INVALID_ARGUMENT;
+    }
+    if (pat_is_key_large(pat)) {
+      id = node->node_large.lr[1];
+    } else {
+      id = node->node.lr[1];
+    }
   }
   if (id == GRN_ID_NIL) {
     return GRN_END_OF_DATA;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -3329,9 +3329,6 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     id = grn_pat_fuzzy_search_find_prefixed_start_node_id(ctx, &data);
   } else {
     PAT_AT(pat, GRN_ID_NIL, node);
-    if (!node) {
-      return GRN_INVALID_ARGUMENT;
-    }
     if (pat_is_key_large(pat)) {
       id = node->node_large.lr[1];
     } else {

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -136,6 +136,19 @@ pat_key_storage_size(uint32_t key_size)
   return pat_key_is_embeddable(key_size) ? 0 : key_size;
 }
 
+static inline grn_id
+pat_node_get_right(grn_pat *pat, pat_node_common *n)
+{
+  if (n) {
+    if (pat_is_key_large(pat)) {
+      return n->node_large.lr[1];
+    } else {
+      return n->node.lr[1];
+    }
+  }
+  return GRN_ID_NIL;
+}
+
 #define PAT_DEL(x)     ((x)->bits & PAT_DELETING)
 #define PAT_IMD(x)     ((x)->bits & PAT_IMMEDIATE)
 #define PAT_LEN(x)     (uint32_t)(((x)->bits >> 3) + 1)
@@ -3329,11 +3342,7 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     id = grn_pat_fuzzy_search_find_prefixed_start_node_id(ctx, &data);
   } else {
     PAT_AT(pat, GRN_ID_NIL, node);
-    if (pat_is_key_large(pat)) {
-      id = node->node_large.lr[1];
-    } else {
-      id = node->node.lr[1];
-    }
+    id = pat_node_get_right(pat, node);
   }
   if (id == GRN_ID_NIL) {
     return GRN_END_OF_DATA;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -3339,11 +3339,10 @@ grn_pat_fuzzy_search(grn_ctx *ctx,
     id = grn_pat_fuzzy_search_find_prefixed_start_node_id(ctx, &data);
   } else {
     PAT_AT(pat, GRN_ID_NIL, node);
-    if (node) {
-      id = pat_node_get_right(pat, node);
-    } else {
+    if (!node) {
       return ctx->rc;
     }
+    id = pat_node_get_right(pat, node);
   }
   if (id == GRN_ID_NIL) {
     return GRN_END_OF_DATA;


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.