### PR TITLE
language-model: add support for parallel vectorization

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -17592,7 +17592,7 @@ namespace grn::ii {
         };
         if (!executor->execute(offset,
                                execute,
-                               "[index][builder][append_src][parallel]")) {
+                               "[index][builder][append-src][parallel]")) {
           executor->wait_all();
           return ctx_->rc;
         }


### PR DESCRIPTION
In general, 1 GPU is faster than multiple CPUs. So `--n-default-workers=-1` will not be optimal because it's based on the number of CPUs.

You must check GPU usage not CPU usage for the optimal number of workers.