### PR TITLE
NormalizerNFKC: Add support for `unify_hyphen_and_prolonged_sound_mark` and `remove_symbol` combination

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -3593,8 +3593,7 @@ grn_nfkc_normalize_unify(grn_ctx *ctx, grn_nfkc_normalize_data *data)
   bool need_swap = false;
   /* If both `unify_hyphen_and_prolonged_sound_mark` and `remove_symbol` are
    * enabled, unification is not necessary because the hyphen has already been
-   * removed. Same for `unify_middle_dot`.
-   */
+   * removed. Same for `unify_middle_dot`. */
   bool unify_hyphen_and_prolonged_sound_mark =
     (data->options->unify_hyphen_and_prolonged_sound_mark &&
      !data->options->remove_symbol);

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("remove_symbol", true,                   "unify_hyphen_and_prolonged_sound_mark", true,                   "version", "NFKC_VERSION")'   "090ー1234ー5678"   WITH_TYPES
+normalize   'NormalizerNFKC("remove_symbol", true,                   "unify_hyphen_and_prolonged_sound_mark", true,                   "version", "NFKC_VERSION")'   "telephone number-˗֊‐‑‒–⁃⁻₋−﹣－ー—―─━ｰ090ー1xxxー5xxx"   WITH_TYPES
 [
   [
     0,
@@ -6,19 +6,35 @@ normalize   'NormalizerNFKC("remove_symbol", true,                   "unify_hyph
     0.0
   ],
   {
-    "normalized": "09012345678",
+    "normalized": "telephone number0901xxx5xxx",
     "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
       "digit",
       "digit",
       "digit",
       "digit",
+      "alpha",
+      "alpha",
+      "alpha",
       "digit",
-      "digit",
-      "digit",
-      "digit",
-      "digit",
-      "digit",
-      "digit",
+      "alpha",
+      "alpha",
+      "alpha",
       "null"
     ],
     "checks": []

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.expected
@@ -1,0 +1,26 @@
+normalize   'NormalizerNFKC("remove_symbol", true,                   "unify_hyphen_and_prolonged_sound_mark", true,                   "version", "NFKC_VERSION")'   "090ー1234ー5678"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "09012345678",
+    "types": [
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.test
@@ -3,6 +3,6 @@ normalize \
   'NormalizerNFKC("remove_symbol", true, \
                   "unify_hyphen_and_prolonged_sound_mark", true, \
                   "version", "NFKC_VERSION")' \
-  "090ー1234ー5678" \
+  "telephone number-˗֊‐‑‒–⁃⁻₋−﹣－ー—―─━ｰ090ー1xxxー5xxx" \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/mix/remove_symbol_and_unify_hyphen_and_prolonged_sound_mark.test
@@ -1,0 +1,8 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("remove_symbol", true, \
+                  "unify_hyphen_and_prolonged_sound_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "090ー1234ー5678" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/


### PR DESCRIPTION
GitHub: fixes GH-1543

When `unify_hyphen_and_prolonged_sound_mark` is enabled, the hyphen becomes a symbol and should be removed with `remove_symbol`.

Related fixes: GH-2080