### PR TITLE
NormalizerNFKC unify-iteration-mark: partially support Ideographic Iteration Mark (U+3005)

### DIFF
--- a/lib/normalizer.c
+++ b/lib/normalizer.c
@@ -3489,30 +3489,31 @@ grn_nfkc_normalize_unify_iteration_mark(grn_ctx *ctx,
   }
 #  undef N_KATAKANA_BYTES
   else if (current_length == 3 && current[0] == 0xe3 && current[1] == 0x80 &&
-           current[2] == 0xbb && previous_length >= 3 &&
+           (current[2] == 0x85 || current[2] == 0xbb) && previous_length >= 3 &&
            GRN_CHAR_TYPE(grn_nfkc_char_type(previous)) == GRN_CHAR_KANJI) {
     /**
+     * U+3005 IDEOGRAPHIC ITERATION MARK
      * U+303B VERTICAL IDEOGRAPHIC ITERATION MARK
      * For kanji iteration mark, we simply repeat the previous kanji character.
      * This implementation only handles simple cases as follows.
-     * - U+5404 U+303B -> U+5404 U+5404
-     *   ("CJK UNIFIED IDEOGRAPH-5404" "VERTICAL IDEOGRAPHIC ITERATION MARK" ->
+     * - U+5404 U+3005 -> U+5404 U+5404
+     *   ("CJK UNIFIED IDEOGRAPH-5404" "IDEOGRAPHIC ITERATION MARK" ->
      *    "CJK UNIFIED IDEOGRAPH-5404" "CJK UNIFIED IDEOGRAPH-5404")
-     * - U+2000B U+303B -> U+2000B U+2000B
-     *   ("CJK UNIFIED IDEOGRAPH-2000B" "VERTICAL IDEOGRAPHIC ITERATION MARK" ->
+     * - U+2000B U+3005 -> U+2000B U+2000B
+     *   ("CJK UNIFIED IDEOGRAPH-2000B" "IDEOGRAPHIC ITERATION MARK" ->
      *    "CJK UNIFIED IDEOGRAPH-2000B" "CJK UNIFIED IDEOGRAPH-2000B")
      * More complex patterns are not supported as follows.
      * - 2 or more characters are iterated:
-     *   U+90E8 U+5206 U+303B U+303B -> U+90E8 U+5206 U+90E8 U+5206
+     *   U+90E8 U+5206 U+3005 U+3005 -> U+90E8 U+5206 U+90E8 U+5206
      *   ("CJK UNIFIED IDEOGRAPH-90E8" "CJK UNIFIED IDEOGRAPH-5206"
-     *    "VERTICAL IDEOGRAPHIC ITERATION MARK"
-     *    "VERTICAL IDEOGRAPHIC ITERATION MARK" ->
+     *    "IDEOGRAPHIC ITERATION MARK"
+     *    "IDEOGRAPHIC ITERATION MARK" ->
      *    "CJK UNIFIED IDEOGRAPH-90E8" "CJK UNIFIED IDEOGRAPH-5206"
      *    "CJK UNIFIED IDEOGRAPH-90E8" "CJK UNIFIED IDEOGRAPH-5206")
      * - The same character is iterated multiple times:
-     *   U+53E4 U+303B U+303B U+7C73 -> U+53E4 U+53E4 U+53E4 U+7C73
-     *   ("CJK UNIFIED IDEOGRAPH-53E4" "VERTICAL IDEOGRAPHIC ITERATION MARK"
-     *    "VERTICAL IDEOGRAPHIC ITERATION MARK" "CJK UNIFIED IDEOGRAPH-7C73" ->
+     *   U+53E4 U+3005 U+3005 U+7C73 -> U+53E4 U+53E4 U+53E4 U+7C73
+     *   ("CJK UNIFIED IDEOGRAPH-53E4" "IDEOGRAPHIC ITERATION MARK"
+     *    "IDEOGRAPHIC ITERATION MARK" "CJK UNIFIED IDEOGRAPH-7C73" ->
      *    "CJK UNIFIED IDEOGRAPH-53E4" "CJK UNIFIED IDEOGRAPH-53E4"
      *    "CJK UNIFIED IDEOGRAPH-53E4" "CJK UNIFIED IDEOGRAPH-7C73")
      */

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/alphabet.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/alphabet.expected
@@ -1,0 +1,33 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "Ah々, I understood."   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ah々, i understood.",
+    "types": [
+      "alpha",
+      "alpha",
+      "symbol",
+      "symbol",
+      "others",
+      "alpha",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/alphabet.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/alphabet.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "Ah々, I understood." \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/cjk_unified_ideograph.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/cjk_unified_ideograph.expected
@@ -1,0 +1,51 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "CJK Unified Ideographsである、𠀋々もサポートする。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "cjk unified ideographsである、𠀋𠀋もサポートする。",
+    "types": [
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "kanji",
+      "kanji",
+      "hiragana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/cjk_unified_ideograph.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/cjk_unified_ideograph.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "CJK Unified Ideographsである、𠀋々もサポートする。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/hiragana.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/hiragana.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私の家は、こ々です。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "私の家は、こ々です。",
+    "types": [
+      "kanji",
+      "hiragana",
+      "kanji",
+      "hiragana",
+      "symbol",
+      "hiragana",
+      "symbol",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/hiragana.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/hiragana.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "私の家は、こ々です。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/kanji.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/kanji.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私は、時々こけます。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "私は、時時こけます。",
+    "types": [
+      "kanji",
+      "hiragana",
+      "symbol",
+      "kanji",
+      "kanji",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/kanji.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/kanji.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "私は、時々こけます。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/katakana.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/katakana.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私の家は、コ々です。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "私の家は、コ々です。",
+    "types": [
+      "kanji",
+      "hiragana",
+      "kanji",
+      "hiragana",
+      "symbol",
+      "katakana",
+      "symbol",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/katakana.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/ideographic/katakana.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "私の家は、コ々です。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/


### PR DESCRIPTION
GitHub: GH-2487
    
This PR partially supports for the Ideographic Iteration Mark (U+3005)
    
This implementation handles:
- U+6642 CJK UNIFIED IDEOGRAPH-6642
  U+3005 IDEOGRAPHIC ITERATION MARK ->
  U+6642 CJK UNIFIED IDEOGRAPH-6642
  U+6642 CJK UNIFIED IDEOGRAPH-6642 
    
On the other hand, it doesn't handle the following cases:
- 2 more characters are iterated:
  U+90E8 CJK UNIFIED IDEOGRAPH-90E8
  U+5206 CJK UNIFIED IDEOGRAPH-5206
  U+3005 IDEOGRAPHIC ITERATION MARK
  U+3005 IDEOGRAPHIC ITERATION MARK ->
  U+90E8 CJK UNIFIED IDEOGRAPH-90E8
  U+5206 CJK UNIFIED IDEOGRAPH-5206
  U+90E8 CJK UNIFIED IDEOGRAPH-90E8
  U+5206 CJK UNIFIED IDEOGRAPH-5206
- The same character is iterated multiple times:
  U+53E4 CJK UNIFIED IDEOGRAPH-53E4
  U+3005 IDEOGRAPHIC ITERATION MARK
  U+3005 IDEOGRAPHIC ITERATION MARK
  U+7C73 CJK UNIFIED IDEOGRAPH-7C73 ->
  U+53E4 CJK UNIFIED IDEOGRAPH-53E4
  U+53E4 CJK UNIFIED IDEOGRAPH-53E4
  U+53E4 CJK UNIFIED IDEOGRAPH-53E4
  U+7C73 CJK UNIFIED IDEOGRAPH-7C73
