### PR TITLE
ci: archlinux: passing two refresh flag to force a refresh of all package databases

### DIFF
--- a/dockerfiles/arch-linux.dockerfile
+++ b/dockerfiles/arch-linux.dockerfile
@@ -17,7 +17,7 @@
 FROM archlinux
 
 RUN \
-  pacman --sync --refresh --refresh --upgrade --noconfirm \
+  pacman --sync --refresh --refresh --sysupgrade --noconfirm \
     # mecab-ipadic must have this but it doesn't have it.
     # So we install this in base environment.
     autoconf \


### PR DESCRIPTION
Fix: GH-2616

### Cause

Versions of some packages such as ruby-3.4.7-1-x86_64.pkg.tar.zst and aws-sdk-cpp-s3-1.11.667-1-x86_64.pkg.tar.zst are old.
These are not exist in mirror.
Therefore, we can't download require some packages currently.

### Solution

We update repository data forcefully.
Arch Linux's CI is successful as below by this modification.

https://github.com/groonga/groonga/actions/runs/18928862551/job/54041595746