### PR TITLE
cmake llama.cpp: suppress the `discarded-qualifiers` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1700,27 +1700,27 @@ if(NOT "${GRN_WITH_LLAMA_CPP}" STREQUAL "no")
         string(APPEND CMAKE_C_FLAGS " /wd4996")
         string(APPEND CMAKE_CXX_FLAGS " /wd4996")
       elseif(GRN_C_COMPILER_GNU_LIKE)
-        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+        if(CMAKE_C_COMPILER_ID STREQUAL GNU)
+          # TODO: Remove this suppression if upstream PR is merged.
+          # https://github.com/ggml-org/llama.cpp/pull/16573
+          string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-discarded-qualifiers")
+          string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
+                 " -Wno-discarded-qualifiers")
+        elseif(CMAKE_C_COMPILER_ID STREQUAL Clang)
           # This is for old Clang...?
           #
           # https://github.com/ggml-org/llama.cpp/issues/15374 will not
           # be fixed.
           string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-absolute-value")
           string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -Wno-absolute-value")
+          string(APPEND CMAKE_C_FLAGS_DEBUG
+                 " -Wno-incompatible-pointer-types-discards-qualifiers")
+          string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
+                 " -Wno-incompatible-pointer-types-discards-qualifiers")
         endif()
         string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-declaration-after-statement")
         string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
                " -Wno-declaration-after-statement")
-        # TODO: Remove this suppression if upstream PR is merged.
-        # https://github.com/ggml-org/llama.cpp/pull/16573
-        if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
-          string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-ignored-qualifiers")
-          string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO " -Wno-ignored-qualifiers")
-        else()
-          string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-discarded-qualifiers")
-          string(APPEND CMAKE_C_FLAGS_RELWITHDEBINFO
-                 " -Wno-discarded-qualifiers")
-        endif()
         string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-frame-larger-than")
         string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -Wno-frame-larger-than")
         string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-non-virtual-dtor")


### PR DESCRIPTION
## Issue

We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/_deps/llama_cpp-src/ggml/src/ggml-cpu/ggml-cpu.c:3567:24: error: passing argument 1 of 'putenv' discards 'const' qualifier from pointer target type [-Werro =discarded-qualifiers]
```

## Cause

When building Groonga with MariaDB, the bundled llama.cpp triggers `-Werror`.

## Solution

Upstream llama.cpp doesn't setup discarded-qualifiers, so we suppress the warning by explicitly passing `-Wno-discarded-qualifiers` in Debug and RelWithDebInfo builds.