### PR TITLE
doc install amazonlinux: Remove the install procudere of groonga-token-mecab package

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/install/amazon_linux.po
+++ b/doc/locale/ja/LC_MESSAGES/install/amazon_linux.po
@@ -28,11 +28,8 @@ msgstr ""
 msgid "Install:"
 msgstr "インストール:"
 
-msgid "If you want to use `MeCab <https://taku910.github.io/mecab/>`_ as a tokenizer, install groonga-tokenizer-mecab package."
-msgstr "`MeCab <https://taku910.github.io/mecab/>`_ をトークナイザーとして使いたいときは、groonga-tokenizer-mecabパッケージをインストールしてください。"
-
-msgid "Install groonga-tokenizer-mecab package:"
-msgstr "groonga-tokenizer-mecabパッケージのインストール:"
+msgid "You can't install groonga-tokenizer-mecab package in Amazon Linux 2023. Because Amazon Linux 2023 doesn't provide `MeCab <https://taku910.github.io/mecab/>`_ package."
+msgstr "Amazon Linux 2023 では、groonga-tokenizer-mecabパッケージはインストールできません。 Amazon Linux 2023が、 `MeCab <https://taku910.github.io/mecab/>`_ パッケージを提供していないためです。"
 
 msgid "There is a package that provides MySQL compatible normalizer as a Groonga plugin. If you want to use that one, install groonga-normalizer-mysql package."
 msgstr "MySQL互換のノーマライザーをGroongaのプラグインとして提供するパッケージがあります。MySQL互換のノーマライザーを使うには `groonga-normalizer-mysql <https://github.com/groonga/groonga-normalizer-mysql>`_ パッケージをインストールしてください。"

--- a/doc/source/install/amazon_linux.rst
+++ b/doc/source/install/amazon_linux.rst
@@ -19,14 +19,8 @@ Install:
 
 .. include:: server-use.rst
 
-If you want to use `MeCab <https://taku910.github.io/mecab/>`_ as a
-tokenizer, install groonga-tokenizer-mecab package.
-
-Install groonga-tokenizer-mecab package:
-
-.. code-block:: console
-
-   $ sudo dnf install -y groonga-tokenizer-mecab
+You can't install groonga-tokenizer-mecab package in Amazon Linux 2023.
+Because Amazon Linux 2023 doesn't provide `MeCab <https://taku910.github.io/mecab/>`_ package.
 
 There is a package that provides MySQL compatible normalizer as a
 Groonga plugin. If you want to use that one, install


### PR DESCRIPTION
Because we don't provide the groonga-token-mecab package in Amazon Linux 2023.