### PR TITLE
release: prevent `VERSION=` usage with rake release when releasing skipped version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -203,7 +203,7 @@ namespace :release do
   end
 
   desc "Tag"
-  task :tag do
+  task tag: "version:validate" do
     latest_news = Dir.glob("doc/source/news/*.*").max do |a, b|
       File.basename(a).to_f - File.basename(b).to_f
     end


### PR DESCRIPTION
GitHub: GH-2503

When `VERSION=x.x.x rake release` was used to skip versions,
GitHub Actions workflows would read the wrong version from base_version file,
which wasn't updated during the release process.
This caused packages to be built with incorrect version numbers.

Now developers must use `rake dev:version:bump NEW_VERSION=x.x.x`  before `rake release` to properly update `base_version`, ensuring workflows use the correct version.