### PR TITLE
cmake: suppress the `frame-larger-than` warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ if(GRN_C_COMPILER_GNU_LIKE)
   check_cxxflag("-fexceptions")
   check_cxxflag("-fimplicit-templates")
   check_build_flag("-Wno-implicit-fallthrough")
+  check_cflag("-Wno-frame-larger-than")
 elseif(MSVC)
   # Enable warnings
 


### PR DESCRIPTION
## Issue

We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/extra/groonga/lib/cache.c:308:1: error: the frame size of 17664 bytes is larger than 16384 bytes [-Werror=frame-larger-than=]
```

## How to reproduce

```console
cmake \
  -S . \
  -B ../groonga.build \
  --preset=debug-default \
  -DCMAKE_INSTALL_PREFIX=/tmp/local \
  -DCMAKE_C_FLAGS="-Werror=frame-larger-than=16384" && \
cmake --build ../groonga.build/
...
/home/otegami/work/c/groonga/lib/cache.c:308:1: error: the frame size of 17696 bytes is larger than 16384 bytes [-Werror=frame-larger-than=]
  308 | }
      | ^
```

## Cause

In MariaDB’s build environment, compiler warnings are promoted to errors.
As a result, any `-Wframe-larger-than=` diagnostics fail the build.

## Solution

We will suppress this warning now because there are no effects to Groonga.