### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_inspect_nodes

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -5362,17 +5362,20 @@ grn_pat_inspect_node(grn_ctx *ctx,
 void
 grn_pat_inspect_nodes(grn_ctx *ctx, grn_pat *pat, grn_obj *buf)
 {
-  pat_node *node;
+  pat_node_common *node;
   grn_obj key_buf;
 
   GRN_TEXT_PUTS(ctx, buf, "{");
   PAT_AT(pat, GRN_ID_NIL, node);
-  if (node->lr[1] != GRN_ID_NIL) {
-    GRN_TEXT_PUTS(ctx, buf, "\n");
-    GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
-    grn_pat_inspect_node(ctx, pat, node->lr[1], -1, &key_buf, 0, "", buf);
-    GRN_OBJ_FIN(ctx, &key_buf);
-    GRN_TEXT_PUTS(ctx, buf, "\n");
+  if (node) {
+    grn_id right_node_id = pat_node_get_right(pat, node);
+    if (right_node_id != GRN_ID_NIL) {
+      GRN_TEXT_PUTS(ctx, buf, "\n");
+      GRN_OBJ_INIT(&key_buf, GRN_BULK, 0, pat->obj.header.domain);
+      grn_pat_inspect_node(ctx, pat, right_node_id, -1, &key_buf, 0, "", buf);
+      GRN_OBJ_FIN(ctx, &key_buf);
+      GRN_TEXT_PUTS(ctx, buf, "\n");
+    }
   }
   GRN_TEXT_PUTS(ctx, buf, "}");
 }


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.