### PR TITLE
pat: fix a wrong max total key size when we use "KEY_LARGE"

### DIFF
--- a/lib/grn.h
+++ b/lib/grn.h
@@ -201,10 +201,6 @@ typedef int grn_sock;
 #  define INT64_MIN (-9223372036854775808)
 #endif /* INT64_MIN */
 
-#ifndef UINT64_MAX
-#  define UINT64_MAX (18446744073709551615)
-#endif /* UINT64_MAX */
-
 #ifdef WIN32
 #  define grn_lseek(fd, offset, whence) _lseeki64(fd, offset, whence)
 #else /* WIN32 */

--- a/lib/grn_pat.h
+++ b/lib/grn_pat.h
@@ -28,9 +28,8 @@
 extern "C" {
 #endif
 
-#define GRN_PAT_MAX_KEY_SIZE             GRN_TABLE_MAX_KEY_SIZE
-#define GRN_PAT_MAX_TOTAL_KEY_SIZE       (UINT32_MAX - 1)
-#define GRN_PAT_MAX_TOTAL_KEY_SIZE_LARGE (UINT64_MAX - 1)
+#define GRN_PAT_MAX_KEY_SIZE       GRN_TABLE_MAX_KEY_SIZE
+#define GRN_PAT_MAX_TOTAL_KEY_SIZE (UINT32_MAX - 1)
 
 struct _grn_pat {
   grn_db_obj obj;

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -49,9 +49,12 @@
 /* If we use GRN_PAT_MAX_N_SEGMENTS_LARGE, max total key size is 1TiB:
    GRN_PAT_SEGMENT_SIZE * 0x40000 = 1TiB */
 #define GRN_PAT_MAX_N_SEGMENTS_LARGE 0x40000
-#define GRN_PAT_MDELINFOS            (GRN_PAT_NDELINFOS - 1)
+#define GRN_PAT_MAX_TOTAL_KEY_SIZE_LARGE                                       \
+  ((uint64_t)GRN_PAT_SEGMENT_SIZE * (uint64_t)GRN_PAT_MAX_N_SEGMENTS_LARGE -   \
+   1) // 1TiB - 1 (-1 is initial curr_key value)
+#define GRN_PAT_MDELINFOS (GRN_PAT_NDELINFOS - 1)
 
-#define GRN_PAT_BIN_KEY              0x70000
+#define GRN_PAT_BIN_KEY   0x70000
 
 typedef enum {
   DIRECTION_LEFT = 0,

--- a/test/command/suite/object_inspect/table/have_records/key_large/pat_key.expected
+++ b/test/command/suite/object_inspect/table/have_records/key_large/pat_key.expected
@@ -30,7 +30,7 @@ object_inspect --name Users
         "size": 4096
       },
       "total_size": 5,
-      "max_total_size": 18446744073709551614
+      "max_total_size": 1099511627775
     },
     "value": {
       "type": null

--- a/test/command/suite/object_inspect/table/no_record/key_large/pat_key.expected
+++ b/test/command/suite/object_inspect/table/no_record/key_large/pat_key.expected
@@ -25,7 +25,7 @@ object_inspect --name Users
         "size": 4096
       },
       "total_size": 0,
-      "max_total_size": 18446744073709551614
+      "max_total_size": 1099511627775
     },
     "value": {
       "type": null


### PR DESCRIPTION
This commit is part of the work to implement GH-2349.

If we use "KEY_LARGE" in "TABLE_PAT_KEY", max total key size is 1TiB.
However, Groonga returns "UINT64_MAX - 1" currently. This value is too big.