### PR TITLE
cmake: suppress `-Wdeclaration-after-statement` warning for H3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1579,6 +1579,10 @@ if(NOT "${GRN_WITH_H3}" STREQUAL "no")
         # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4307
         string(APPEND CMAKE_C_FLAGS " /wd4307")
         string(APPEND CMAKE_CXX_FLAGS " /wd4307")
+      elseif(GRN_C_COMPILER_GNU_LIKE)
+        string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-declaration-after-statement")
+        string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
+               " -Wno-declaration-after-statement")
       endif()
       set(BUILD_BENCHMARKS OFF)
       set(BUILD_FILTERS OFF)


### PR DESCRIPTION
## Issue

We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/_deps/h3-src/src/h3lib/lib/coordijk.c: In function 'ijkDistance':
/home/buildbot/_deps/h3-src/src/h3lib/lib/coordijk.c:649:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
  649 |     CoordIJK absDiff = {abs(diff.i), abs(diff.j), abs(diff.k)};
      |     ^~~~~~~~
cc1: all warnings being treated as errors
```

## Cause

Building Groonga with MariaDB fails due to
`-Werror=declaration-after-statement` when using the bundled H3. This is because H3 uses C99-style mixed declarations, which are incompatible with ISO C90.

## Solution

Since upstream H3 is implemented in C99 and unlikely to change this style, we suppress the warning by
explicitly passing `-Wno-declaration-after-statement` in Debug and RelWithDebInfo builds.

- https://github.com/uber/h3/blob/master/CMakeLists.txt#L362