### PR TITLE
language-model: add support for prefix

### DIFF
--- a/include/groonga/language_model.h
+++ b/include/groonga/language_model.h
@@ -150,6 +150,30 @@ grn_language_model_open_inferencer(grn_ctx *ctx, grn_language_model *model);
 GRN_API grn_rc
 grn_language_model_inferencer_close(grn_ctx *ctx,
                                     grn_language_model_inferencer *inferencer);
+
+/**
+ * \brief Prepend `prefix` to all values of `input_column` in \ref
+ *        grn_language_model_inferencer_vectorize_in_batch and \ref
+ *        grn_language_model_inferencer_vectorize_applier.
+ *
+ * \param ctx The context object.
+ * \param inferencer The inferencer.
+ * \param prefix The prefix.
+ * \param prefix_length The byte size of `prefix`. You can use `-1` if
+ *                      `prefix` is a `\0`-terminated string.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.1.9
+ */
+GRN_API grn_rc
+grn_language_model_inferencer_set_input_column_value_prefix(
+  grn_ctx *ctx,
+  grn_language_model_inferencer *inferencer,
+  const char *prefix,
+  int64_t prefix_length);
+
 /**
  * \brief Vectorize a text.
  *

--- a/lib/grn_language_model.hpp
+++ b/lib/grn_language_model.hpp
@@ -72,6 +72,15 @@ namespace grn {
     LanguageModelInferencer(Impl *impl);
     ~LanguageModelInferencer();
 
+    /// \brief Prepend `prefix` to all values of `input_column` in
+    ///        \ref vectorize_in_batch.
+    ///
+    /// \param prefix The prefix for all values of `input_column.
+    ///
+    /// \since 15.1.9
+    void
+    set_input_column_value_prefix(std::string prefix);
+
     /// \brief Generate an embedding for a record
     ///
     /// \param ctx A \ref grn_ctx.

--- a/test/command/suite/language_model/prefix.expected
+++ b/test/command/suite/language_model/prefix.expected
@@ -1,0 +1,74 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],2]
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                                              "code_column", "rabitq_code",                                              "passage_prefix", "passage: ",                                              "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
+#|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+select Data   --filter 'language_model_knn(text, "male child")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        "This is an apple."
+      ]
+    ]
+  ]
+]
+select Data   --filter 'language_model_knn(text, "fruit")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        "I am a boy."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/language_model/prefix.test
+++ b/test/command/suite/language_model/prefix.test
@@ -1,0 +1,33 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY ShortBinary \
+  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                                             "code_column", "rabitq_code", \
+                                             "passage_prefix", "passage: ", \
+                                             "query_prefix", "query: ")'
+# This is for waiting for downloading model.
+#@timeout 300
+column_create RaBitQ data_text COLUMN_INDEX Data text
+
+select Data \
+  --filter 'language_model_knn(text, "male child")' \
+  --output_columns text
+
+select Data \
+  --filter 'language_model_knn(text, "fruit")' \
+  --output_columns text


### PR DESCRIPTION
Some models such as multilingual-e5 require prefix for search target texts and query texts. This adds support for these cases.

`passage_prefix` is for prefix for search target text. `query_prefix` is for prefix for query text.

    TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
                          "code_column", "rabitq_code", \
                          "passage_prefix", "passage: ", \
                          "query_prefix", "query: ")

TODO: Add support for prefix in `language_model_vectorize()` applier.