### PR TITLE
pat: use pat_node_common instead of pat_node in related wal recover 

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2564,7 +2564,7 @@ grn_pat_reuse_node(grn_ctx *ctx,
                    grn_id *id_location,
                    const char *tag)
 {
-  uint8_t key_buffer = _pat_node_get_key(ctx, pat, node);
+  uint8_t *key_buffer = _pat_node_get_key(ctx, pat, node);
   if (!key_buffer) {
     grn_obj_set_error(ctx,
                       (grn_obj *)pat,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2277,10 +2277,10 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
                         "failed to get node");
       return false;
     }
-    if (check_node < pat_node_get_check(pat, node) &&
-        pat_node_get_check(pat, node) < check_max) {
+    uint16_t check_node_current = pat_node_get_check(pat, node);
+    if (check_node < check_node_current && check_node_current < check_max) {
       check_node_previous = check_node;
-      check_node = pat_node_get_check(pat, node);
+      check_node = check_node_current;
       id_location_previous = id_location;
       id_location =
         _grn_pat_next_location(ctx, pat, node, key, check_node, check_max);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1898,11 +1898,13 @@ _grn_pat_create(grn_ctx *ctx,
     array_spec[SEGMENT_KEY].w_of_element = 0;
     if (flags & GRN_OBJ_KEY_LARGE) {
       array_spec[SEGMENT_KEY].max_n_segments = GRN_PAT_MAX_N_SEGMENTS_LARGE;
+      array_spec[SEGMENT_PAT].w_of_element = 5;
+      array_spec[SEGMENT_PAT].max_n_segments = 1 << (30 - (22 - 5));
     } else {
       array_spec[SEGMENT_KEY].max_n_segments = GRN_PAT_MAX_N_SEGMENTS;
+      array_spec[SEGMENT_PAT].w_of_element = 4;
+      array_spec[SEGMENT_PAT].max_n_segments = 1 << (30 - (22 - 4));
     }
-    array_spec[SEGMENT_PAT].w_of_element = 4;
-    array_spec[SEGMENT_PAT].max_n_segments = 1 << (30 - (22 - 4));
     array_spec[SEGMENT_SIS].w_of_element = w_of_element;
     array_spec[SEGMENT_SIS].max_n_segments = 1 << (30 - (22 - w_of_element));
     io = grn_io_create_with_array(ctx,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2498,7 +2498,7 @@ _grn_pat_enable_node(grn_ctx *ctx,
 static inline void
 grn_pat_reuse_shared_node(grn_ctx *ctx,
                           grn_pat *pat,
-                          pat_node *node,
+                          pat_node_common *node,
                           grn_id id,
                           const uint8_t *key,
                           uint32_t key_size,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1196,25 +1196,6 @@ grn_pat_wal_add_entry(grn_ctx *ctx, grn_pat_wal_add_entry_data *data)
 static inline void
 grn_pat_wal_add_entry_data_set_record_direction(
   grn_ctx *ctx,
-  grn_pat_wal_add_entry_data *data,
-  grn_id parent_record_id,
-  pat_node *parent_node,
-  grn_id *id_location)
-{
-  data->grandparent_record_id = data->parent_record_id;
-  data->parent_record_direction = data->record_direction;
-  data->parent_record_id = parent_record_id;
-  if (id_location == &(parent_node->lr[DIRECTION_LEFT])) {
-    data->record_direction = DIRECTION_LEFT;
-  } else {
-    data->record_direction = DIRECTION_RIGHT;
-  }
-  data->previous_record_id = *id_location;
-}
-
-static inline void
-_grn_pat_wal_add_entry_data_set_record_direction(
-  grn_ctx *ctx,
   grn_pat *pat,
   grn_pat_wal_add_entry_data *data,
   grn_id parent_record_id,
@@ -2264,12 +2245,12 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
   grn_id *id_location_previous = NULL;
   grn_id *id_location = pat_node_get_right_address(pat, node);
   data->wal_data.record_direction = DIRECTION_RIGHT;
-  _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                   pat,
-                                                   &(data->wal_data),
-                                                   id,
-                                                   node,
-                                                   id_location);
+  grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                  pat,
+                                                  &(data->wal_data),
+                                                  id,
+                                                  node,
+                                                  id_location);
   if (*id_location == GRN_ID_NIL) {
     data->last_id_location = id_location;
     data->wal_data.check = PAT_CHECK_PACK(key_size - 1, 7, false);
@@ -2317,12 +2298,12 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
       id_location_previous = id_location;
       id_location =
         _grn_pat_next_location(ctx, pat, node, key, check_node, check_max);
-      _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                       pat,
-                                                       &(data->wal_data),
-                                                       id,
-                                                       node,
-                                                       id_location);
+      grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                      pat,
+                                                      &(data->wal_data),
+                                                      id,
+                                                      node,
+                                                      id_location);
     } else {
       found_key = _pat_node_get_key(ctx, pat, node);
       if (!found_key) {
@@ -2389,12 +2370,12 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
         PAT_AT(pat, id, node);
         id_location = pat_node_get_right_address(pat, node);
         data->wal_data.parent_record_direction = DIRECTION_RIGHT;
-        _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                         pat,
-                                                         &(data->wal_data),
-                                                         id,
-                                                         node,
-                                                         id_location);
+        grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                        pat,
+                                                        &(data->wal_data),
+                                                        id,
+                                                        node,
+                                                        id_location);
         while ((id = *id_location) != GRN_ID_NIL) {
           PAT_AT(pat, id, node);
           if (!node) {
@@ -2412,12 +2393,12 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
           }
           id_location =
             _grn_pat_next_location(ctx, pat, node, key, check_node, check_max);
-          _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                           pat,
-                                                           &(data->wal_data),
-                                                           id,
-                                                           node,
-                                                           id_location);
+          grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                          pat,
+                                                          &(data->wal_data),
+                                                          id,
+                                                          node,
+                                                          id_location);
         }
       }
     }
@@ -4041,12 +4022,12 @@ _grn_pat_del(grn_ctx *ctx,
   PAT_AT(pat, id, node);
   proot = p = pat_node_get_right_address(pat, node);
   wal_data.record_direction = DIRECTION_RIGHT;
-  _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                   pat,
-                                                   &wal_data,
-                                                   id,
-                                                   node,
-                                                   p);
+  grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                  pat,
+                                                  &wal_data,
+                                                  id,
+                                                  node,
+                                                  p);
   for (;;) {
     grn_id next_id = *p;
     if (next_id == GRN_ID_NIL) {
@@ -4079,12 +4060,12 @@ _grn_pat_del(grn_ctx *ctx,
     p0 = p;
     node_check = check;
     p = _grn_pat_next_location(ctx, pat, node, key, node_check, check_max);
-    _grn_pat_wal_add_entry_data_set_record_direction(ctx,
-                                                     pat,
-                                                     &wal_data,
-                                                     id,
-                                                     node,
-                                                     p);
+    grn_pat_wal_add_entry_data_set_record_direction(ctx,
+                                                    pat,
+                                                    &wal_data,
+                                                    id,
+                                                    node,
+                                                    p);
     node_previous = node;
   }
   if (optarg && optarg->func &&

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2507,11 +2507,11 @@ grn_pat_reuse_shared_node(grn_ctx *ctx,
                           uint16_t check_max,
                           grn_id *id_location)
 {
-  pat->header->garbages[0] = node->lr[0];
+  pat->header->garbages[0] = pat_node_get_left(pat, node);
   pat->header->n_garbages--;
   pat->header->n_entries++;
-  pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
-  grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
+  _pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
+  _grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
 }
 
 static inline void

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2500,7 +2500,7 @@ grn_pat_reuse_shared_node(grn_ctx *ctx,
 static inline void
 grn_pat_add_shared_node(grn_ctx *ctx,
                         grn_pat *pat,
-                        pat_node *node,
+                        pat_node_common *node,
                         grn_id id,
                         const uint8_t *key,
                         uint32_t key_size,
@@ -2508,24 +2508,6 @@ grn_pat_add_shared_node(grn_ctx *ctx,
                         uint16_t check,
                         uint16_t check_max,
                         grn_id *id_location)
-{
-  pat->header->curr_rec = id;
-  pat->header->n_entries++;
-  pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
-  grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
-}
-
-static inline void
-_grn_pat_add_shared_node(grn_ctx *ctx,
-                         grn_pat *pat,
-                         pat_node_common *node,
-                         grn_id id,
-                         const uint8_t *key,
-                         uint32_t key_size,
-                         uint32_t shared_key_offset,
-                         uint16_t check,
-                         uint16_t check_max,
-                         grn_id *id_location)
 {
   pat->header->curr_rec = id;
   pat->header->n_entries++;
@@ -2724,16 +2706,16 @@ grn_pat_add_internal(grn_ctx *ctx, grn_pat_add_data *data)
                             data->shared_key_offset);
           return GRN_ID_NIL;
         }
-        _grn_pat_add_shared_node(ctx,
-                                 pat,
-                                 node,
-                                 data->wal_data.record_id,
-                                 data->wal_data.key,
-                                 data->wal_data.key_size,
-                                 data->wal_data.shared_key_offset,
-                                 data->wal_data.check,
-                                 data->check_max,
-                                 data->last_id_location);
+        grn_pat_add_shared_node(ctx,
+                                pat,
+                                node,
+                                data->wal_data.record_id,
+                                data->wal_data.key,
+                                data->wal_data.key_size,
+                                data->wal_data.shared_key_offset,
+                                data->wal_data.check,
+                                data->check_max,
+                                data->last_id_location);
         pat->header->wal_id = data->wal_data.wal_id;
       }
     } else {
@@ -6726,16 +6708,16 @@ grn_pat_wal_recover_add_shared_entry(grn_ctx *ctx,
   *id_location = entry->previous_record_id;
   uint16_t check_max =
     (uint16_t)PAT_CHECK_PACK(entry->key.content.binary.size, 0, false);
-  _grn_pat_add_shared_node(ctx,
-                           pat,
-                           node,
-                           entry->record_id,
-                           entry->key.content.binary.data,
-                           entry->key.content.binary.size,
-                           (uint32_t)(entry->shared_key_offset),
-                           entry->check,
-                           check_max,
-                           id_location);
+  grn_pat_add_shared_node(ctx,
+                          pat,
+                          node,
+                          entry->record_id,
+                          entry->key.content.binary.data,
+                          entry->key.content.binary.size,
+                          (uint32_t)(entry->shared_key_offset),
+                          entry->check,
+                          check_max,
+                          id_location);
 }
 
 static void

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2303,7 +2303,7 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
                           "node->check:%u "
                           "check_max:%u",
                           check_node,
-                          pat_node_get_check(pat, node),
+                          check_node_current,
                           check_max);
         return false;
       }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1492,21 +1492,9 @@ _pat_node_set_key(grn_ctx *ctx,
 static inline void
 pat_node_set_shared_key(grn_ctx *ctx,
                         grn_pat *pat,
-                        pat_node *node,
+                        pat_node_common *node,
                         uint32_t key_size,
                         uint32_t shared_key_offset)
-{
-  PAT_IMD_OFF(node);
-  PAT_LEN_SET(node, key_size);
-  node->key = shared_key_offset;
-}
-
-static inline void
-_pat_node_set_shared_key(grn_ctx *ctx,
-                         grn_pat *pat,
-                         pat_node_common *node,
-                         uint32_t key_size,
-                         uint32_t shared_key_offset)
 {
   pat_node_set_key_immediate_off(pat, node);
   pat_node_set_key_length(pat, node, key_size);
@@ -2493,7 +2481,7 @@ grn_pat_reuse_shared_node(grn_ctx *ctx,
   pat->header->garbages[0] = pat_node_get_left(pat, node);
   pat->header->n_garbages--;
   pat->header->n_entries++;
-  _pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
+  pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
   _grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
 }
 
@@ -2511,7 +2499,7 @@ grn_pat_add_shared_node(grn_ctx *ctx,
 {
   pat->header->curr_rec = id;
   pat->header->n_entries++;
-  _pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
+  pat_node_set_shared_key(ctx, pat, node, key_size, shared_key_offset);
   _grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
 }
 

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -6792,16 +6792,16 @@ grn_pat_wal_recover_reuse_entry(grn_ctx *ctx,
   *id_location = entry->previous_record_id;
   uint16_t check_max =
     (uint16_t)PAT_CHECK_PACK(entry->key.content.binary.size, 0, false);
-  _grn_pat_reuse_node(ctx,
-                      pat,
-                      node,
-                      entry->record_id,
-                      entry->key.content.binary.data,
-                      entry->key.content.binary.size,
-                      entry->check,
-                      check_max,
-                      id_location,
-                      tag);
+  grn_pat_reuse_node(ctx,
+                     pat,
+                     node,
+                     entry->record_id,
+                     entry->key.content.binary.data,
+                     entry->key.content.binary.size,
+                     entry->check,
+                     check_max,
+                     id_location,
+                     tag);
 }
 
 static void

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2564,8 +2564,7 @@ grn_pat_reuse_node(grn_ctx *ctx,
                    grn_id *id_location,
                    const char *tag)
 {
-  uint8_t *key_buffer;
-  key_buffer = _pat_node_get_key(ctx, pat, node);
+  uint8_t key_buffer = _pat_node_get_key(ctx, pat, node);
   if (!key_buffer) {
     grn_obj_set_error(ctx,
                       (grn_obj *)pat,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2548,7 +2548,7 @@ _grn_pat_add_shared_node(grn_ctx *ctx,
 static inline grn_rc
 grn_pat_reuse_node(grn_ctx *ctx,
                    grn_pat *pat,
-                   pat_node *node,
+                   pat_node_common *node,
                    grn_id id,
                    const uint8_t *key,
                    uint32_t key_size,
@@ -2556,41 +2556,6 @@ grn_pat_reuse_node(grn_ctx *ctx,
                    uint16_t check_max,
                    grn_id *id_location,
                    const char *tag)
-{
-  uint8_t *key_buffer;
-  key_buffer = pat_node_get_key(ctx, pat, node);
-  if (!key_buffer) {
-    grn_obj_set_error(ctx,
-                      (grn_obj *)pat,
-                      GRN_FILE_CORRUPT,
-                      id,
-                      tag,
-                      "failed to get key from node: "
-                      "size:%u",
-                      key_size);
-    return ctx->rc;
-  }
-  uint32_t key_storage_size = pat_key_storage_size(key_size);
-  pat->header->garbages[key_storage_size] = node->lr[0];
-  PAT_LEN_SET(node, key_size);
-  grn_memcpy(key_buffer, key, key_size);
-  pat->header->n_garbages--;
-  pat->header->n_entries++;
-  grn_pat_enable_node(ctx, pat, node, id, key, check, check_max, id_location);
-  return GRN_SUCCESS;
-}
-
-static inline grn_rc
-_grn_pat_reuse_node(grn_ctx *ctx,
-                    grn_pat *pat,
-                    pat_node_common *node,
-                    grn_id id,
-                    const uint8_t *key,
-                    uint32_t key_size,
-                    uint16_t check,
-                    uint16_t check_max,
-                    grn_id *id_location,
-                    const char *tag)
 {
   uint8_t *key_buffer;
   key_buffer = _pat_node_get_key(ctx, pat, node);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -2248,7 +2248,6 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
   const uint8_t *found_key = NULL;
   uint32_t found_key_size = 0;
   grn_id id_previous = GRN_ID_NIL;
-  pat_node_common *node_previous = NULL;
   int check_node = -1;
   int check_node_previous = -1;
   for (;;) {
@@ -2268,7 +2267,6 @@ grn_pat_add_internal_find(grn_ctx *ctx, grn_pat_add_data *data)
       found_key_size = pat_node_get_key_length(pat, node);
       break;
     }
-    node_previous = node;
     PAT_AT(pat, id, node);
     if (!node) {
       grn_obj_set_error(ctx,

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -6810,7 +6810,7 @@ grn_pat_wal_recover_reuse_shared_entry(grn_ctx *ctx,
                                        grn_wal_reader_entry *entry,
                                        const char *wal_error_tag)
 {
-  pat_node *node = pat_get(ctx, pat, entry->record_id);
+  pat_node_common *node = _pat_node_get(ctx, pat, entry->record_id);
   if (!node) {
     grn_wal_set_recover_error(ctx,
                               GRN_NO_MEMORY_AVAILABLE,
@@ -6820,8 +6820,9 @@ grn_pat_wal_recover_reuse_shared_entry(grn_ctx *ctx,
                               "failed to refer node");
     return;
   }
-  node->lr[0] = entry->next_garbage_record_id;
-  pat_node *parent_node = pat_get(ctx, pat, entry->parent_record_id);
+  pat_node_set_left(pat, node, entry->next_garbage_record_id);
+  pat_node_common *parent_node =
+    _pat_node_get(ctx, pat, entry->parent_record_id);
   if (!parent_node) {
     grn_wal_set_recover_error(ctx,
                               GRN_NO_MEMORY_AVAILABLE,
@@ -6831,7 +6832,8 @@ grn_pat_wal_recover_reuse_shared_entry(grn_ctx *ctx,
                               "failed to refer parent node");
     return;
   }
-  grn_id *id_location = &(parent_node->lr[entry->record_direction]);
+  grn_id *id_location =
+    pat_node_get_child_address(pat, parent_node, entry->record_direction);
   *id_location = entry->previous_record_id;
   uint16_t check_max =
     (uint16_t)PAT_CHECK_PACK(entry->key.content.binary.size, 0, false);


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.