### PR TITLE
Rename TokenLanguageModel to TokenLanguageModelKNN

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -161,7 +161,7 @@ Description: Language model related plugin for Groonga
  Groonga is an open-source fulltext search engine and column store.
  It lets you write high-performance applications that requires fulltext search.
  .
- This package provides TokenLanguageModel and language_model_knn() by
+ This package provides TokenLanguageModelKNN and language_model_knn() by
  language_model/knn.
  .
  This package provides langauge_model_vectorize() by functions/language_model.

--- a/packages/yum/groonga.spec.in
+++ b/packages/yum/groonga.spec.in
@@ -199,7 +199,7 @@ Requires:	%{name}-libs = %{version}-%{release}
 %description plugin-language-model
 Language model plugin for Groonga.
 
-This provides TokenLanguageModel and language_model_knn() by
+This provides TokenLanguageModelKNN and language_model_knn() by
 language_model/knn.
 
 This provides language_model_vectorize() by functions/language_model.

--- a/plugins/language_model/knn.cpp
+++ b/plugins/language_model/knn.cpp
@@ -1259,7 +1259,7 @@ grn_rc
 GRN_PLUGIN_REGISTER(grn_ctx *ctx)
 {
   {
-    grn_obj *tokenizer = grn_tokenizer_create(ctx, "TokenLanguageModel", -1);
+    grn_obj *tokenizer = grn_tokenizer_create(ctx, "TokenLanguageModelKNN", -1);
     if (tokenizer) {
       grn_tokenizer_set_build_func(ctx, tokenizer, build);
       grn_tokenizer_set_init_func(ctx, tokenizer, init);

--- a/test/command/suite/language_model/build/small.expected
+++ b/test/command/suite/language_model/build/small.expected
@@ -13,7 +13,7 @@ load --table Data
 {"text": "Groonga is a full text search engine."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                           "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]

--- a/test/command/suite/language_model/build/small.test
+++ b/test/command/suite/language_model/build/small.test
@@ -17,8 +17,8 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                          "code_column", "rabitq_code")'
+  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
+                                             "code_column", "rabitq_code")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/sort/filtered.expected
+++ b/test/command/suite/language_model/sort/filtered.expected
@@ -13,7 +13,7 @@ load --table Data
 {"text": "This is an apple."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                           "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]

--- a/test/command/suite/language_model/sort/filtered.test
+++ b/test/command/suite/language_model/sort/filtered.test
@@ -17,8 +17,8 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                          "code_column", "rabitq_code")'
+  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
+                                             "code_column", "rabitq_code")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/sort/no_filter.expected
+++ b/test/command/suite/language_model/sort/no_filter.expected
@@ -13,7 +13,7 @@ load --table Data
 {"text": "Groonga is a full text search engine."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                           "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]

--- a/test/command/suite/language_model/sort/no_filter.test
+++ b/test/command/suite/language_model/sort/no_filter.test
@@ -17,8 +17,8 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                          "code_column", "rabitq_code")'
+  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
+                                             "code_column", "rabitq_code")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/update.expected
+++ b/test/command/suite/language_model/update.expected
@@ -12,7 +12,7 @@ load --table Data
 {"text": "I am a queen."}
 ]
 [[0,0.0,0.0],2]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                           "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]

--- a/test/command/suite/language_model/update.test
+++ b/test/command/suite/language_model/update.test
@@ -16,8 +16,8 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModel("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                          "code_column", "rabitq_code")'
+  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
+                                             "code_column", "rabitq_code")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text


### PR DESCRIPTION
Since the `TokenLanguageModel` is too generic, we will rename it to `TokenLanguageModelKNN` with `KNN` added.