### PR TITLE
Bundle base64 implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1894,6 +1894,72 @@ else()
   set(GRN_WITH_CURL FALSE)
 endif()
 
+set(GRN_BASE64_BUNDLED_VERSION "0.5.2")
+set(GRN_BASE64_BUNDLED_SHA256
+    "723a0f9f4cf44cf79e97bcc315ec8f85e52eb104c8882942c3f2fba95acc080d")
+set(GRN_WITH_BASE64
+    "auto"
+    CACHE STRING "Use aklomp/base64 for ShortBinary/Binary/LargeBinary.")
+set(GRN_WITH_BASE64_BUNDLED FALSE)
+if(NOT "${GRN_WITH_BASE64}" STREQUAL "no")
+  if("${GRN_WITH_BASE64}" STREQUAL "bundled")
+    set(base64_FOUND FALSE)
+  else()
+    if("${GRN_WITH_BASE64}" STREQUAL "system")
+      find_package(base64 REQUIRED)
+    else()
+      find_package(base64)
+    endif()
+  endif()
+  if(base64_FOUND)
+    set(GRN_WITH_BASE64 TRUE)
+    target_link_libraries(grn_dependencies INTERFACE aklomp::base64)
+    message(STATUS "base64: system")
+  elseif(NOT FETCHCONTENT_FULLY_DISCONNECTED)
+    # FETCHCONTENT_FULLY_DISCONNECTED isn't for disabling network
+    # access but deb uses it...
+
+    # We need to use function to create a variable scope
+    function(grn_build_base64)
+      set(BASE64_SOURCE_BASE_NAME
+          "base64-${GRN_USEARCH_BUNDLED_VERSION}.tar.gz")
+      set(BASE64_SOURCE_LOCAL_PATH
+          "${CMAKE_CURRENT_SOURCE_DIR}/vendor/${BASE64_SOURCE_BASE_NAME}")
+      if(EXISTS ${BASE64_SOURCE_LOCAL_PATH})
+        set(BASE64_SOURCE_URL ${BASE64_SOURCE_LOCAL_PATH})
+      else()
+        set(BASE64_SOURCE_URL
+            "https://github.com/aklomp/base64/archive/refs/tags")
+        string(APPEND BASE64_SOURCE_URL
+               "/v${GRN_BASE64_BUNDLED_VERSION}.tar.gz")
+      endif()
+      fetchcontent_declare(
+        base64
+        ${GRN_FETCH_CONTENT_COMMON_OPTIONS}
+        URL ${BASE64_SOURCE_URL}
+        URL_HASH "SHA256=${GRN_BASE64_BUNDLED_SHA256}")
+      grn_prepare_fetchcontent()
+      set(BASE64_WERROR OFF)
+      fetchcontent_makeavailable(base64)
+      if(CMAKE_VERSION VERSION_LESS 3.28)
+        set_property(DIRECTORY ${base64_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL
+                                                             TRUE)
+      endif()
+      install(FILES "${base64_SOURCE_DIR}/LICENSE"
+                    "${base64_SOURCE_DIR}/README.md"
+              DESTINATION "${GRN_DATA_DIR}/base64")
+    endfunction()
+    grn_build_base64()
+    target_link_libraries(grn_dependencies INTERFACE base64)
+    set(GRN_WITH_BASE64_BUNDLED TRUE)
+    message(STATUS "base64: bundled")
+  else()
+    set(GRN_WITH_BASE64 FALSE)
+  endif()
+else()
+  set(GRN_WITH_BASE64 FALSE)
+endif()
+
 find_program(
   RUBY
   NAMES "ruby"

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -91,6 +91,7 @@
 
 /* packages */
 #cmakedefine GRN_WITH_APACHE_ARROW
+#cmakedefine GRN_WITH_BASE64
 #cmakedefine GRN_WITH_BENCHMARK
 #cmakedefine GRN_WITH_BLOSC
 #cmakedefine GRN_WITH_CURL

--- a/packages/debian/libgroonga0.install
+++ b/packages/debian/libgroonga0.install
@@ -16,6 +16,7 @@ usr/lib/*/groonga/scripts/*
 usr/lib/*/libgroonga*.so.*
 usr/share/groonga/COPYING
 usr/share/groonga/README.md
+usr/share/groonga/base64/*
 usr/share/groonga/c-blosc2/*
 usr/share/groonga/groonga-log/*
 usr/share/groonga/llama.cpp/*

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -382,6 +382,7 @@ exit 0
 %{_libdir}/groonga/scripts/ruby/logger/*.rb
 %{_libdir}/groonga/scripts/ruby/query_logger/*.rb
 %{_datadir}/groonga/COPYING
+%{_datadir}/groonga/base64/
 %{_datadir}/groonga/c-blosc2/
 %{_datadir}/groonga/groonga-log/
 %{_datadir}/groonga/html/

--- a/vendor/download.rb
+++ b/vendor/download.rb
@@ -42,6 +42,7 @@ def git_clone_archive(url, tag, archive_path)
 end
 
 all_targets = [
+  "base64",
   "blosc",
   "croaring",
   "h3",
@@ -63,6 +64,11 @@ end
 cmakelists = File.read(File.join(__dir__, "..", "CMakeLists.txt"))
 targets.each do |target|
   case target
+  when "base64"
+    version = cmakelists[/set\(GRN_BASE64_BUNDLED_VERSION \"(.+)"\)/, 1]
+    url = "https://github.com/aklomp/base64/archive/refs/tags/"
+    url << "v#{version}.tar.gz"
+    download(url, "base64-#{version}.tar.gz")
   when "blosc"
     version = cmakelists[/set\(GRN_BLOSC_BUNDLED_VERSION \"(.+)"\)/, 1]
     url = "https://github.com/Blosc/c-blosc2/archive/refs/tags/"


### PR DESCRIPTION
https://github.com/aklomp/base64

Because it looks faster. It uses SIMD if possible.

Apache Arrow bundles another base64 implementation but it will be slower than it. Because this is a simple base64 implementation.

(I haven't measured them. :p)