### PR TITLE
cmake llama.cpp: suppress the missing-braces warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1726,6 +1726,10 @@ if(NOT "${GRN_WITH_LLAMA_CPP}" STREQUAL "no")
                " -Wno-declaration-after-statement")
         string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-frame-larger-than")
         string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -Wno-frame-larger-than")
+        # TODO: Remove this suppression if upstream PR is merged.
+        # https://github.com/ggml-org/llama.cpp/pull/16614
+        string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-missing-braces")
+        string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -Wno-missing-braces")
         string(APPEND CMAKE_CXX_FLAGS_DEBUG " -Wno-non-virtual-dtor")
         string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -Wno-non-virtual-dtor")
         string(APPEND CMAKE_C_FLAGS_DEBUG " -Wno-unused-function")


### PR DESCRIPTION
## Issue

We got the following error when we built Groonga with MariaDB.

```
/home/buildbot/_deps/llama_cpp-src/src/llama-batch.h:126:48: error: missing braces around initializer for 'std::__array_traits<int, 1>::_Type' {aka 'int [1]'} [-Werror=missing-braces]
```

## Cause

When building Groonga with MariaDB, the bundled llama.cpp triggers `-Werror`.

## Solution

Upstream llama.cpp doesn't setup `-Wmissing-braces`, so we suppress the warning by explicitly passing `-Wno-missing-braces` in Debug and RelWithDebInfo builds.