### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_cursor_open

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -140,9 +140,9 @@ static inline grn_id
 pat_node_get_right(grn_pat *pat, pat_node_common *node)
 {
   if (pat_is_key_large(pat)) {
-    return node->node_large.lr[1];
+    return node->node_large.lr[DIRECTION_RIGHT];
   } else {
-    return node->node.lr[1];
+    return node->node.lr[DIRECTION_RIGHT];
   }
 }
 
@@ -150,9 +150,9 @@ static inline grn_id
 pat_node_get_left(grn_pat *pat, pat_node_common *node)
 {
   if (pat_is_key_large(pat)) {
-    return node->node_large.lr[0];
+    return node->node_large.lr[DIRECTION_LEFT];
   } else {
-    return node->node.lr[0];
+    return node->node.lr[DIRECTION_LEFT];
   }
 }
 

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5072,7 +5072,7 @@ grn_pat_cursor_open(grn_ctx *ctx,
       if ((id = pat_node_get_right(pat, node))) {
         PAT_AT(pat, id, node);
         if (node) {
-          grn_pat_cursor_push(c, GRN_CURSOR_DESCENDING, pat, node);
+          grn_pat_cursor_push(ctx, c, GRN_CURSOR_DESCENDING, pat, node);
         }
       }
     }
@@ -5097,7 +5097,7 @@ grn_pat_cursor_open(grn_ctx *ctx,
       if ((id = pat_node_get_right(pat, node))) {
         PAT_AT(pat, id, node);
         if (node) {
-          grn_pat_cursor_push(c, GRN_CURSOR_ASCENDING, pat, node);
+          grn_pat_cursor_push(ctx, c, GRN_CURSOR_ASCENDING, pat, node);
         }
       }
     }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -4377,10 +4377,11 @@ pop(grn_pat_cursor *c)
 }
 
 static inline void
-push_pat_cursor(grn_pat_cursor *cursor,
-                int order,
-                grn_pat *pat,
-                pat_node_common *node)
+grn_pat_cursor_push(grn_ctx *ctx,
+                    grn_pat_cursor *cursor,
+                    int order,
+                    grn_pat *pat,
+                    pat_node_common *node)
 {
   uint16_t ch = pat_chk(pat, node);
   if (order & GRN_CURSOR_DESCENDING) {

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -161,7 +161,7 @@ pat_node_get_left(grn_pat *pat, pat_node_common *node)
 #define PAT_LEN(x) (uint32_t)(((x)->bits >> 3) + 1)
 #define PAT_CHK(x) ((x)->check)
 static inline uint16_t
-pat_chk(grn_pat *pat, pat_node_common *node)
+pat_node_get_check(grn_pat *pat, pat_node_common *node)
 {
   if (pat_is_key_large(pat)) {
     return node->node_large.check;
@@ -4383,7 +4383,7 @@ grn_pat_cursor_push(grn_ctx *ctx,
                     grn_pat *pat,
                     pat_node_common *node)
 {
-  uint16_t ch = pat_chk(pat, node);
+  uint16_t ch = pat_node_get_check(pat, node);
   if (order & GRN_CURSOR_DESCENDING) {
     push(cursor, pat_node_get_left(pat, node), ch);
     push(cursor, pat_node_get_right(pat, node), ch);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -4383,13 +4383,13 @@ grn_pat_cursor_push(grn_ctx *ctx,
                     grn_pat *pat,
                     pat_node_common *node)
 {
-  uint16_t ch = pat_node_get_check(pat, node);
+  uint16_t check = pat_node_get_check(pat, node);
   if (order & GRN_CURSOR_DESCENDING) {
-    push(cursor, pat_node_get_left(pat, node), ch);
-    push(cursor, pat_node_get_right(pat, node), ch);
+    push(cursor, pat_node_get_left(pat, node), check);
+    push(cursor, pat_node_get_right(pat, node), check);
   } else {
-    push(cursor, pat_node_get_right(pat, node), ch);
-    push(cursor, pat_node_get_left(pat, node), ch);
+    push(cursor, pat_node_get_right(pat, node), check);
+    push(cursor, pat_node_get_left(pat, node), check);
   }
 }
 

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5072,7 +5072,7 @@ grn_pat_cursor_open(grn_ctx *ctx,
       if ((id = pat_node_get_right(pat, node))) {
         PAT_AT(pat, id, node);
         if (node) {
-          push_pat_cursor(c, GRN_CURSOR_DESCENDING, pat, node);
+          grn_pat_cursor_push(c, GRN_CURSOR_DESCENDING, pat, node);
         }
       }
     }
@@ -5097,7 +5097,7 @@ grn_pat_cursor_open(grn_ctx *ctx,
       if ((id = pat_node_get_right(pat, node))) {
         PAT_AT(pat, id, node);
         if (node) {
-          push_pat_cursor(c, GRN_CURSOR_ASCENDING, pat, node);
+          grn_pat_cursor_push(c, GRN_CURSOR_ASCENDING, pat, node);
         }
       }
     }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -156,10 +156,10 @@ pat_node_get_left(grn_pat *pat, pat_node_common *node)
   }
 }
 
-#define PAT_DEL(x)     ((x)->bits & PAT_DELETING)
-#define PAT_IMD(x)     ((x)->bits & PAT_IMMEDIATE)
-#define PAT_LEN(x)     (uint32_t)(((x)->bits >> 3) + 1)
-#define PAT_CHK(x)     ((x)->check)
+#define PAT_DEL(x) ((x)->bits & PAT_DELETING)
+#define PAT_IMD(x) ((x)->bits & PAT_IMMEDIATE)
+#define PAT_LEN(x) (uint32_t)(((x)->bits >> 3) + 1)
+#define PAT_CHK(x) ((x)->check)
 static inline uint16_t
 pat_chk(grn_pat *pat, pat_node_common *node)
 {


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.