### PR TITLE
ii ordered-near-phrase-product: fix interval caclulation

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -13153,12 +13153,14 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
       n = n_max_element_intervals + 1;
     }
     int32_t previous_pos = data->phrase_groups[0].btree->min->pos;
+    int32_t previous_n_tokens_in_phrase =
+      data->phrase_groups[0].btree->min->n_tokens_in_phrase;
     for (i = 1; i < n; i++) {
       token_info *min = data->phrase_groups[i].btree->min;
       int32_t pos = min->pos;
       int32_t max_element_interval =
         GRN_INT32_VALUE_AT(data->max_element_intervals, i - 1);
-      int32_t interval = pos - previous_pos - min->n_tokens_in_phrase;
+      int32_t interval = pos - previous_pos - previous_n_tokens_in_phrase;
       if (max_element_interval >= 0 && interval > max_element_interval) {
         return false;
       }
@@ -13166,6 +13168,7 @@ grn_ii_select_data_check_near_element_intervals(grn_ctx *ctx,
         return false;
       }
       previous_pos = pos;
+      previous_n_tokens_in_phrase = min->n_tokens_in_phrase;
     }
     return true;
   } else {

--- a/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.expected
@@ -8,10 +8,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 [[0,0.0,0.0],1]
-select Entries   --filter 'content *ONPP-1,0,10,9"(abc bcd) (def)"'   --output_columns '_score, content'
+select Entries   --filter 'content *ONPP-1,0,10,9"(abc bcd) (de)"'   --output_columns '_score, content'
 [
   [
     0,
@@ -35,7 +35,7 @@ select Entries   --filter 'content *ONPP-1,0,10,9"(abc bcd) (def)"'   --output_c
       ],
       [
         1,
-        "abc123456789def"
+        "abc1234567890def"
       ]
     ]
   ]

--- a/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.test
+++ b/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.test
@@ -9,9 +9,9 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc1234567890def"}
 ]
 
 select Entries \
-  --filter 'content *ONPP-1,0,10,9"(abc bcd) (def)"' \
+  --filter 'content *ONPP-1,0,10,9"(abc bcd) (de)"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,8 +8,8 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc12345678901defg"}
 ]
 [[0,0.0,0.0],1]
-select Entries   --filter 'content *ONPP-1,0,10,9"(abc bcd) (ef)"'   --output_columns '_score, content'
+select Entries   --filter 'content *ONPP-1,0,10,9"(abc bcd) (defg)"'   --output_columns '_score, content'
 [[0,0.0,0.0],[[[0],[["_score","Int32"],["content","Text"]]]]]

--- a/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/filter/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,9 +9,9 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc12345678901defg"}
 ]
 
 select Entries \
-  --filter 'content *ONPP-1,0,10,9"(abc bcd) (ef)"' \
+  --filter 'content *ONPP-1,0,10,9"(abc bcd) (defg)"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.expected
+++ b/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.expected
@@ -8,10 +8,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc123456789defg"}
 ]
 [[0,0.0,0.0],1]
-select Entries   --match_columns content   --query '*ONPP-1,0,12,9"(abc bcd) (def)"'   --output_columns '_score, content'
+select Entries   --match_columns content   --query '*ONPP-1,0,12,9"(abc bcd) (defg)"'   --output_columns '_score, content'
 [
   [
     0,
@@ -35,7 +35,7 @@ select Entries   --match_columns content   --query '*ONPP-1,0,12,9"(abc bcd) (de
       ],
       [
         1,
-        "abc123456789def"
+        "abc123456789defg"
       ]
     ]
   ]

--- a/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.test
+++ b/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/match.test
@@ -9,10 +9,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc123456789defg"}
 ]
 
 select Entries \
   --match_columns content \
-  --query '*ONPP-1,0,12,9"(abc bcd) (def)"' \
+  --query '*ONPP-1,0,12,9"(abc bcd) (defg)"' \
   --output_columns '_score, content'

--- a/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
+++ b/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.expected
@@ -8,8 +8,8 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 [[0,0.0,0.0],true]
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc12345678901defg"}
 ]
 [[0,0.0,0.0],1]
-select Entries   --match_columns content   --query '*ONPP-1,0,10,9"(abc bcd) (ef)"'   --output_columns '_score, content'
+select Entries   --match_columns content   --query '*ONPP-1,0,10,9"(abc bcd) (defg)"'   --output_columns '_score, content'
 [[0,0.0,0.0],[[[0],[["_score","Int32"],["content","Text"]]]]]

--- a/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
+++ b/test/command/suite/select/query/ordered_near_phrase_product/min_interval/with_max_element_intervals/not_match_more_max.test
@@ -9,10 +9,10 @@ column_create Terms entries_content COLUMN_INDEX|WITH_POSITION Entries content
 
 load --table Entries
 [
-{"content": "abc123456789def"}
+{"content": "abc12345678901defg"}
 ]
 
 select Entries \
   --match_columns content \
-  --query '*ONPP-1,0,10,9"(abc bcd) (ef)"' \
+  --query '*ONPP-1,0,10,9"(abc bcd) (defg)"' \
   --output_columns '_score, content'


### PR DESCRIPTION
This problem is similar problem to GH-2407.

Currently, we can not calculate correctly interval between phrase in `*ONPP` operator too.

We should use the number of tokens in phrase of previous phrase in `*ONPP` operator too.
However, `*ONPP` operator use the number of tokens in phrase of current phrase in caculating interval between phrases.

So, we modify that use it of previous phrase in this commit.