### PR TITLE
table: use value that can be expressed within uint16_t

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -819,7 +819,7 @@ typedef uint32_t grn_column_flags;
 
 /* flags only for grn_table_flags */
 
-#define GRN_OBJ_KEY_LARGE (0x01 << 16)
+#define GRN_OBJ_KEY_LARGE (0x01 << 11)
 
 /* flags only for grn_column_flags */
 

--- a/test/command/suite/check/pat/large_key.expected
+++ b/test/command/suite/check/pat/large_key.expected
@@ -14,7 +14,7 @@ check --obj Users
   ],
   [
     {
-      "flags": "0001C001",
+      "flags": "0000C801",
       "key size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/check/pat/large_key_with_embeddable_key.expected
+++ b/test/command/suite/check/pat/large_key_with_embeddable_key.expected
@@ -14,7 +14,7 @@ check --obj Users
   ],
   [
     {
-      "flags": "0001C001",
+      "flags": "0000C801",
       "key size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/truncate/table/key_large_hash.expected
+++ b/test/command/suite/truncate/table/key_large_hash.expected
@@ -1,0 +1,23 @@
+table_create Diaries TABLE_HASH_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+column_create Diaries content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+load --table Diaries
+[
+{"_key": "2015-02-20", "content": "I tried Groonga."}
+]
+[[0,0.0,0.0],1]
+dump
+table_create Diaries TABLE_HASH_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text
+
+load --table Diaries
+[
+["_key","content"],
+["2015-02-20","I tried Groonga."]
+]
+truncate Diaries
+[[0,0.0,0.0],true]
+dump
+table_create Diaries TABLE_HASH_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text

--- a/test/command/suite/truncate/table/key_large_hash.test
+++ b/test/command/suite/truncate/table/key_large_hash.test
@@ -1,0 +1,13 @@
+table_create Diaries TABLE_HASH_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text
+
+load --table Diaries
+[
+{"_key": "2015-02-20", "content": "I tried Groonga."}
+]
+
+dump
+
+truncate Diaries
+
+dump

--- a/test/command/suite/truncate/table/key_large_pat.expected
+++ b/test/command/suite/truncate/table/key_large_pat.expected
@@ -1,0 +1,23 @@
+table_create Diaries TABLE_PAT_KEY|KEY_LARGE ShortText
+[[0,0.0,0.0],true]
+column_create Diaries content COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+load --table Diaries
+[
+{"_key": "2015-02-20", "content": "I tried Groonga."}
+]
+[[0,0.0,0.0],1]
+dump
+table_create Diaries TABLE_PAT_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text
+
+load --table Diaries
+[
+["_key","content"],
+["2015-02-20","I tried Groonga."]
+]
+truncate Diaries
+[[0,0.0,0.0],true]
+dump
+table_create Diaries TABLE_PAT_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text

--- a/test/command/suite/truncate/table/key_large_pat.test
+++ b/test/command/suite/truncate/table/key_large_pat.test
@@ -1,0 +1,13 @@
+table_create Diaries TABLE_PAT_KEY|KEY_LARGE ShortText
+column_create Diaries content COLUMN_SCALAR Text
+
+load --table Diaries
+[
+{"_key": "2015-02-20", "content": "I tried Groonga."}
+]
+
+dump
+
+truncate Diaries
+
+dump

--- a/test/command/suite/wal_recover/hash/var/add/immediate/large.expected
+++ b/test/command/suite/wal_recover/hash/var/add/immediate/large.expected
@@ -18,7 +18,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -50,7 +50,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/wal_recover/hash/var/add/separated/large.expected
+++ b/test/command/suite/wal_recover/hash/var/add/separated/large.expected
@@ -18,7 +18,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -50,7 +50,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/wal_recover/hash/var/delete/immediate/large.expected
+++ b/test/command/suite/wal_recover/hash/var/delete/immediate/large.expected
@@ -18,7 +18,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -50,7 +50,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/wal_recover/hash/var/delete/separated/large.expected
+++ b/test/command/suite/wal_recover/hash/var/delete/separated/large.expected
@@ -18,7 +18,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -50,7 +50,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/wal_recover/hash/var/reuse/immediate/large.expected
+++ b/test/command/suite/wal_recover/hash/var/reuse/immediate/large.expected
@@ -16,7 +16,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -49,7 +49,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -81,7 +81,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,

--- a/test/command/suite/wal_recover/hash/var/reuse/separated/large.expected
+++ b/test/command/suite/wal_recover/hash/var/reuse/separated/large.expected
@@ -16,7 +16,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -49,7 +49,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,
@@ -81,7 +81,7 @@ check --obj Data
   ],
   [
     {
-      "flags": "0001C000",
+      "flags": "0000C800",
       "key_size": 4096,
       "value_size": 0,
       "tokenizer": 0,


### PR DESCRIPTION
Fix: Gh-2484

Because the flag value of TABLE_PAT_KEY and TABLE_HASH_KEY are also used as grn_db_obj.header.

Groonga does not refer grn_pat.header, but grn_db_obj.header when Groonga execute a "truncate" command.

However, the type of grn_db_obj.header is uint16_t. So, we must set the flag value of TABLE_PAT_KEY and TABLE_HASH_KEY within uint16_t.