### PR TITLE
cmake: Enable C4244 when GRN_WARN_CONVERSION=ON

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -767,6 +767,7 @@ jobs:
           ccache --show-stats --verbose --version
       - name: Install Groonga
         shell: cmd
+        continue-on-error: ${{ matrix.warn_conversion == 'ON' }}
         run: |
           call "%VC_PREFIX%\Auxiliary\Build\vcvarsall.bat" %VC_ARCHITECTURE%
           set CMAKE_ARGS=-S .
@@ -774,6 +775,7 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -G "Ninja"
           set CMAKE_ARGS=%CMAKE_ARGS% "-DCMAKE_INSTALL_PREFIX=%FULL_INSTALL_FOLDER%"
           set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_ALLOW_WARNING=OFF
           set CMAKE_ARGS=%CMAKE_ARGS% "-DGRN_WARN_CONVERSION=${{ matrix.warn_conversion }}"
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_APACHE_ARROW=ON
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_BLOSC=auto
@@ -782,9 +784,6 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZLIB=no
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZSTD=bundled
           set CMAKE_ARGS=%CMAKE_ARGS% -DGROONGA_NORMALIZER_MYSQL_DOC_DIR=share/groonga-normalizer-mysql
-          if "${{ matrix.warn_conversion }}" == "OFF" (
-            set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_ALLOW_WARNING=OFF
-          )
 
           cmake %CMAKE_ARGS% || (type ..\groonga-build\CMakeFiles\CMakeError.log & exit /B)
           cmake --build ..\groonga-build || exit /B

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -784,7 +784,6 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZLIB=no
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZSTD=bundled
           set CMAKE_ARGS=%CMAKE_ARGS% -DGROONGA_NORMALIZER_MYSQL_DOC_DIR=share/groonga-normalizer-mysql
-
           cmake %CMAKE_ARGS% || (type ..\groonga-build\CMakeFiles\CMakeError.log & exit /B)
           cmake --build ..\groonga-build || exit /B
           cmake --install ..\groonga-build || exit /B

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -820,6 +820,7 @@ jobs:
           name: release-${{ env.INSTALL_FOLDER }}
           path: ${{ env.INSTALL_FOLDER }}.zip
       - name: Prepare artifacts with VC++ runtime
+        if: matrix.warn_conversion == 'OFF'
         run: |
           Set-PSDebug -Trace 2
 
@@ -886,9 +887,11 @@ jobs:
 
       # Test
       - uses: ruby/setup-ruby@v1
+        if: matrix.warn_conversion == 'OFF'
         with:
           ruby-version: ruby
       - name: Install test dependencies
+        if: matrix.warn_conversion == 'OFF'
         run: |
           $Env:MAKEFLAGS = "-j${Env:NUMBER_OF_PROCESSORS}"
           gem install `
@@ -896,10 +899,12 @@ jobs:
             pkg-config `
             red-arrow
       - name: "Test: command line"
+        if: matrix.warn_conversion == 'OFF'
         run: |
           ruby test\command_line\run-test.rb `
             --groonga-install-prefix="${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}"
       - name: "Test: HTTP: reference count: Apache Arrow: chunked"
+        if: matrix.warn_conversion == 'OFF'
         run: |
           $Env:GRN_ENABLE_REFERENCE_COUNT = "yes"
           grntest `

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -634,6 +634,11 @@ jobs:
           - runs-on: windows-2022
             vc-toolset-version: 143
             vs-version: 2022
+            warn_conversion: OFF
+          - runs-on: windows-2022
+            vc-toolset-version: 143
+            vs-version: 2022
+            warn_conversion: ON
     env:
       VC_ARCHITECTURE: x64
     runs-on: ${{ matrix.runs-on }}
@@ -769,7 +774,7 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -G "Ninja"
           set CMAKE_ARGS=%CMAKE_ARGS% "-DCMAKE_INSTALL_PREFIX=%FULL_INSTALL_FOLDER%"
           set CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_ALLOW_WARNING=OFF
+          set CMAKE_ARGS=%CMAKE_ARGS% "-DGRN_WARN_CONVERSION=${{ matrix.warn_conversion }}"
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_APACHE_ARROW=ON
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_BLOSC=auto
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_MRUBY=ON
@@ -777,11 +782,16 @@ jobs:
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZLIB=no
           set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_WITH_ZSTD=bundled
           set CMAKE_ARGS=%CMAKE_ARGS% -DGROONGA_NORMALIZER_MYSQL_DOC_DIR=share/groonga-normalizer-mysql
+          if "${{ matrix.warn_conversion }}" == "OFF" (
+            set CMAKE_ARGS=%CMAKE_ARGS% -DGRN_ALLOW_WARNING=OFF
+          )
+
           cmake %CMAKE_ARGS% || (type ..\groonga-build\CMakeFiles\CMakeError.log & exit /B)
           cmake --build ..\groonga-build || exit /B
           cmake --install ..\groonga-build || exit /B
           ccache --show-stats --verbose --version
       - name: Install Groonga Admin
+        if: matrix.warn_conversion == 'OFF'
         run: |
           cd "${Env:FULL_INSTALL_FOLDER}\share\groonga\html"
           Move-Item admin admin.old
@@ -796,6 +806,7 @@ jobs:
 
       # Artifact
       - name: Compress the artifact without VC++ runtime
+        if: matrix.warn_conversion == 'OFF'
         run: |
           pushd "${Env:FULL_INSTALL_FOLDER}\.."
           Compress-Archive `
@@ -806,6 +817,7 @@ jobs:
             "${Env:FULL_INSTALL_FOLDER}.zip" `
             "${Env:INSTALL_FOLDER}.zip"
       - uses: actions/upload-artifact@v4
+        if: matrix.warn_conversion == 'OFF'
         with:
           name: release-${{ env.INSTALL_FOLDER }}
           path: ${{ env.INSTALL_FOLDER }}.zip
@@ -858,6 +870,7 @@ jobs:
             "${Env:GITHUB_WORKSPACE}\packages\windows\vcruntime\ucrt-readme.txt" `
             ${GROONGA_VC_REDIST_LICENSE_DIR}
       - name: Compress the artifact with VC++ runtime
+        if: matrix.warn_conversion == 'OFF'
         run: |
           pushd "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}\.."
           Compress-Archive `
@@ -868,6 +881,7 @@ jobs:
             "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}.zip" `
             "${Env:INSTALL_FOLDER_WITH_VCRUNTIME}.zip"
       - uses: actions/upload-artifact@v4
+        if: matrix.warn_conversion == 'OFF'
         with:
           name: release-${{ env.INSTALL_FOLDER_WITH_VCRUNTIME }}
           path: ${{ env.INSTALL_FOLDER_WITH_VCRUNTIME }}.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,10 +384,6 @@ elseif(MSVC)
 
   # Disable warnings
 
-  # 'argument' : conversion from 'type1' to 'type2', possible loss of data
-  # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
-  string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")
-  string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4244")
   # 'operator': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
   # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4334
   string(APPEND GRN_C_COMPILE_FLAGS " /wd4334")
@@ -399,6 +395,12 @@ if(GRN_WARN_CONVERSION)
   if(GRN_C_COMPILER_GNU_LIKE)
     check_build_flag("-Wconversion")
   elseif(MSVC)
+    string(APPEND GRN_C_COMPILE_FLAGS " /W3")
+    string(APPEND GRN_CXX_COMPILE_FLAGS " /W3")
+    # 'argument' : conversion from 'type1' to 'type2', possible loss of data
+    # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
+    string(APPEND GRN_C_COMPILE_FLAGS " /w24244")
+    string(APPEND GRN_CXX_COMPILE_FLAGS " /w24244")
     # 'var' : conversion from 'size_t' to 'type', possible loss of data
     # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267
     string(APPEND GRN_C_COMPILE_FLAGS " /w34267")
@@ -406,6 +408,10 @@ if(GRN_WARN_CONVERSION)
   endif()
 else()
   if(MSVC)
+    # 'argument' : conversion from 'type1' to 'type2', possible loss of data
+    # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4244
+    string(APPEND GRN_C_COMPILE_FLAGS " /wd4244")
+    string(APPEND GRN_CXX_COMPILE_FLAGS " /wd4244")
     # 'var' : conversion from 'size_t' to 'type', possible loss of data
     # https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267
     string(APPEND GRN_C_COMPILE_FLAGS " /wd4267")


### PR DESCRIPTION
C4244 is also a "possible loss of data" warning as well as C4267, so add it.

C4244: 'argument' : conversion from 'type1' to 'type2', possible loss of data
C4267: 'var' : conversion from 'size_t' to 'type', possible loss of data

Add `/W3` because the default is `/W1`, so level2 and level3 are not warnings.

https://learn.microsoft.com/en-us/cpp/build/reference/compiler-option-warning-level
> /W1 displays level 1 (severe) warnings. /W1 is the default setting in the command-line compiler.