### PR TITLE
ci package: Get the repository name from `GITHUB_REPOSITORY`

### DIFF
--- a/packages/Rakefile
+++ b/packages/Rakefile
@@ -107,7 +107,7 @@ class GroongaPackageTask < PackagesGroongaOrgPackageTask
   end
 
   def github_repository
-    "groonga/groonga"
+    ENV["GITHUB_REPOSITORY"] || "groonga/groonga"
   end
 
   def github_actions_workflow_file_name(target_namespace, target)


### PR DESCRIPTION
In CI, it tries to push the Docker image to `groonga/groonga` even for a forked repository, and it fails.
By using `ENV['GITHUB_REPOSITORY']`, it will push the Docker image to the correct repository.