### PR TITLE
NormalizerNFKC unify_iteration_mark: support single ideographic iteration mark (U+3005)

### DIFF
--- a/lib/grn_nfkc.h
+++ b/lib/grn_nfkc.h
@@ -61,6 +61,7 @@ typedef struct {
   bool unify_kana_hyphen;
   bool unify_kana_prolonged_sound_mark;
   bool unify_katakana_trailing_o;
+  bool unify_iteration_mark;
   bool unify_to_romaji;
   bool unify_to_katakana;
   bool remove_blank;

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -74,6 +74,7 @@ grn_nfkc_normalize_options_init(grn_ctx *ctx,
   options->unify_kana_hyphen = false;
   options->unify_kana_prolonged_sound_mark = false;
   options->unify_katakana_trailing_o = false;
+  options->unify_iteration_mark = false;
   options->unify_to_romaji = false;
   options->unify_to_katakana = false;
   options->remove_blank = false;
@@ -396,6 +397,12 @@ grn_nfkc_normalize_options_apply(grn_ctx *ctx,
                                     raw_options,
                                     i,
                                     options->unify_katakana_trailing_o);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_iteration_mark")) {
+      options->unify_iteration_mark =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->unify_iteration_mark);
     } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "unify_to_romaji")) {
       options->unify_to_romaji =
         grn_vector_get_element_bool(ctx,

--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -3429,6 +3429,57 @@ grn_nfkc_normalize_unify_romaji(grn_ctx *ctx,
 }
 
 static const unsigned char *
+grn_nfkc_normalize_unify_iteration_mark(grn_ctx *ctx,
+                                        const unsigned char *start,
+                                        const unsigned char *current,
+                                        const unsigned char *end,
+                                        size_t *n_used_bytes,
+                                        size_t *n_used_characters,
+                                        unsigned char *unified_buffer,
+                                        size_t *n_unified_bytes,
+                                        size_t *n_unified_characters,
+                                        void *user_data)
+{
+  size_t char_length;
+
+  char_length = (size_t)grn_charlen_(ctx, current, end, GRN_ENC_UTF8);
+
+  *n_used_bytes = char_length;
+  *n_used_characters = 1;
+
+  /* U+3005 IDEOGRAPHIC ITERATION MARK 々 */
+  if (char_length == 3 && current[0] == 0xe3 && current[1] == 0x80 &&
+      current[2] == 0x85) {
+    if (current > start) {
+      const unsigned char *prev = current - 1;
+
+      while (prev > start && (*prev & 0xc0) == 0x80) {
+        prev--;
+      }
+
+      size_t prev_char_length =
+        (size_t)grn_charlen_(ctx, prev, current, GRN_ENC_UTF8);
+
+      if (prev_char_length > 0) {
+        size_t i;
+        for (i = 0; i < prev_char_length; i++) {
+          unified_buffer[(*n_unified_bytes)++] = prev[i];
+        }
+        (*n_unified_characters)++;
+        *n_used_bytes = prev_char_length;
+        (*n_used_characters)++;
+        return unified_buffer;
+      }
+    }
+  }
+
+  *n_unified_bytes = *n_used_bytes;
+  *n_unified_characters = *n_used_characters;
+
+  return current;
+}
+
+static const unsigned char *
 grn_nfkc_normalize_strip(grn_ctx *ctx,
                          const unsigned char *start,
                          const unsigned char *current,
@@ -3617,8 +3668,8 @@ grn_nfkc_normalize_unify(grn_ctx *ctx, grn_nfkc_normalize_data *data)
         data->options->unify_kana_hyphen ||
         data->options->unify_kana_prolonged_sound_mark ||
         data->options->unify_katakana_trailing_o ||
-        data->options->unify_to_romaji || data->options->unify_to_katakana ||
-        data->options->strip)) {
+        data->options->unify_iteration_mark || data->options->unify_to_romaji ||
+        data->options->unify_to_katakana || data->options->strip)) {
     return;
   }
 
@@ -3846,6 +3897,23 @@ grn_nfkc_normalize_unify(grn_ctx *ctx, grn_nfkc_normalize_data *data)
       grn_nfkc_normalize_unify_katakana_trailing_o,
       &need_trailing_check,
       "[unify][katakana-trailing-o]");
+    if (ctx->rc != GRN_SUCCESS) {
+      goto exit;
+    }
+    need_swap = true;
+  }
+
+  if (data->options->unify_iteration_mark) {
+    if (need_swap) {
+      grn_nfkc_normalize_context_swap(ctx, &(data->context), &unify);
+      grn_nfkc_normalize_context_rewind(ctx, &unify);
+    }
+    grn_nfkc_normalize_unify_stateful(ctx,
+                                      data,
+                                      &unify,
+                                      grn_nfkc_normalize_unify_iteration_mark,
+                                      NULL,
+                                      "[unify][iteration-mark]");
     if (ctx->rc != GRN_SUCCESS) {
       goto exit;
     }

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/single.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/single.expected
@@ -1,0 +1,17 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "時々"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "時時",
+    "types": [
+      "kanji",
+      "kanji",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/single.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/single.test
@@ -1,0 +1,6 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true)' \
+  "時々" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/


### PR DESCRIPTION
GitHub: GH-2487

Add support for the ideographic iteration mark 々(U+3005) to the unify_iteration_mark option.
This allows proper normalization of Japanese kanji reduplication like 時々 → 時時.