### PR TITLE
grn_error: Cast when assigning to ctx::errlvl

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -187,7 +187,7 @@ typedef enum {
 #define GRN_COMMAND_VERSION_STABLE GRN_COMMAND_VERSION_1
 #define GRN_COMMAND_VERSION_MAX    GRN_COMMAND_VERSION_3
 
-typedef enum {
+typedef enum /* : unsigned char */ {
   GRN_LOG_NONE = 0,
   GRN_LOG_EMERG,
   GRN_LOG_ALERT,

--- a/lib/grn_error.h
+++ b/lib/grn_error.h
@@ -84,7 +84,7 @@ grn_error_setv(grn_ctx *ctx,
                const char *format,
                va_list args)
 {
-  ctx->errlvl = level;
+  ctx->errlvl = (unsigned char)level;
   if (ctx->rc != GRN_CANCEL) {
     ctx->rc = rc;
   }


### PR DESCRIPTION
This is part of the work of GitHub GH-1641.

`level` is `grn_log_level`, but `ctx::errlvl` is `unsigned char`, so cast it.

https://github.com/groonga/groonga/blob/57809bdcf99041ad4e7fcca87df2642240f81d05/include/groonga/groonga.h#L354