### PR TITLE
bulk: Cast the return value of get()

### DIFF
--- a/include/groonga/bulk.hpp
+++ b/include/groonga/bulk.hpp
@@ -83,7 +83,7 @@ namespace grn {
     {
       switch (bulk->header.domain) {
       case GRN_DB_BOOL:
-        return GRN_BOOL_VALUE(bulk);
+        return static_cast<TYPE>(GRN_BOOL_VALUE(bulk));
       case GRN_DB_INT8:
         return static_cast<TYPE>(GRN_INT8_VALUE(bulk));
       case GRN_DB_UINT8:

--- a/include/groonga/bulk.hpp
+++ b/include/groonga/bulk.hpp
@@ -85,17 +85,17 @@ namespace grn {
       case GRN_DB_BOOL:
         return GRN_BOOL_VALUE(bulk);
       case GRN_DB_INT8:
-        return GRN_INT8_VALUE(bulk);
+        return static_cast<TYPE>(GRN_INT8_VALUE(bulk));
       case GRN_DB_UINT8:
-        return GRN_UINT8_VALUE(bulk);
+        return static_cast<TYPE>(GRN_UINT8_VALUE(bulk));
       case GRN_DB_INT16:
-        return GRN_INT16_VALUE(bulk);
+        return static_cast<TYPE>(GRN_INT16_VALUE(bulk));
       case GRN_DB_UINT16:
-        return GRN_UINT16_VALUE(bulk);
+        return static_cast<TYPE>(GRN_UINT16_VALUE(bulk));
       case GRN_DB_INT32:
-        return GRN_INT32_VALUE(bulk);
+        return static_cast<TYPE>(GRN_INT32_VALUE(bulk));
       case GRN_DB_UINT32:
-        return GRN_UINT32_VALUE(bulk);
+        return static_cast<TYPE>(GRN_UINT32_VALUE(bulk));
       case GRN_DB_INT64:
         return static_cast<TYPE>(GRN_INT64_VALUE(bulk));
       case GRN_DB_UINT64:


### PR DESCRIPTION
Since `GRN_DB_INT64` and larger already casts the return value, cast it for other types.