### PR TITLE
TokenLanguageModelKNN: Improve error handling

### DIFF
--- a/plugins/language_model/knn.cpp
+++ b/plugins/language_model/knn.cpp
@@ -690,6 +690,14 @@ namespace {
 
     auto lexicon = grn_tokenizer_query_get_lexicon(ctx, query);
     auto source_column = grn_tokenizer_query_get_source_column(ctx, query);
+    if (!source_column) {
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_TOKENIZER_ERROR,
+                       "%s source column not found. Note: This tokenizer does "
+                       "not support 'tokenize' command.",
+                       TAG);
+      return nullptr;
+    }
     auto source_table = grn_ctx_at(ctx, source_column->header.domain);
     OpenOptionsData open_options_data;
     open_options_data.lexicon = lexicon;


### PR DESCRIPTION
Using it with `tokenize` command causes a crash, so we added a check for `source_column`.

The following error occurred:

```
> tokenize \
  --tokenizer 'TokenLanguageModel( \
    "model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
    "code_column", "dummy")' \
  --string "Hello World"
Aborted (core dumped)
```