### PR TITLE
sorter: add

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -66,6 +66,7 @@
 #include "groonga/request_timer.h"
 #include "groonga/result_set.h"
 #include "groonga/selector.h"
+#include "groonga/sorter.h"
 #include "groonga/string.h"
 #include "groonga/table.h"
 #include "groonga/table_module.h"

--- a/include/groonga/Makefile.am
+++ b/include/groonga/Makefile.am
@@ -48,9 +48,10 @@ groonga_include_HEADERS =			\
 	request_canceler.h			\
 	request_timer.h				\
 	result_set.h				\
-	selector.h				\
 	scorer.h				\
+	selector.h				\
 	smart_obj.hpp				\
+	sorter.h				\
 	string.h				\
 	table.h					\
 	table_module.h				\

--- a/include/groonga/obj.h
+++ b/include/groonga/obj.h
@@ -190,6 +190,20 @@ GRN_API bool
 grn_obj_is_selector_only_proc(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_applier_proc(grn_ctx *ctx, grn_obj *obj);
+/**
+ * \brief Return whether `obj` is a function that has a sorter callback
+ *        or not.
+ *
+ * \param ctx The context object.
+ * \param obj The target object.
+ *
+ * \return `true` if `obj` is a function that has a sorter callback,
+ *         `false` otherwise.
+ *
+ * Since: 15.1.8
+ */
+GRN_API bool
+grn_obj_is_sorter_proc(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool
 grn_obj_is_normalizer_proc(grn_ctx *ctx, grn_obj *obj);
 GRN_API bool

--- a/include/groonga/sorter.h
+++ b/include/groonga/sorter.h
@@ -1,0 +1,61 @@
+/*
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include <groonga.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _grn_sorter_data grn_sorter_data;
+
+GRN_API grn_obj *
+grn_sorter_data_get_table(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API size_t
+grn_sorter_data_get_offset(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API size_t
+grn_sorter_data_get_limit(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API bool
+grn_sorter_data_is_ascending(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API grn_obj *
+grn_sorter_data_get_result(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API grn_obj *
+grn_sorter_data_get_sorter(grn_ctx *ctx, grn_sorter_data *data);
+GRN_API grn_obj **
+grn_sorter_data_get_args(grn_ctx *ctx, grn_sorter_data *data, size_t *n_args);
+
+/* TODO:
+ * GRN_API bool
+ * grn_sorter_data_is_greater(grn_ctx *ctx, grn_sorter_data *data, grn_id id):
+ *
+ * Returns whether the next sort key is greater or not. Sorter can
+ * call this when the target record's value is the same value. This is
+ * needed on multi column sort.
+ */
+
+typedef grn_rc
+grn_sorter_func(grn_ctx *ctx, grn_sorter_data *data);
+
+GRN_API grn_rc
+grn_proc_set_sorter(grn_ctx *ctx, grn_obj *proc, grn_sorter_func sorter);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -89,6 +89,7 @@ libgroonga_c_sources =				\
 	grn_slow_log.h				\
 	grn_snip.h				\
 	grn_sort.h				\
+	grn_sorter.h				\
 	grn_store.h				\
 	grn_str.h				\
 	grn_string.h				\
@@ -158,6 +159,7 @@ libgroonga_c_sources =				\
 	slow_log.c				\
 	snip.c					\
 	sort.c					\
+	sorter.c				\
 	store.c					\
 	str.c					\
 	string.c				\

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -340,6 +340,17 @@ grn_proc_set_applier(grn_ctx *ctx, grn_obj *proc, grn_applier_func applier)
   return GRN_SUCCESS;
 }
 
+grn_rc
+grn_proc_set_sorter(grn_ctx *ctx, grn_obj *proc, grn_sorter_func sorter)
+{
+  grn_proc *proc_ = (grn_proc *)proc;
+  if (!grn_obj_is_function_proc(ctx, proc)) {
+    return GRN_INVALID_ARGUMENT;
+  }
+  proc_->callbacks.function.sorter = sorter;
+  return GRN_SUCCESS;
+}
+
 /* grn_expr */
 
 grn_obj *

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -438,6 +438,7 @@ struct _grn_proc {
       grn_operator selector_op;
       bool is_stable;
       grn_applier_func *applier;
+      grn_sorter_func *sorter;
     } function;
     struct {
       grn_command_run_func *run;

--- a/lib/grn_sorter.h
+++ b/lib/grn_sorter.h
@@ -1,0 +1,56 @@
+/*
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "grn.h"
+#include "grn_ctx_impl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct _grn_sorter_data {
+  grn_obj *table;
+  size_t offset;
+  size_t limit;
+  grn_table_sort_key *keys;
+  size_t n_keys;
+  grn_obj *result;
+  grn_obj *sorter;
+  grn_obj args;
+};
+
+bool
+grn_sorter_data_init(grn_ctx *ctx,
+                     grn_sorter_data *data,
+                     grn_obj *table,
+                     size_t offset,
+                     size_t limit,
+                     grn_table_sort_key *keys,
+                     size_t n_keys,
+                     grn_obj *result);
+void
+grn_sorter_data_fin(grn_ctx *ctx, grn_sorter_data *data);
+
+grn_rc
+grn_sorter_data_run(grn_ctx *ctx, grn_sorter_data *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/obj.c
+++ b/lib/obj.c
@@ -1141,6 +1141,17 @@ grn_obj_is_applier_proc(grn_ctx *ctx, grn_obj *obj)
 }
 
 bool
+grn_obj_is_sorter_proc(grn_ctx *ctx, grn_obj *obj)
+{
+  if (!grn_obj_is_function_proc(ctx, obj)) {
+    return false;
+  }
+
+  grn_proc *proc = (grn_proc *)obj;
+  return proc->callbacks.function.sorter != NULL;
+}
+
+bool
 grn_obj_is_normalizer_proc(grn_ctx *ctx, grn_obj *obj)
 {
   grn_proc *proc;

--- a/lib/sorter.c
+++ b/lib/sorter.c
@@ -1,0 +1,199 @@
+/*
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "grn_sorter.h"
+#include "grn_expr.h"
+
+grn_obj *
+grn_sorter_data_get_table(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return data->table;
+}
+
+size_t
+grn_sorter_data_get_offset(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return data->offset;
+}
+
+size_t
+grn_sorter_data_get_limit(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return data->limit;
+}
+
+bool
+grn_sorter_data_is_ascending(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return !(data->keys[0].flags & GRN_TABLE_SORT_DESC);
+}
+
+grn_table_sort_key *
+grn_sorter_data_get_keys(grn_ctx *ctx, grn_sorter_data *data, size_t *n_keys)
+{
+  *n_keys = data->n_keys;
+  return data->keys;
+}
+
+grn_obj *
+grn_sorter_data_get_result(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return data->result;
+}
+
+grn_obj *
+grn_sorter_data_get_sorter(grn_ctx *ctx, grn_sorter_data *data)
+{
+  return data->sorter;
+}
+
+grn_obj **
+grn_sorter_data_get_args(grn_ctx *ctx, grn_sorter_data *data, size_t *n_args)
+{
+  *n_args = GRN_PTR_VECTOR_SIZE(&(data->args));
+  return (grn_obj **)GRN_BULK_HEAD(&(data->args));
+}
+
+static bool
+grn_sorter_data_extract(grn_ctx *ctx, grn_sorter_data *data)
+{
+  grn_obj *first_key = data->keys[0].key;
+  if (!grn_obj_is_expr(ctx, first_key)) {
+    return false;
+  }
+
+  grn_expr *expr = (grn_expr *)first_key;
+  grn_expr_code *codes = expr->codes;
+  uint32_t codes_curr = expr->codes_curr;
+  if (codes_curr < 3) {
+    return false;
+  }
+  if (codes[0].op != GRN_OP_PUSH) {
+    return false;
+  }
+  if (!grn_obj_is_sorter_proc(ctx, codes[0].value)) {
+    return false;
+  }
+
+  data->sorter = codes[0].value;
+  if (codes[0].modify == 0) {
+    return false;
+  }
+  uint32_t call_i = codes[0].modify;
+  if (codes[call_i].op != GRN_OP_CALL) {
+    return false;
+  }
+  if (call_i != codes_curr - 1) {
+    if (call_i + 1 == codes_curr - 1 && codes[call_i + 1].op == GRN_OP_MINUS) {
+      /* -sorter(...): OK */
+      data->keys[0].flags = GRN_TABLE_SORT_DESC;
+    } else {
+      return false;
+    }
+  }
+
+  for (uint32_t i = 1; i < call_i; i++) {
+    switch (codes[i].op) {
+    case GRN_OP_GET_VALUE:
+    case GRN_OP_PUSH:
+      if (codes[i].modify == 0) {
+        GRN_PTR_PUT(ctx, &(data->args), codes[i].value);
+      } else {
+        uint32_t sub_call_i = i + codes[i].modify;
+        if (codes[sub_call_i].op != GRN_OP_CALL) {
+          return false;
+        }
+        /* Literal argument expressions are only supported for
+         * now. Nested function call and so on aren't supported
+         * yet. */
+        if (!grn_obj_is_function_proc(ctx, codes[i].value)) {
+          return false;
+        }
+        for (uint32_t j = i + 1; j < sub_call_i; j++) {
+          if (codes[j].op != GRN_OP_PUSH) {
+            return false;
+          }
+          grn_obj *sub_arg = codes[j].value;
+          if (!sub_arg) {
+            return false;
+          }
+          switch (sub_arg->header.type) {
+          case GRN_BULK:
+          case GRN_VECTOR:
+          case GRN_UVECTOR:
+          case GRN_PVECTOR:
+            /* supported */
+            break;
+          default:
+            return false;
+          }
+        }
+        expr->codes += i;
+        expr->codes_curr = call_i - i + 1;
+        grn_expr_executor executor;
+        grn_expr_executor_init(ctx, &executor, (grn_obj *)expr);
+        grn_obj *arg = grn_expr_executor_exec(ctx, &executor, GRN_ID_NIL);
+        GRN_PTR_PUT(ctx, &(data->args), arg);
+        grn_expr_executor_fin(ctx, &executor);
+        expr->codes = codes;
+        expr->codes_curr = codes_curr;
+        i += codes[i].modify;
+      }
+      break;
+    default:
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool
+grn_sorter_data_init(grn_ctx *ctx,
+                     grn_sorter_data *data,
+                     grn_obj *table,
+                     size_t offset,
+                     size_t limit,
+                     grn_table_sort_key *keys,
+                     size_t n_keys,
+                     grn_obj *result)
+{
+  data->table = table;
+  data->offset = offset;
+  data->limit = limit;
+  data->keys = keys;
+  data->n_keys = n_keys;
+  data->result = result;
+  data->sorter = NULL;
+  GRN_PTR_INIT(&(data->args), GRN_OBJ_VECTOR, GRN_ID_NIL);
+
+  return grn_sorter_data_extract(ctx, data);
+}
+
+void
+grn_sorter_data_fin(grn_ctx *ctx, grn_sorter_data *data)
+{
+  GRN_OBJ_FIN(ctx, &(data->args));
+}
+
+grn_rc
+grn_sorter_data_run(grn_ctx *ctx, grn_sorter_data *data)
+{
+  grn_proc *proc = (grn_proc *)(data->sorter);
+  return proc->callbacks.function.sorter(ctx, data);
+}


### PR DESCRIPTION
This is for implementing custom sort logic. For example, we can re-implement `--sort_keys geo_distance(...)` by sorter.