### PR TITLE
language-model-knn: fix wrong number of centroids in centroid searcher

### DIFF
--- a/plugins/language_model/knn.cpp
+++ b/plugins/language_model/knn.cpp
@@ -322,7 +322,8 @@ namespace {
                                                     sizeof(float) *
                                                       options->centroids.size(),
                                                     nullptr);
-    options->centroid_searcher.ntotal = options->centroids.size();
+    options->centroid_searcher.ntotal =
+      options->centroids.size() / options->n_dimensions;
 
     options->random_rotation_matrix.d_in = options->n_dimensions;
     options->random_rotation_matrix.d_out = options->n_dimensions;


### PR DESCRIPTION
`options->centroids.size()` returns the number of all float values not the number of centroids.