### PR TITLE
cmake msvc: enable possible loss of data warning

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -632,6 +632,11 @@ jobs:
       matrix:
         include:
           - runs-on: windows-2022
+            allow_warning: OFF
+            vc-toolset-version: 143
+            vs-version: 2022
+          - runs-on: windows-2022
+            allow_warning: ON
             vc-toolset-version: 143
             vs-version: 2022
     env:
@@ -769,7 +774,7 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -G "Ninja"
           set CMAKE_ARGS=%CMAKE_ARGS% "-DCMAKE_INSTALL_PREFIX=%FULL_INSTALL_FOLDER%"
           set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_ALLOW_WARNING=OFF
+          set CMAKE_ARGS=%CMAKE_ARGS% "-DGRN_ALLOW_WARNING=${{ matrix.allow_warning }}"
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_APACHE_ARROW=ON
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_BLOSC=auto
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_MRUBY=ON
@@ -782,6 +787,7 @@ jobs:
           cmake --install ..\groonga-build || exit /B
           ccache --show-stats --verbose --version
       - name: Install Groonga Admin
+        if: matrix.allow_warning != 'ON'
         run: |
           cd "${Env:FULL_INSTALL_FOLDER}\share\groonga\html"
           Move-Item admin admin.old
@@ -796,6 +802,7 @@ jobs:
 
       # Artifact
       - name: Compress the artifact without VC++ runtime
+        if: matrix.allow_warning != 'ON'
         run: |
           pushd "${Env:FULL_INSTALL_FOLDER}\.."
           Compress-Archive `
@@ -806,6 +813,7 @@ jobs:
             "${Env:FULL_INSTALL_FOLDER}.zip" `
             "${Env:INSTALL_FOLDER}.zip"
       - uses: actions/upload-artifact@v4
+        if: matrix.allow_warning != 'ON'
         with:
           name: release-${{ env.INSTALL_FOLDER }}
           path: ${{ env.INSTALL_FOLDER }}.zip
@@ -858,6 +866,7 @@ jobs:
             "${Env:GITHUB_WORKSPACE}\packages\windows\vcruntime\ucrt-readme.txt" `
             ${GROONGA_VC_REDIST_LICENSE_DIR}
       - name: Compress the artifact with VC++ runtime
+        if: matrix.allow_warning != 'ON'
         run: |
           pushd "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}\.."
           Compress-Archive `
@@ -868,6 +877,7 @@ jobs:
             "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}.zip" `
             "${Env:INSTALL_FOLDER_WITH_VCRUNTIME}.zip"
       - uses: actions/upload-artifact@v4
+        if: matrix.allow_warning != 'ON'
         with:
           name: release-${{ env.INSTALL_FOLDER_WITH_VCRUNTIME }}
           path: ${{ env.INSTALL_FOLDER_WITH_VCRUNTIME }}.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,13 +381,13 @@ elseif(MSVC)
   # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4146
   string(APPEND GRN_C_COMPILE_FLAGS " /w24146")
   string(APPEND GRN_CXX_COMPILE_FLAGS " /w24146")
+  # 'argument' : conversion from 'type1' to 'type2', possible loss of data
+  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
+  string(APPEND GRN_C_COMPILE_FLAGS " /w14244")
+  string(APPEND GRN_CXX_COMPILE_FLAGS " /w14244")
 
   # Disable warnings
 
-  # 'argument' : conversion from 'type1' to 'type2', possible loss of data
-  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
-  string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4244")
   # 'operator': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
   # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4334")
@@ -419,6 +419,14 @@ if(NOT GRN_ALLOW_WARNING)
     set(GRN_C_COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS} -Werror")
     set(GRN_CXX_COMPILE_FLAGS "${GRN_CXX_COMPILE_FLAGS} -Werror")
   elseif(MSVC)
+    # Disable warnings
+    # Temporary code.
+    # We would like to fix all C4244 warnings and will remove them when we are done.
+    # 'argument' : conversion from 'type1' to 'type2', possible loss of data
+    # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
+    string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")
+    string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4244")
+
     set(GRN_C_COMPILE_FLAGS "${GRN_C_COMPILE_FLAGS} /WX")
     set(GRN_CXX_COMPILE_FLAGS "${GRN_CXX_COMPILE_FLAGS} /WX")
   endif()


### PR DESCRIPTION
We plan to check and fix the code that causes C4244 warning.
Therefore, we will enable C4244 so that it can be checked.

The build succeeds, but with more warning output.