### PR TITLE
pat: use pat_node_common instead of pat_node in grn_pat_wal_recover_add_entry

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2475,7 +2475,6 @@ _grn_pat_enable_node(grn_ctx *ctx,
     pat_node_set_right(pat, node, *id_location);
     pat_node_set_left(pat, node, id);
   }
-  // smp_wmb();
   *id_location = id;
 }
 


### PR DESCRIPTION
This PR push after merging GH-2349.
