### PR TITLE
NormalizerNFKC unify-iteration-mark: support Katakana Voiced Iteration Mark (U+30FE)

### DIFF
--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/alphabet.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/alphabet.expected
@@ -1,0 +1,33 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "Ahヾ, I understood."   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ahヾ, i understood.",
+    "types": [
+      "alpha",
+      "alpha",
+      "katakana",
+      "symbol",
+      "others",
+      "alpha",
+      "others",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "alpha",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/alphabet.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/alphabet.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "Ahヾ, I understood." \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/hiragana.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/hiragana.expected
@@ -1,0 +1,24 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "これは、たヾです。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "これは、たヾです。",
+    "types": [
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "hiragana",
+      "katakana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/hiragana.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/hiragana.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "これは、たヾです。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/kanji.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/kanji.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "私は、時ヾこけます。"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "私は、時ヾこけます。",
+    "types": [
+      "kanji",
+      "hiragana",
+      "symbol",
+      "kanji",
+      "katakana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "hiragana",
+      "symbol",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/kanji.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/kanji.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "私は、時ヾこけます。" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_borders.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_borders.expected
@@ -1,0 +1,25 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "オヾッヾナヾノヾマヾ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "オヾッヾナヾノヾマヾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_borders.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_borders.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "オヾッヾナヾノヾマヾ" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ha_series.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ha_series.expected
@@ -1,0 +1,45 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "ハヾバヾパヾヒヾビヾピヾフヾブヾプヾヘヾベヾペヾホヾボヾポヾ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "ハバババパヾヒビビビピヾフブブブプヾヘベベベペヾホボボボポヾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ha_series.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ha_series.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "ハヾバヾパヾヒヾビヾピヾフヾブヾプヾヘヾベヾペヾホヾボヾポヾ" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ka_series.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ka_series.expected
@@ -1,0 +1,35 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "カヾガヾキヾギヾクヾグヾケヾゲヾコヾゴヾ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "カガガガキギギギクグググケゲゲゲコゴゴゴ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ka_series.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ka_series.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "カヾガヾキヾギヾクヾグヾケヾゲヾコヾゴヾ" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_sa_series.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_sa_series.expected
@@ -1,0 +1,35 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "サヾザヾシヾジヾスヾズヾセヾゼヾソヾゾヾ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "サザザザシジジジスズズズセゼゼゼソゾゾゾ",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_sa_series.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_sa_series.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "サヾザヾシヾジヾスヾズヾセヾゼヾソヾゾヾ" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ta_series.expected
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ta_series.expected
@@ -1,0 +1,35 @@
+normalize   'NormalizerNFKC("unify_iteration_mark", true,                   "version", "NFKC_VERSION")'   "タヾダヾチヾヂヾツヾヅヾテヾデヾトヾドヾ"   WITH_TYPES
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "タダダダチヂヂヂツヅヅヅテデデデトドドド",
+    "types": [
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "katakana",
+      "null"
+    ],
+    "checks": []
+  }
+]

--- a/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ta_series.test
+++ b/test/command/suite/normalizers/nfkc/unify_iteration_mark/katakana_voiced/katakana_ta_series.test
@@ -1,0 +1,7 @@
+#@add-substitution /"version",\s"(?:.+?)"/ "\"version\", \"#{ENV['NFKC'] || '10.0.0'}\"" "\"version\", \"NFKC_VERSION\""
+normalize \
+  'NormalizerNFKC("unify_iteration_mark", true, \
+                  "version", "NFKC_VERSION")' \
+  "タヾダヾチヾヂヾツヾヅヾテヾデヾトヾドヾ" \
+  WITH_TYPES
+#@remove-substitution /"version",\s"(?:.+?)"/


### PR DESCRIPTION
GitHub: GH-2487

This PR supports the Katakana Voiced Iteration Mark (U+30FE).

This implementation handles the following cases:
- U+30D6 KATAKANA LETTER BU
  U+30FE KATAKANA VOICED ITERATION MARK ->
  U+30D6 KATAKANA LETTER BU
  U+30D6 KATAKANA LETTER BU
- U+30D5 KATAKANA LETTER FU
  U+30FE KATAKANA VOICED ITERATION MARK
  U+30AD KATAKANA LETTER KI ->
  U+30D5 KATAKANA LETTER FU
  U+30D6 KATAKANA LETTER BU
  U+30AD KATAKANA LETTER KI

## We don't handle the following cases

### No-voicing-mapping case

For characters without a standard voiced mark mapping, normalization would produce uncommon forms.

- U+30AA KATAKANA LETTER O
  U+30FE KATAKANA VOICED ITERATION MARK ->
  U+30AA KATAKANA LETTER O
  U+30FE KATAKANA VOICED ITERATION MARK

### Semi-voiced conflict case

U+30FE implies repeating with a voiced mark, but PO uses a semi-voiced mark. There is no consistent rule (keep semi-voiced or switch to voiced). To avoid surprising rewrites, we leave it unchanged.

- U+30DD KATAKANA LETTER PO
  U+30FE KATAKANA VOICED ITERATION MARK ->
  U+30DD KATAKANA LETTER PO
  U+30FE KATAKANA VOICED ITERATION MARK