### PR TITLE
ci cmake: use Apache Arrow main branch to detect incompatible changes early

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -127,8 +127,7 @@ jobs:
           cmake \
             -B apache-arrow/cpp.build \
             -S apache-arrow/cpp \
-            -GNinja \
-            --preset ninja-release \
+            --preset ninja-debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
         if: env.APACHE_ARROW == 'main'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -140,8 +140,8 @@ jobs:
           cmake --install apache-arrow/cpp.build
       - name: Set environment variables
         run: |
-          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
+          echo "LD_LIBRARY_PATH=${PWD}/install/lib" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig" >> ${GITHUB_ENV}
       - name: Enable Apache Arrow repository
         if: env.APACHE_ARROW != 'main'
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -130,7 +130,7 @@ jobs:
           restore-keys: |
             cmake-ubuntu-apache-arrow-${{ matrix.cc }}-ccache-
             cmake-ubuntu-apache-arrow-ccache-
-      - name: Install dependecies for Apache Arrow
+      - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
@@ -199,7 +199,7 @@ jobs:
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
             libarrow-compute-dev \
             libarrow-dev \
-      - name: Install packages
+      - name: Install packages for Groonga
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -187,7 +187,7 @@ jobs:
           #   -i"" \
           #   -e "s,^URIs: \\(.*\\)/,URIs: \\1-rc/,g" \
           #   /etc/apt/sources.list.d/apache-arrow.sources
-      - name : Install Apache Arrow packages
+      - name: Install Apache Arrow packages
         if: env.APACHE_ARROW != 'main'
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -112,7 +112,7 @@ jobs:
           path: ccache
           key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
           restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
-      - name: Install packages
+      - name: Install common build dependencies
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
@@ -170,7 +170,7 @@ jobs:
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
             libarrow-compute-dev \
             libarrow-dev \
-      - name: Install packages for Groonga
+      - name: Install Groonga build dependencies
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
@@ -211,7 +211,7 @@ jobs:
       - name: Install
         run: |
           ninja -C ../groonga.build install
-      - name: Set environment variables for Groonga
+      - name: Set test environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -125,25 +125,22 @@ jobs:
       - name: Configure Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
-          cd apache-arrow
           ccache --show-stats --verbose --version || :
           cmake \
-            -B cpp.build \
-            -S cpp \
+            -B apache-arrow/cpp.build \
+            -S apache-arrow/cpp \
             -GNinja \
             --preset ninja-release \
-            -DCMAKE_INSTALL_PREFIX=../install
+            -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
-          cd apache-arrow
-          cmake --build cpp.build
+          cmake --build apache-arrow/cpp.build
           ccache --show-stats --verbose || true
       - name: Install Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
-          cd apache-arrow
-          cmake --install cpp.build
+          cmake --install apache-arrow/cpp.build
       - name: Set environment variables
         run: |
           echo "LD_LIBRARY_PATH=${PWD}/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -113,7 +113,8 @@ jobs:
             build-essential \
             ninja-build \
             ccache \
-            cmake
+            cmake \
+            libxsimd-dev
       - uses: actions/checkout@v4
         if: matrix.apache-arrow-main == 'yes'
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,15 +77,22 @@ jobs:
             cxx: g++
           - cc: gcc
             cxx: g++
+            apache-arrow: "main"
+          - cc: gcc
+            cxx: g++
             mruby: "OFF"
           - cc: clang
             cxx: clang++
+          - cc: clang
+            cxx: clang++
+            apache-arrow: "main"
           - cc: clang
             cxx: clang++
             ubsan: "ON"
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
+      APACHE_ARROW: ${{ matrix.apache-arrow }}
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
       GRN_WITH_MRUBY: ${{ matrix.mruby }}
@@ -110,10 +117,12 @@ jobs:
             cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-
             cmake-ubuntu-groonga-ccache-
       - name: Configure ccache for Apache Arrow
+        if: env.APACHE_ARROW == 'main'
         run: |
           echo "CCACHE_DIR_ARROW=${PWD}/ccache-arrow" >> ${GITHUB_ENV}
           echo "CMAKE_CXX_COMPILER_LAUNCHER_ARROW=ccache" >> ${GITHUB_ENV}
       - name: Cache Apache Arrow ccache
+        if: env.APACHE_ARROW == 'main'
         uses: actions/cache@v4
         with:
           path: ccache-arrow
@@ -130,6 +139,7 @@ jobs:
             ccache \
             cmake
       - name: Configure Apache Arrow
+        if: env.APACHE_ARROW == 'main'
         env:
           CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
         run: |
@@ -143,6 +153,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$PWD/install \
             -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER_ARROW}
       - name: Build Apache Arrow
+        if: env.APACHE_ARROW == 'main'
         env:
           CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
         run: |
@@ -150,14 +161,44 @@ jobs:
           cmake --build cpp.build
           ccache --show-stats --verbose || true
       - name: Install Apache Arrow
+        if: env.APACHE_ARROW == 'main'
         run: |
           cd apache-arrow
           cmake --install cpp.build
       - name: Set environment variables for Apache Arrow
+        if: env.APACHE_ARROW == 'main'
         run: |
           echo "LD_LIBRARY_PATH=${PWD}/apache-arrow/install/lib:${{ env.LD_LIBRARY_PATH }}" >> ${GITHUB_ENV}
           echo "PKG_CONFIG_PATH=${PWD}/apache-arrow/install/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> ${GITHUB_ENV}
           echo "${PWD}/apache-arrow/install/bin" >> ${GITHUB_PATH}
+      - name: Enable Apache Arrow repository
+        if: env.APACHE_ARROW != 'main'
+        run: |
+          sudo apt update -o="APT::Acquire::Retries=3"
+          sudo apt install -y -V -o="APT::Acquire::Retries=3" \
+            lsb-release \
+            wget
+          # Use released version for now. Apache Arrow (RC) APT
+          # repository has some problems for now:
+          # https://github.com/apache/arrow/issues/46083
+          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          # Always use RC version to detect Apache Arrow related
+          # problems as fast as possible. Released Apache Arrow is
+          # tested in package related jobs.
+          # wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')-rc/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          # sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
+          # sudo sed \
+          #   -i"" \
+          #   -e "s,^URIs: \\(.*\\)/,URIs: \\1-rc/,g" \
+          #   /etc/apt/sources.list.d/apache-arrow.sources
+      - name : Install Apache Arrow packages
+        if: env.APACHE_ARROW != 'main'
+        run: |
+          sudo apt update -o="APT::Acquire::Retries=3"
+          sudo apt install -y -V -o="APT::Acquire::Retries=3" \
+            libarrow-compute-dev \
+            libarrow-dev \
       - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -99,29 +99,22 @@ jobs:
         with:
           submodules: recursive
       - uses: actions/checkout@v4
+        if: env.APACHE_ARROW == 'main'
         with:
           path: apache-arrow
           repository: apache/arrow
       - name: Prepare ccache
         run: |
           echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
-      - name: Cache Groonga ccache
+      - name: Cache ccache
         uses: actions/cache@v4
         with:
           path: ccache
-          key: cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**') }}
+          key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
           restore-keys: |
-            cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-
-            cmake-ubuntu-groonga-ccache-
-      - name: Cache Apache Arrow ccache
-        if: env.APACHE_ARROW == 'main'
-        uses: actions/cache@v4
-        with:
-          path: ccache-arrow
-          key: cmake-ubuntu-apache-arrow-${{ matrix.cc }}-ccache-${{ hashFiles('apache-arrow/cpp/src/**') }}
-          restore-keys: |
-            cmake-ubuntu-apache-arrow-${{ matrix.cc }}-ccache-
-            cmake-ubuntu-apache-arrow-ccache-
+            cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
+            cmake-ubuntu-${{ matrix.cc }}-ccache-
+            cmake-ubuntu-ccache-
       - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,7 +77,7 @@ jobs:
             cxx: g++
           - cc: gcc
             cxx: g++
-            apache-arrow: "main"
+            apache-arrow-main: yes
           - cc: gcc
             cxx: g++
             mruby: "OFF"
@@ -106,7 +106,7 @@ jobs:
             ccache \
             cmake
       - uses: actions/checkout@v4
-        if: matrix.apache-arrow == 'main'
+        if: matrix.apache-arrow-main == 'yes'
         with:
           path: apache-arrow
           repository: apache/arrow
@@ -117,10 +117,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ccache
-          key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
-          restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
+          key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
+          restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-
       - name: Configure Apache Arrow
-        if: matrix.apache-arrow == 'main'
+        if: matrix.apache-arrow-main == 'yes'
         run: |
           ccache --show-stats --verbose --version
           cmake \
@@ -129,12 +129,12 @@ jobs:
             --preset ninja-debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
-        if: matrix.apache-arrow == 'main'
+        if: matrix.apache-arrow-main == 'yes'
         run: |
           cmake --build apache-arrow/cpp.build
           ccache --show-stats --verbose
       - name: Install Apache Arrow
-        if: matrix.apache-arrow == 'main'
+        if: matrix.apache-arrow-main == 'yes'
         run: |
           cmake --install apache-arrow/cpp.build
       - name: Set environment variables
@@ -142,7 +142,7 @@ jobs:
           echo "LD_LIBRARY_PATH=${PWD}/install/lib" >> ${GITHUB_ENV}
           echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig" >> ${GITHUB_ENV}
       - name: Enable Apache Arrow repository
-        if: matrix.apache-arrow != 'main'
+        if: matrix.apache-arrow-main != 'yes'
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
@@ -163,7 +163,7 @@ jobs:
           #   -e "s,^URIs: \\(.*\\)/,URIs: \\1-rc/,g" \
           #   /etc/apt/sources.list.d/apache-arrow.sources
       - name: Install Apache Arrow packages
-        if: matrix.apache-arrow != 'main'
+        if: matrix.apache-arrow-main != 'yes'
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Configure Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
-          ccache --show-stats --verbose --version || :
+          ccache --show-stats --verbose --version
           cmake \
             -B apache-arrow/cpp.build \
             -S apache-arrow/cpp \
@@ -133,7 +133,7 @@ jobs:
         if: env.APACHE_ARROW == 'main'
         run: |
           cmake --build apache-arrow/cpp.build
-          ccache --show-stats --verbose || true
+          ccache --show-stats --verbose
       - name: Install Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
@@ -192,7 +192,7 @@ jobs:
             zlib1g-dev
       - name: CMake
         run: |
-          ccache --show-stats --verbose --version || :
+          ccache --show-stats --verbose --version
           cmake \
             -B ../groonga.build \
             -S . \
@@ -207,7 +207,7 @@ jobs:
       - name: Build
         run: |
           ninja -C ../groonga.build
-          ccache --show-stats --verbose --version || :
+          ccache --show-stats --verbose --version
       - name: Install
         run: |
           ninja -C ../groonga.build install

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -117,7 +117,6 @@ jobs:
         if: env.APACHE_ARROW == 'main'
         run: |
           echo "CCACHE_DIR_ARROW=${PWD}/ccache-arrow" >> ${GITHUB_ENV}
-          echo "CMAKE_CXX_COMPILER_LAUNCHER_ARROW=ccache" >> ${GITHUB_ENV}
       - name: Cache Apache Arrow ccache
         if: env.APACHE_ARROW == 'main'
         uses: actions/cache@v4
@@ -148,7 +147,6 @@ jobs:
             -GNinja \
             --preset ninja-release \
             -DCMAKE_INSTALL_PREFIX=$PWD/install \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER_ARROW}
       - name: Build Apache Arrow
         if: env.APACHE_ARROW == 'main'
         env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -97,6 +97,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Prepare ccache
+        run: |
+          echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ccache
+          key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**') }}
+          restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-
       - name: Install common build dependencies
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
@@ -110,15 +119,6 @@ jobs:
         with:
           path: apache-arrow
           repository: apache/arrow
-      - name: Prepare ccache
-        run: |
-          echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
-      - name: Cache ccache
-        uses: actions/cache@v4
-        with:
-          path: ccache
-          key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
-          restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow-main }}-ccache-
       - name: Configure Apache Arrow
         if: matrix.apache-arrow-main == 'yes'
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -126,7 +126,8 @@ jobs:
           cmake \
             -B apache-arrow/cpp.build \
             -S apache-arrow/cpp \
-            --preset ninja-debug \
+            --preset ninja-debug-minimal \
+            -DARROW_COMPUTE=ON \
             -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
         if: matrix.apache-arrow-main == 'yes'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -155,8 +155,8 @@ jobs:
       - name: Set environment variables for Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
-          echo "LD_LIBRARY_PATH=${PWD}/apache-arrow/install/lib:${{ env.LD_LIBRARY_PATH }}" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/apache-arrow/install/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> ${GITHUB_ENV}
+          echo "LD_LIBRARY_PATH=${PWD}/apache-arrow/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/apache-arrow/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
           echo "${PWD}/apache-arrow/install/bin" >> ${GITHUB_PATH}
       - name: Enable Apache Arrow repository
         if: env.APACHE_ARROW != 'main'
@@ -235,8 +235,8 @@ jobs:
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${{ env.LD_LIBRARY_PATH }}" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> ${GITHUB_ENV}
+          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \
                "${{ matrix.mruby }}" == "" ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -114,7 +114,6 @@ jobs:
           restore-keys: |
             cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
             cmake-ubuntu-${{ matrix.cc }}-ccache-
-            cmake-ubuntu-ccache-
       - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -111,9 +111,7 @@ jobs:
         with:
           path: ccache
           key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
-          restore-keys: |
-            cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
-            cmake-ubuntu-${{ matrix.cc }}-ccache-
+          restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
       - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -94,45 +94,76 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - uses: actions/checkout@v4
+        with:
+          path: apache-arrow
+          repository: apache/arrow
       - name: Prepare ccache
         run: |
           echo "CCACHE_DIR=${PWD}/ccache" >> ${GITHUB_ENV}
-      - name: Cache ccache
+      - name: Cache Groonga ccache
         uses: actions/cache@v4
         with:
           path: ccache
-          key: cmake-ubuntu-${{ matrix.cc }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**') }}
-          restore-keys: cmake-ubuntu-${{ matrix.cc }}-ccache-
-      - name: Enable Apache Arrow repository
+          key: cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**') }}
+          restore-keys: |
+            cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-
+            cmake-ubuntu-groonga-ccache-
+      - name: Configure ccache for Apache Arrow
+        run: |
+          echo "CCACHE_DIR_ARROW=${PWD}/ccache-arrow" >> ${GITHUB_ENV}
+          echo "CMAKE_CXX_COMPILER_LAUNCHER_ARROW=ccache" >> ${GITHUB_ENV}
+      - name: Cache Apache Arrow ccache
+        uses: actions/cache@v4
+        with:
+          path: ccache-arrow
+          key: cmake-ubuntu-apache-arrow-${{ matrix.cc }}-ccache-${{ hashFiles('apache-arrow/cpp/src/**') }}
+          restore-keys: |
+            cmake-ubuntu-apache-arrow-${{ matrix.cc }}-ccache-
+            cmake-ubuntu-apache-arrow-ccache-
+      - name: Install dependecies for Apache Arrow
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
-            lsb-release \
-            wget
-          # Use released version for now. Apache Arrow (RC) APT
-          # repository has some problems for now:
-          # https://github.com/apache/arrow/issues/46083
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          # Always use RC version to detect Apache Arrow related
-          # problems as fast as possible. Released Apache Arrow is
-          # tested in package related jobs.
-          # wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')-rc/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          # sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-          # sudo sed \
-          #   -i"" \
-          #   -e "s,^URIs: \\(.*\\)/,URIs: \\1-rc/,g" \
-          #   /etc/apt/sources.list.d/apache-arrow.sources
+            build-essential \
+            ninja-build \
+            ccache \
+            cmake
+      - name: Configure Apache Arrow
+        env:
+          CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
+        run: |
+          cd apache-arrow
+          ccache --show-stats --verbose --version || :
+          cmake \
+            -B cpp.build \
+            -S cpp \
+            -GNinja \
+            --preset ninja-release \
+            -DCMAKE_INSTALL_PREFIX=$PWD/install \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER_ARROW}
+      - name: Build Apache Arrow
+        env:
+          CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
+        run: |
+          cd apache-arrow
+          cmake --build cpp.build
+          ccache --show-stats --verbose || true
+      - name: Install Apache Arrow
+        run: |
+          cd apache-arrow
+          cmake --install cpp.build
+      - name: Set environment variables for Apache Arrow
+        run: |
+          echo "LD_LIBRARY_PATH=${PWD}/apache-arrow/install/lib:${{ env.LD_LIBRARY_PATH }}" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/apache-arrow/install/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> ${GITHUB_ENV}
+          echo "${PWD}/apache-arrow/install/bin" >> ${GITHUB_PATH}
       - name: Install packages
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
-            ccache \
-            cmake \
             gdb \
             gettext \
-            libarrow-compute-dev \
-            libarrow-dev \
             libedit-dev \
             libevent-dev \
             libluajit-5.1-dev \
@@ -144,7 +175,6 @@ jobs:
             libxxhash-dev \
             libzstd-dev \
             mecab-naist-jdic \
-            ninja-build \
             rapidjson-dev \
             ruby-dev \
             zlib1g-dev
@@ -157,6 +187,7 @@ jobs:
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=$PWD/install \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DArrow_DIR=$PWD/apache-arrow/install/lib/cmake/Arrow \
             -DGRN_ALLOW_WARNING=OFF \
             -DGRN_WITH_APACHE_ARROW=ON \
             -DGRN_WITH_BLOSC=auto \
@@ -172,8 +203,8 @@ jobs:
       - name: Set environment variables
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          echo "LD_LIBRARY_PATH=${PWD}/install/lib" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig" >> ${GITHUB_ENV}
+          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${{ env.LD_LIBRARY_PATH }}" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \
                "${{ matrix.mruby }}" == "" ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -98,6 +98,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Install common build dependencies
+        run: |
+          sudo apt update -o="APT::Acquire::Retries=3"
+          sudo apt install -y -V -o="APT::Acquire::Retries=3" \
+            build-essential \
+            ninja-build \
+            ccache \
+            cmake
       - uses: actions/checkout@v4
         if: env.APACHE_ARROW == 'main'
         with:
@@ -112,14 +120,6 @@ jobs:
           path: ccache
           key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
           restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
-      - name: Install common build dependencies
-        run: |
-          sudo apt update -o="APT::Acquire::Retries=3"
-          sudo apt install -y -V -o="APT::Acquire::Retries=3" \
-            build-essential \
-            ninja-build \
-            ccache \
-            cmake
       - name: Configure Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -113,10 +113,6 @@ jobs:
           restore-keys: |
             cmake-ubuntu-groonga-${{ matrix.cc }}-ccache-
             cmake-ubuntu-groonga-ccache-
-      - name: Configure ccache for Apache Arrow
-        if: env.APACHE_ARROW == 'main'
-        run: |
-          echo "CCACHE_DIR_ARROW=${PWD}/ccache-arrow" >> ${GITHUB_ENV}
       - name: Cache Apache Arrow ccache
         if: env.APACHE_ARROW == 'main'
         uses: actions/cache@v4
@@ -136,8 +132,6 @@ jobs:
             cmake
       - name: Configure Apache Arrow
         if: env.APACHE_ARROW == 'main'
-        env:
-          CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
         run: |
           cd apache-arrow
           ccache --show-stats --verbose --version || :
@@ -149,8 +143,6 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=$PWD/install \
       - name: Build Apache Arrow
         if: env.APACHE_ARROW == 'main'
-        env:
-          CCACHE_DIR: ${{ env.CCACHE_DIR_ARROW }}
         run: |
           cd apache-arrow
           cmake --build cpp.build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -111,10 +111,10 @@ jobs:
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
             build-essential \
-            ninja-build \
             ccache \
             cmake \
-            libxsimd-dev
+            libxsimd-dev \
+            ninja-build
       - uses: actions/checkout@v4
         if: matrix.apache-arrow-main == 'yes'
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -140,7 +140,7 @@ jobs:
             -S cpp \
             -GNinja \
             --preset ninja-release \
-            -DCMAKE_INSTALL_PREFIX=$PWD/install \
+            -DCMAKE_INSTALL_PREFIX=../install
       - name: Build Apache Arrow
         if: env.APACHE_ARROW == 'main'
         run: |
@@ -152,12 +152,10 @@ jobs:
         run: |
           cd apache-arrow
           cmake --install cpp.build
-      - name: Set environment variables for Apache Arrow
-        if: env.APACHE_ARROW == 'main'
+      - name: Set environment variables
         run: |
-          echo "LD_LIBRARY_PATH=${PWD}/apache-arrow/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/apache-arrow/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
-          echo "${PWD}/apache-arrow/install/bin" >> ${GITHUB_PATH}
+          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
+          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
       - name: Enable Apache Arrow repository
         if: env.APACHE_ARROW != 'main'
         run: |
@@ -209,10 +207,6 @@ jobs:
       - name: CMake
         run: |
           ccache --show-stats --verbose --version || :
-          CMAKE_ARGS=""
-          if [ "${APACHE_ARROW}" = "main" ]; then
-            CMAKE_ARGS="${CMAKE_ARGS} -DArrow_DIR=$PWD/apache-arrow/install/lib/cmake/Arrow"
-          fi
           cmake \
             -B ../groonga.build \
             -S . \
@@ -223,8 +217,7 @@ jobs:
             -DGRN_WITH_APACHE_ARROW=ON \
             -DGRN_WITH_BLOSC=auto \
             -DGRN_WITH_MRUBY=${GRN_WITH_MRUBY:-ON} \
-            -DGRN_WITH_UBSAN=${GRN_WITH_UBSAN:-OFF} \
-            ${CMAKE_ARGS}
+            -DGRN_WITH_UBSAN=${GRN_WITH_UBSAN:-OFF}
       - name: Build
         run: |
           ninja -C ../groonga.build
@@ -232,11 +225,9 @@ jobs:
       - name: Install
         run: |
           ninja -C ../groonga.build install
-      - name: Set environment variables
+      - name: Set environment variables for Groonga
         run: |
           echo "COLUMNS=79" >> ${GITHUB_ENV}
-          echo "LD_LIBRARY_PATH=${PWD}/install/lib:${LD_LIBRARY_PATH}" >> ${GITHUB_ENV}
-          echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig:${PKG_CONFIG_PATH}" >> ${GITHUB_ENV}
           echo "TZ=Asia/Tokyo" >> ${GITHUB_ENV}
           if [ "${{ matrix.cc }}" == "gcc" -a \
                "${{ matrix.mruby }}" == "" ]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -85,9 +85,6 @@ jobs:
             cxx: clang++
           - cc: clang
             cxx: clang++
-            apache-arrow: "main"
-          - cc: clang
-            cxx: clang++
             ubsan: "ON"
     runs-on: ubuntu-latest
     timeout-minutes: 90

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -89,7 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
-      APACHE_ARROW: ${{ matrix.apache-arrow }}
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
       GRN_WITH_MRUBY: ${{ matrix.mruby }}
@@ -107,7 +106,7 @@ jobs:
             ccache \
             cmake
       - uses: actions/checkout@v4
-        if: env.APACHE_ARROW == 'main'
+        if: matrix.apache-arrow == 'main'
         with:
           path: apache-arrow
           repository: apache/arrow
@@ -121,7 +120,7 @@ jobs:
           key: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-${{ hashFiles('lib/**', 'src/**', 'plugins/**', 'include/**', 'apache-arrow/cpp/src/**') }}
           restore-keys: cmake-ubuntu-${{ matrix.cc }}-${{ matrix.apache-arrow }}-ccache-
       - name: Configure Apache Arrow
-        if: env.APACHE_ARROW == 'main'
+        if: matrix.apache-arrow == 'main'
         run: |
           ccache --show-stats --verbose --version
           cmake \
@@ -130,12 +129,12 @@ jobs:
             --preset ninja-debug \
             -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
-        if: env.APACHE_ARROW == 'main'
+        if: matrix.apache-arrow == 'main'
         run: |
           cmake --build apache-arrow/cpp.build
           ccache --show-stats --verbose
       - name: Install Apache Arrow
-        if: env.APACHE_ARROW == 'main'
+        if: matrix.apache-arrow == 'main'
         run: |
           cmake --install apache-arrow/cpp.build
       - name: Set environment variables
@@ -143,7 +142,7 @@ jobs:
           echo "LD_LIBRARY_PATH=${PWD}/install/lib" >> ${GITHUB_ENV}
           echo "PKG_CONFIG_PATH=${PWD}/install/lib/pkgconfig" >> ${GITHUB_ENV}
       - name: Enable Apache Arrow repository
-        if: env.APACHE_ARROW != 'main'
+        if: matrix.apache-arrow != 'main'
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \
@@ -164,7 +163,7 @@ jobs:
           #   -e "s,^URIs: \\(.*\\)/,URIs: \\1-rc/,g" \
           #   /etc/apt/sources.list.d/apache-arrow.sources
       - name: Install Apache Arrow packages
-        if: env.APACHE_ARROW != 'main'
+        if: matrix.apache-arrow != 'main'
         run: |
           sudo apt update -o="APT::Acquire::Retries=3"
           sudo apt install -y -V -o="APT::Acquire::Retries=3" \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -222,18 +222,22 @@ jobs:
       - name: CMake
         run: |
           ccache --show-stats --verbose --version || :
+          CMAKE_ARGS=""
+          if [ "${APACHE_ARROW}" = "main" ]; then
+            CMAKE_ARGS="${CMAKE_ARGS} -DArrow_DIR=$PWD/apache-arrow/install/lib/cmake/Arrow"
+          fi
           cmake \
             -B ../groonga.build \
             -S . \
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=$PWD/install \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DArrow_DIR=$PWD/apache-arrow/install/lib/cmake/Arrow \
             -DGRN_ALLOW_WARNING=OFF \
             -DGRN_WITH_APACHE_ARROW=ON \
             -DGRN_WITH_BLOSC=auto \
             -DGRN_WITH_MRUBY=${GRN_WITH_MRUBY:-ON} \
-            -DGRN_WITH_UBSAN=${GRN_WITH_UBSAN:-OFF}
+            -DGRN_WITH_UBSAN=${GRN_WITH_UBSAN:-OFF} \
+            ${CMAKE_ARGS}
       - name: Build
         run: |
           ninja -C ../groonga.build


### PR DESCRIPTION
GitHub: GH-2434
    
This allows us to notice any breaking changes in Apache Arrow before their official release,
giving us time to adapt our code accordingly.