### PR TITLE
io: add null check to prevent accessing non-exist object

### DIFF
--- a/lib/io.c
+++ b/lib/io.c
@@ -1440,6 +1440,7 @@ grn_io_lock(grn_ctx *ctx, grn_io *io, int timeout)
   if (!io) { return GRN_INVALID_ARGUMENT; }
   for (count = 0;; count++) {
     uint32_t lock;
+    if (!io) { return GRN_INVALID_ARGUMENT; }
     GRN_ATOMIC_ADD_EX(io->lock, 1, lock);
     if (lock) {
       GRN_ATOMIC_ADD_EX(io->lock, -1, lock);


### PR DESCRIPTION
Currently, Groonga may crash when multiple commands wait for getting lock.
This modification is prevented the crash by checking existence of object.

If multiple commands wait for getting lock, Groonga can't guarantee the order of these commands.
For example, if both "table_remove" and "io_flush" wait for getting lock, Groonga may execute "table_remove" before "io_flush" depends on the  release of lock timing.

In the avobe case, the table of the "io_flush" target has been already removed by "table_remove" when "io_flush" try to get the lock.
And Groonga crash for accessing invalid area.
