### PR TITLE
cmake: suppress declaration-after-statement warning for BASE64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1966,6 +1966,11 @@ if(NOT "${GRN_WITH_BASE64}" STREQUAL "no")
         URL ${BASE64_SOURCE_URL}
         URL_HASH "SHA256=${GRN_BASE64_BUNDLED_SHA256}")
       grn_prepare_fetchcontent()
+      if(GRN_C_COMPILER_GNU_LIKE)
+        string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-declaration-after-statement")
+        string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
+               " -Wno-declaration-after-statement")
+      endif()
       set(BASE64_WERROR OFF)
       fetchcontent_makeavailable(base64)
       if(CMAKE_VERSION VERSION_LESS 3.28)


### PR DESCRIPTION
### Issue

We got the following error when we built Groonga with MariaDB.

```
/home/runner/work/mroonga/mroonga/mariadb.build/_deps/base64-src/lib/arch/generic/64/enc_loop.c: In function ‘enc_loop_generic_64_inner’:
/home/runner/work/mroonga/mroonga/mariadb.build/_deps/base64-src/lib/arch/generic/64/enc_loop.c:15:9: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
   15 |         const size_t index0 = (src >> 52) & 0xFFFU;
      |         ^~~~~
```

### Cause

When building Groonga with MariaDB, the bundled
base64 triggers `-Werror`.

### Solution

Upstream base64 doesn't use C99 or earlier standardeven. It is unlikely to change this style, so we suppress the warning by explicitly passing -Wno-declaration-after-statement in Debug and RelWithDebInfo builds.