### PR TITLE
Add ShortBinary/Binary/LargeBinary

### DIFF
--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2018  Brazil
-  Copyright (C) 2018-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -1073,6 +1073,9 @@ typedef enum {
   GRN_DB_WGS84_GEO_POINT,
   GRN_DB_FLOAT32,
   GRN_DB_BFLOAT16,
+  GRN_DB_SHORT_BINARY,
+  GRN_DB_BINARY,
+  GRN_DB_LONG_BINARY,
 } grn_builtin_type;
 
 typedef enum {
@@ -2772,6 +2775,34 @@ grn_ctx_recv_handler_set(grn_ctx *,
 #define GRN_TEXT_EQUAL_CSTRING(bulk, string)                                   \
   (GRN_TEXT_LEN(bulk) == strlen(string) &&                                     \
    memcmp(GRN_TEXT_VALUE(bulk), string, GRN_TEXT_LEN(bulk)) == 0)
+
+#define GRN_BINARY_INIT(obj, flags)                                            \
+  GRN_VALUE_VAR_SIZE_INIT(obj, flags, GRN_DB_BINARY)
+#define GRN_SHORT_BINARY_INIT(obj, flags)                                      \
+  GRN_VALUE_VAR_SIZE_INIT(obj, flags, GRN_DB_SHORT_BINARY)
+#define GRN_LONG_BINARY_INIT(obj, flags)                                       \
+  GRN_VALUE_VAR_SIZE_INIT(obj, flags, GRN_DB_LONG_BINARY)
+#define GRN_BINARY_SET_REF(obj, data, len)                                     \
+  do {                                                                         \
+    (obj)->u.b.head = (char *)(data);                                          \
+    (obj)->u.b.curr = (char *)(data) + (len);                                  \
+  } while (0)
+#define GRN_BINARY_SET(ctx, obj, data, len)                                    \
+  do {                                                                         \
+    if ((obj)->header.impl_flags & GRN_OBJ_REFER) {                            \
+      GRN_BINARY_SET_REF((obj), (data), (len));                                \
+    } else {                                                                   \
+      grn_bulk_write_from((ctx),                                               \
+                          (obj),                                               \
+                          (const char *)(data),                                \
+                          0,                                                   \
+                          (unsigned int)(len));                                \
+    }                                                                          \
+  } while (0)
+#define GRN_BINARY_PUT(ctx, obj, data, len)                                    \
+  grn_bulk_write((ctx), (obj), (const char *)(data), (unsigned int)(len))
+#define GRN_BINARY_VALUE(obj) ((const uint8_t *)GRN_BULK_HEAD(obj))
+#define GRN_BINARY_LEN(obj)   GRN_BULK_VSIZE(obj)
 
 #define GRN_BOOL_INIT(obj, flags)                                              \
   GRN_VALUE_FIX_SIZE_INIT(obj, flags, GRN_DB_BOOL)

--- a/include/groonga/obj.h
+++ b/include/groonga/obj.h
@@ -52,6 +52,8 @@ grn_obj_is_bulk(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_bulk(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
+grn_obj_is_binary_family_bulk(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
 grn_obj_is_number_family_bulk(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_maybe_record_bulk(grn_ctx *ctx, grn_obj *obj);
@@ -59,6 +61,8 @@ GRN_API bool
 grn_obj_is_vector(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_vector(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
+grn_obj_is_binary_family_vector(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_number_family_vector(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
@@ -94,6 +98,8 @@ grn_obj_is_scalar_column(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_scalar_column(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
+grn_obj_is_binary_family_scalar_column(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
 grn_obj_is_number_family_scalar_column(grn_ctx *ctx, grn_obj *obj);
 /**
  * \brief Check whether the specified object is a vector column or not.
@@ -107,6 +113,8 @@ GRN_API bool
 grn_obj_is_vector_column(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_vector_column(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
+grn_obj_is_binary_family_vector_column(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_weight_vector_column(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
@@ -157,6 +165,8 @@ grn_obj_is_scalar_accessor(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
+grn_obj_is_binary_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
 grn_obj_is_number_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_vector_accessor(grn_ctx *ctx, grn_obj *obj);
@@ -164,6 +174,8 @@ GRN_API bool
 grn_obj_is_type(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_text_family_type(grn_ctx *ctx, grn_obj *obj);
+GRN_API bool
+grn_obj_is_binary_family_type(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_proc(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2018  Brazil
-  Copyright (C) 2018-2023  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -166,6 +166,12 @@ grn_output_str(grn_ctx *ctx,
                grn_content_type output_type,
                const char *value,
                size_t value_len);
+GRN_API void
+grn_output_binary(grn_ctx *ctx,
+                  grn_obj *outbuf,
+                  grn_content_type output_type,
+                  const uint8_t *value,
+                  size_t value_len);
 GRN_API void
 grn_output_bool(grn_ctx *ctx,
                 grn_obj *outbuf,

--- a/include/groonga/type.h
+++ b/include/groonga/type.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2016  Brazil
-  Copyright (C) 2020-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2020-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -37,6 +37,8 @@ GRN_API bool
 grn_type_id_is_float_family(grn_ctx *ctx, grn_id id);
 GRN_API bool
 grn_type_id_is_text_family(grn_ctx *ctx, grn_id id);
+GRN_API bool
+grn_type_id_is_binary_family(grn_ctx *ctx, grn_id id);
 GRN_API bool
 grn_type_id_is_compatible(grn_ctx *ctx, grn_id id1, grn_id id2);
 GRN_API size_t

--- a/lib/db.c
+++ b/lib/db.c
@@ -13991,6 +13991,9 @@ grn_obj_reinit(grn_ctx *ctx, grn_obj *obj, grn_id domain, uint8_t flags)
     case GRN_DB_SHORT_TEXT:
     case GRN_DB_TEXT:
     case GRN_DB_LONG_TEXT:
+    case GRN_DB_SHORT_BINARY:
+    case GRN_DB_BINARY:
+    case GRN_DB_LONG_BINARY:
       if (flags & GRN_OBJ_VECTOR) {
         if (obj->header.type != GRN_VECTOR) {
           grn_bulk_fin(ctx, obj);
@@ -15010,6 +15013,22 @@ grn_db_init_builtin_types(grn_ctx *ctx)
                 GRN_TYPE_BFLOAT16_FLAGS,
                 GRN_TYPE_BFLOAT16_SIZE);
   if (!obj || DB_OBJ(obj)->id != GRN_DB_BFLOAT16) {
+    return GRN_FILE_CORRUPT;
+  }
+  obj = deftype(ctx,
+                "ShortBinary",
+                GRN_OBJ_KEY_VAR_SIZE,
+                GRN_TYPE_SHORT_BINARY_SIZE);
+  if (!obj || DB_OBJ(obj)->id != GRN_DB_SHORT_BINARY) {
+    return GRN_FILE_CORRUPT;
+  }
+  obj = deftype(ctx, "Binary", GRN_OBJ_KEY_VAR_SIZE, GRN_TYPE_BINARY_SIZE);
+  if (!obj || DB_OBJ(obj)->id != GRN_DB_BINARY) {
+    return GRN_FILE_CORRUPT;
+  }
+  obj =
+    deftype(ctx, "LongBinary", GRN_OBJ_KEY_VAR_SIZE, GRN_TYPE_LONG_BINARY_SIZE);
+  if (!obj || DB_OBJ(obj)->id != GRN_DB_LONG_BINARY) {
     return GRN_FILE_CORRUPT;
   }
   for (id = grn_db_curr_id(ctx, db) + 1; id < GRN_DB_MECAB; id++) {

--- a/lib/grn_arrow.h
+++ b/lib/grn_arrow.h
@@ -91,6 +91,11 @@ grn_arrow_stream_writer_add_column_text_dictionary(
   const char *value,
   size_t value_length);
 grn_rc
+grn_arrow_stream_writer_add_column_binary(grn_ctx *ctx,
+                                          grn_arrow_stream_writer *writer,
+                                          const uint8_t *value,
+                                          size_t value_length);
+grn_rc
 grn_arrow_stream_writer_add_column_int8(grn_ctx *ctx,
                                         grn_arrow_stream_writer *writer,
                                         int8_t value);

--- a/lib/grn_type.h
+++ b/lib/grn_type.h
@@ -1,5 +1,5 @@
 /*
-  Copyright(C) 2020  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2020-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -27,6 +27,9 @@ extern "C" {
 #define GRN_TYPE_SHORT_TEXT_SIZE GRN_TABLE_MAX_KEY_SIZE
 #define GRN_TYPE_TEXT_SIZE (1U << 16)
 #define GRN_TYPE_LONG_TEXT_SIZE (1U << 31)
+#define GRN_TYPE_SHORT_BINARY_SIZE GRN_TABLE_MAX_KEY_SIZE
+#define GRN_TYPE_BINARY_SIZE (1U << 16)
+#define GRN_TYPE_LONG_BINARY_SIZE (1U << 31)
 
 grn_obj *
 grn_type_create_internal(grn_ctx *ctx,

--- a/lib/obj.c
+++ b/lib/obj.c
@@ -176,7 +176,17 @@ grn_obj_is_text_family_bulk(grn_ctx *ctx, grn_obj *obj)
     return false;
   }
 
-  return GRN_TYPE_IS_TEXT_FAMILY(obj->header.domain);
+  return grn_type_id_is_text_family(ctx, obj->header.domain);
+}
+
+bool
+grn_obj_is_binary_family_bulk(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_bulk(ctx, obj)) {
+    return false;
+  }
+
+  return grn_type_id_is_binary_family(ctx, obj->header.domain);
 }
 
 bool
@@ -217,6 +227,16 @@ grn_obj_is_text_family_vector(grn_ctx *ctx, grn_obj *obj)
   }
 
   return grn_type_id_is_text_family(ctx, obj->header.domain);
+}
+
+bool
+grn_obj_is_binary_family_vector(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_vector(ctx, obj)) {
+    return false;
+  }
+
+  return grn_type_id_is_binary_family(ctx, obj->header.domain);
 }
 
 bool
@@ -507,6 +527,16 @@ grn_obj_is_text_family_scalar_column(grn_ctx *ctx, grn_obj *obj)
 }
 
 bool
+grn_obj_is_binary_family_scalar_column(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_scalar_column(ctx, obj)) {
+    return false;
+  }
+
+  return grn_type_id_is_binary_family(ctx, grn_obj_get_range(ctx, obj));
+}
+
+bool
 grn_obj_is_number_family_scalar_column(grn_ctx *ctx, grn_obj *obj)
 {
   if (!grn_obj_is_scalar_column(ctx, obj)) {
@@ -536,6 +566,16 @@ grn_obj_is_text_family_vector_column(grn_ctx *ctx, grn_obj *obj)
   }
 
   return grn_type_id_is_text_family(ctx, grn_obj_get_range(ctx, obj));
+}
+
+bool
+grn_obj_is_binary_family_vector_column(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_vector_column(ctx, obj)) {
+    return false;
+  }
+
+  return grn_type_id_is_binary_family(ctx, grn_obj_get_range(ctx, obj));
 }
 
 bool
@@ -897,6 +937,40 @@ grn_obj_is_text_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj)
 }
 
 bool
+grn_obj_is_binary_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj)
+{
+  grn_accessor *accessor;
+
+  if (!grn_obj_is_accessor(ctx, obj)) {
+    return false;
+  }
+
+  accessor = (grn_accessor *)obj;
+  while (accessor->next) {
+    accessor = accessor->next;
+  }
+
+  switch (accessor->action) {
+  case GRN_ACCESSOR_GET_ID:
+  case GRN_ACCESSOR_GET_SCORE:
+  case GRN_ACCESSOR_GET_NSUBRECS:
+  case GRN_ACCESSOR_GET_MAX:
+  case GRN_ACCESSOR_GET_MIN:
+  case GRN_ACCESSOR_GET_SUM:
+  case GRN_ACCESSOR_GET_AVG:
+  case GRN_ACCESSOR_GET_MEAN:
+    return false;
+  case GRN_ACCESSOR_GET_VALUE:
+    return grn_type_id_is_binary_family(ctx,
+                                        grn_obj_get_range(ctx, accessor->obj));
+  case GRN_ACCESSOR_GET_COLUMN_VALUE:
+    return grn_obj_is_binary_family_scalar_column(ctx, accessor->obj);
+  default:
+    return false;
+  }
+}
+
+bool
 grn_obj_is_number_family_scalar_accessor(grn_ctx *ctx, grn_obj *obj)
 {
   grn_accessor *accessor;
@@ -969,7 +1043,17 @@ grn_obj_is_text_family_type(grn_ctx *ctx, grn_obj *obj)
     return false;
   }
 
-  return GRN_TYPE_IS_TEXT_FAMILY(grn_obj_id(ctx, obj));
+  return grn_type_id_is_text_family(ctx, grn_obj_id(ctx, obj));
+}
+
+bool
+grn_obj_is_binary_family_type(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_type(ctx, obj)) {
+    return false;
+  }
+
+  return grn_type_id_is_binary_family(ctx, grn_obj_id(ctx, obj));
 }
 
 bool

--- a/lib/store.c
+++ b/lib/store.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2018  Brazil
-  Copyright (C) 2020-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2020-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -5483,6 +5483,9 @@ grn_ja_cast_value_scalar(
   default:
     if (grn_type_id_is_text_family(ctx, range_id) &&
         grn_type_id_is_text_family(ctx, value->header.domain)) {
+      /* do nothing */
+    } else if (grn_type_id_is_binary_family(ctx, range_id) &&
+               grn_type_id_is_binary_family(ctx, value->header.domain)) {
       /* do nothing */
     } else {
       if (range_id != value->header.domain) {

--- a/lib/str.c
+++ b/lib/str.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2017  Brazil
-  Copyright (C) 2018-2023  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -3309,6 +3309,13 @@ grn_text_otoj(grn_ctx *ctx, grn_obj *bulk, grn_obj *obj, grn_obj_format *format)
       } else {
         GRN_TEXT_PUTS(ctx, bulk, "\"\"");
       }
+      break;
+    case GRN_DB_SHORT_BINARY:
+    case GRN_DB_BINARY:
+    case GRN_DB_LONG_BINARY:
+      GRN_TEXT_PUTC(ctx, bulk, '"');
+      grn_obj_cast(ctx, obj, bulk, false);
+      GRN_TEXT_PUTC(ctx, bulk, '"');
       break;
     default:
       if (format) {

--- a/lib/type.c
+++ b/lib/type.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2016  Brazil
-  Copyright (C) 2020-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2020-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -63,6 +63,12 @@ grn_type_id_to_string_builtin(grn_ctx *ctx, grn_id id)
     return "Float32";
   case GRN_DB_BFLOAT16:
     return "BFloat16";
+  case GRN_DB_SHORT_BINARY:
+    return "ShortBinary";
+  case GRN_DB_BINARY:
+    return "Binary";
+  case GRN_DB_LONG_BINARY:
+    return "LongBinary";
   default:
     return "not a builtin type";
   }
@@ -98,6 +104,12 @@ bool
 grn_type_id_is_text_family(grn_ctx *ctx, grn_id id)
 {
   return GRN_DB_SHORT_TEXT <= id && id <= GRN_DB_LONG_TEXT;
+}
+
+bool
+grn_type_id_is_binary_family(grn_ctx *ctx, grn_id id)
+{
+  return GRN_DB_SHORT_BINARY <= id && id <= GRN_DB_LONG_BINARY;
 }
 
 bool
@@ -156,6 +168,12 @@ grn_type_id_size(grn_ctx *ctx, grn_id id)
   case GRN_DB_TOKYO_GEO_POINT:
   case GRN_DB_WGS84_GEO_POINT:
     return sizeof(grn_geo_point);
+  case GRN_DB_SHORT_BINARY:
+    return GRN_TYPE_SHORT_BINARY_SIZE;
+  case GRN_DB_BINARY:
+    return GRN_TYPE_BINARY_SIZE;
+  case GRN_DB_LONG_BINARY:
+    return GRN_TYPE_LONG_BINARY_SIZE;
   default:
     {
       GRN_API_ENTER;

--- a/test/command/suite/column_create/path/existent.expected
+++ b/test/command/suite/column_create/path/existent.expected
@@ -314,6 +314,54 @@ object_list
       "path": null,
       "size": 2
     },
+    "ShortBinary": {
+      "id": 21,
+      "name": "ShortBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 4096
+    },
+    "Binary": {
+      "id": 22,
+      "name": "Binary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 65536
+    },
+    "LongBinary": {
+      "id": 23,
+      "name": "LongBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 2147483648
+    },
     "TokenMecab": {
       "id": 64,
       "name": "TokenMecab",

--- a/test/command/suite/load/short_binary/json.expected
+++ b/test/command/suite/load/short_binary/json.expected
@@ -1,0 +1,47 @@
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data content COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"content": "AAECAw=="}
+]
+[[0,0.0,0.0],1]
+select Data
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        1
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "content",
+          "ShortBinary"
+        ]
+      ],
+      [
+        1,
+        "AAECAw=="
+      ]
+    ]
+  ]
+]
+dump
+table_create Data TABLE_NO_KEY
+column_create Data content COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+["_id","content"],
+[1,"AAECAw=="]
+]

--- a/test/command/suite/load/short_binary/json.test
+++ b/test/command/suite/load/short_binary/json.test
@@ -1,0 +1,12 @@
+table_create Data TABLE_NO_KEY
+column_create Data content COLUMN_SCALAR ShortBinary
+
+# "AAECAw==" == base64_encode("\x00\x01\x02\x02")
+load --table Data
+[
+{"content": "AAECAw=="}
+]
+
+select Data
+
+dump

--- a/test/command/suite/object_list/full.expected
+++ b/test/command/suite/object_list/full.expected
@@ -332,6 +332,54 @@ object_list
       "path": null,
       "size": 2
     },
+    "ShortBinary": {
+      "id": 21,
+      "name": "ShortBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 4096
+    },
+    "Binary": {
+      "id": 22,
+      "name": "Binary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 65536
+    },
+    "LongBinary": {
+      "id": 23,
+      "name": "LongBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 2147483648
+    },
     "TokenMecab": {
       "id": 64,
       "name": "TokenMecab",

--- a/test/command/suite/table_create/path/existent.expected
+++ b/test/command/suite/table_create/path/existent.expected
@@ -312,6 +312,54 @@ object_list
       "path": null,
       "size": 2
     },
+    "ShortBinary": {
+      "id": 21,
+      "name": "ShortBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 4096
+    },
+    "Binary": {
+      "id": 22,
+      "name": "Binary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 65536
+    },
+    "LongBinary": {
+      "id": 23,
+      "name": "LongBinary",
+      "opened": false,
+      "n_elements": 4,
+      "type": {
+        "id": 32,
+        "name": "type"
+      },
+      "flags": {
+        "value": 16384,
+        "names": "KEY_VAR_SIZE"
+      },
+      "path": null,
+      "size": 2147483648
+    },
     "TokenMecab": {
       "id": 64,
       "name": "TokenMecab",


### PR DESCRIPTION
This is an experimental feature.

* `load`, `dump` and `select --output_columns` are only supported.
* Apache Arrow input isn't tested. It may not work.
  * We need to improve grntest for Apache Arrow input with binary value.
* MessagePack output isn't tested. It may not work.
* XML output isn't tested. It may not work.
* TSV output isn't tested. It may not work.
* Use base64 in JSON.
* Use base64 in grn_inspect().
* Use Apache Arrow's base64 implementation as fallback.