### PR TITLE
docs: install/cmake: remove needless options

### DIFF
--- a/doc/source/install/cmake.md
+++ b/doc/source/install/cmake.md
@@ -273,8 +273,8 @@ Now, you can build Groonga.
 Here is a command line to build and install Groonga.
 
 ```console
-$ cmake --build -B <Build directory path>
-$ sudo cmake --install -B <Build directory path>
+$ cmake --build <Build directory path>
+$ sudo cmake --install <Build directory path>
 ```
 
 ### Windows


### PR DESCRIPTION
To fix the following errors:

```console
$ cmake --build -B build.ninja
Unknown argument build.ninja
Usage: cmake --build <dir>             [options] [-- [native-options]]
       cmake --build --preset <preset> [options] [-- [native-options]]
(snip)
```

```console
$ sudo cmake --install -B build.ninja
Unknown argument build.ninja
Usage: cmake --install <dir> [options]
(snip)
```