### PR TITLE
token-filter-stem: add support for non ASCII alphabets

### DIFF
--- a/include/groonga/nfkc.h
+++ b/include/groonga/nfkc.h
@@ -1,5 +1,6 @@
 /*
-  Copyright(C) 2009-2016 Brazil
+  Copyright (C) 2009-2016  Brazil
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -25,6 +26,7 @@ extern "C" {
 #endif
 
 GRN_API grn_char_type grn_nfkc_char_type(const unsigned char *utf8);
+GRN_API grn_char_type grn_nfkc_latest_char_type(const unsigned char *utf8);
 
 #ifdef __cplusplus
 }

--- a/lib/nfkc.c
+++ b/lib/nfkc.c
@@ -30,6 +30,13 @@ grn_nfkc_char_type(const unsigned char *utf8)
   return grn_nfkc50_char_type(utf8);
 }
 
+grn_char_type
+grn_nfkc_latest_char_type(const unsigned char *utf8)
+{
+  /* This must be updated when we add the latest Unicode support. */
+  return grn_nfkc160_char_type(utf8);
+}
+
 const char *
 grn_nfkc_decompose(const unsigned char *utf8)
 {

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -66,12 +66,17 @@ if [ "${run_test}" = "yes" ]; then
       ;;
   esac
 
-  if [ "${os}-${version}" == "almalinux-10" ]; then
+  if [ "${os}-${version}" = "almalinux-10" ]; then
     # Float32 value format is different.
     rm command/suite/tokenizers/document_vector_bm25/alphabet.test
     rm command/suite/tokenizers/document_vector_bm25/reindex.test
     rm command/suite/tokenizers/document_vector_bm25/token_column.test
     rm command/suite/tokenizers/document_vector_bm25/token_column_different_lexicon.test
+  fi
+
+  if [ "$(rpm --query libstemmer --queryformat '%{version}')" -eq 0 ]; then
+    # Arabic isn't supported.
+    rm command/suite/token_filters/stem/arabic.test
   fi
 
   ${DNF} install -y \

--- a/test/command/suite/token_filters/stem/arabic.expected
+++ b/test/command/suite/token_filters/stem/arabic.expected
@@ -1,0 +1,28 @@
+plugin_register token_filters/stem
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenNgram   --normalizer 'NormalizerNFKC("version", "16.0.0")'   --token_filters 'TokenFilterStem("algorithm", "arabic")'
+[[0,0.0,0.0],true]
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+[[0,0.0,0.0],true]
+table_tokenize Terms "الكتاب مفيد" --mode ADD
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "كتاب",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "مفيد",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/token_filters/stem/arabic.test
+++ b/test/command/suite/token_filters/stem/arabic.test
@@ -1,0 +1,11 @@
+#@on-error omit
+plugin_register token_filters/stem
+#@on-error default
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenNgram \
+  --normalizer 'NormalizerNFKC("version", "16.0.0")' \
+  --token_filters 'TokenFilterStem("algorithm", "arabic")'
+column_create Terms is_stop_word COLUMN_SCALAR Bool
+
+table_tokenize Terms "الكتاب مفيد" --mode ADD


### PR DESCRIPTION
GitHub: fix GH-2539

See also: https://github.com/pgroonga/pgroonga/discussions/781

Example: Arabic.

Reported by Tsai, Xing Wei. Thanks!!!