### PR TITLE
test: add version parameter to NormalizerNFKC unify_iteration_mark tests

### DIFF
--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/alphabet.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/alphabet.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "Ahゝ, I understood."   WITH_TYPES
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "Ahゝ, I understood."   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/alphabet.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/alphabet.test
@@ -1,6 +1,7 @@
 #@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
 normalize \
-  'NormalizerNFKC("unify_iteration_mark", true)' \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
   "Ahゝ, I understood." \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/kangi.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/kangi.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "私は、時ゝこけます。"   WITH_TYPES
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私は、時ゝこけます。"   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/kangi.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/kangi.test
@@ -1,6 +1,7 @@
 #@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
 normalize \
-  'NormalizerNFKC("unify_iteration_mark", true)' \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
   "私は、時ゝこけます。" \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/katakana.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/katakana.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "私の家は、コゝです。"   WITH_TYPES
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私の家は、コゝです。"   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/katakana.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/katakana.test
@@ -1,6 +1,7 @@
 #@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
 normalize \
-  'NormalizerNFKC("unify_iteration_mark", true)' \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
   "私の家は、コゝです。" \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/with_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/with_voiced_sound_mark.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "こゝで、一つづゝ分ける。"   WITH_TYPES
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "こゝで、一つづゝ分ける。"   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/with_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/with_voiced_sound_mark.test
@@ -1,6 +1,7 @@
 #@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
 normalize \
-  'NormalizerNFKC("unify_iteration_mark", true)' \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
   "こゝで、一つづゝ分ける。" \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/without_voiced_sound_mark.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/without_voiced_sound_mark.expected
@@ -1,4 +1,4 @@
-normalize   'NormalizerNFKC("unify_iteration_mark", true)'   "私の家は、こゝです。"   WITH_TYPES
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私の家は、こゝです。"   WITH_TYPES
 [
   [
     0,

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/without_voiced_sound_mark.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/hiragana/without_voiced_sound_mark.test
@@ -1,6 +1,7 @@
 #@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
 normalize \
-  'NormalizerNFKC("unify_iteration_mark", true)' \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
   "私の家は、こゝです。" \
   WITH_TYPES
 #@remove-substitution /"version",\s"(?:.+?)"/


### PR DESCRIPTION
The @add-substitution directive requires the version parameter to be explicitly specified in the normalize command for the substitution to work correctly. Without it, the test framework cannot properly replace the version value.

ref: https://github.com/groonga/groonga/pull/2500#discussion_r2312788153