### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_del_data structure 

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -6757,12 +6757,12 @@ grn_pat_wal_recover_delete_entry(grn_ctx *ctx,
     return;
   }
   data.proot = pat_node_get_right_address(pat, root_node);
-  data.p0 = pat_node_get_child_address(pat,
-                                       grandparent_node,
-                                       entry->parent_record_direction);
   data.p = pat_node_get_child_address(pat,
                                       data.node_previous,
                                       entry->record_direction);
+  data.p0 = pat_node_get_child_address(pat,
+                                       grandparent_node,
+                                       entry->parent_record_direction);
   data.n_garbages = entry->n_garbages;
   data.n_entries = entry->n_entries;
   grn_pat_del_internal(ctx, pat, &data);


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

I added the following function temporary.

- _grn_pat_wal_add_entry_data_set_record_direction()
- _pat_node_get_key()
- _grn_pat_next_location()

Because if we modify the above functions, we must modify many place in lib/pat.c to prevent build error.
So, I added the above functions temporary to reduce affect.

The above functions will change to functions that have no "_" prefix at the completion of GH-2349.