### PR TITLE
pat: use pat_node_common instead of pat_node in _grn_pat_create()

### DIFF
--- a/lib/pat.c
+++ b/lib/pat.c
@@ -1920,8 +1920,8 @@ _grn_pat_create(grn_ctx *ctx,
     grn_io_close(ctx, io);
     return NULL;
   }
-  pat_node_set_right(pat, node0, 0);
-  pat_node_set_left(pat, node0, 0);
+  pat_node_set_right(pat, node0, GRN_ID_NIL);
+  pat_node_set_left(pat, node0, GRN_ID_NIL);
   pat_node_set_key_offset(pat, node0, 0);
   return pat;
 }

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -6324,8 +6324,8 @@ grn_pat_node_compare_by_key(const grn_id id1, const grn_id id2, void *arg)
   grn_ctx *ctx = ((pat_node_compare_by_key_data *)arg)->ctx;
   grn_pat *pat = ((pat_node_compare_by_key_data *)arg)->pat;
 
-  pat_node_common *node1 = _pat_node_get(ctx, pat, id1);
-  pat_node_common *node2 = _pat_node_get(ctx, pat, id2);
+  pat_node_common *node1 = pat_node_get(ctx, pat, id1);
+  pat_node_common *node2 = pat_node_get(ctx, pat, id2);
   uint64_t node1_key_offset = pat_node_get_key_offset(pat, node1);
   uint64_t node2_key_offset = pat_node_get_key_offset(pat, node2);
 


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

`pat_get()` is not use since this commit.
So, I replace this function.