### PR TITLE
progress-logger: extract from grn_index_column_diff()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,7 @@ repos:
           ?lib/grn_pat\.h|
           ?lib/grn_portability\.h|
           ?lib/grn_proc\.h|
+          ?lib/grn_progress_logger\.h|
           ?lib/grn_request_canceler\.h|
           ?lib/grn_request_timer\.h|
           ?lib/grn_scan_info\.h|
@@ -168,6 +169,7 @@ repos:
           ?lib/proc/proc_snippet\.c|
           ?lib/proc/proc_tokenize\.c|
           ?lib/proc\.c|
+          ?lib/progress_logger\.c|
           ?lib/selector\.c|
           ?lib/snip\.c|
           ?lib/store\.c|

--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -76,6 +76,7 @@ libgroonga_c_sources =				\
 	grn_posting.h				\
 	grn_proc.h				\
 	grn_progress.h				\
+	grn_progress_logger.h			\
 	grn_report.h				\
 	grn_request_canceler.h			\
 	grn_request_timer.h			\
@@ -146,6 +147,7 @@ libgroonga_c_sources =				\
 	posting.c				\
 	proc.c					\
 	progress.c				\
+	progress_logger.c			\
 	raw_string.c				\
 	report.c				\
 	request_canceler.c			\

--- a/lib/grn_progress_logger.h
+++ b/lib/grn_progress_logger.h
@@ -1,0 +1,54 @@
+/*
+  Copyright (C) 2019-2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "grn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct grn_progress_logger {
+  const char *tag;
+  const char *targets_label;
+  uint32_t n_targets;
+  uint32_t n_processed_targets;
+  uint32_t previous_n_processed_targets;
+  uint32_t last_logged_n_processed_targets;
+  uint32_t interval;
+  uint32_t n_targets_digits;
+  grn_log_level log_level;
+  grn_timeval start_time;
+  grn_timeval previous_time;
+} grn_progress_logger;
+
+void
+grn_progress_logger_init(grn_ctx *ctx,
+                         grn_progress_logger *logger,
+                         const char *tag,
+                         const char *targets_label,
+                         uint32_t n_targets);
+void
+grn_progress_logger_fin(grn_ctx *ctx, grn_progress_logger *logger);
+void
+grn_progress_logger_log(grn_ctx *ctx, grn_progress_logger *logger);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -18,12 +18,13 @@
 */
 
 #include "grn_index_column.h"
-#include "grn_ii.h"
-#include "grn_float.h"
-#include "grn_hash.h"
 
-#include <string.h>
+#include "grn_hash.h"
+#include "grn_ii.h"
+#include "grn_progress_logger.h"
+
 #include <math.h>
+#include <string.h>
 
 static uint64_t grn_index_sparsity = 10;
 
@@ -386,13 +387,8 @@ typedef struct {
     grn_obj postings;
   } buffers;
   struct {
-    unsigned int n_records;
-    unsigned int i;
-    unsigned int interval;
-    int n_records_digits;
-    grn_log_level log_level;
-    grn_timeval start_time;
-    grn_timeval previous_time;
+    grn_obj tag;
+    grn_progress_logger logger;
   } progress;
 } grn_index_column_diff_data;
 
@@ -437,133 +433,34 @@ grn_index_column_diff_data_fin(grn_ctx *ctx, grn_index_column_diff_data *data)
   GRN_OBJ_FIN(ctx, &(data->buffers.value));
   GRN_OBJ_FIN(ctx, &(data->buffers.postings));
   grn_hash_close(ctx, data->current.token_counters);
+  GRN_OBJ_FIN(ctx, &(data->progress.tag));
 }
 
 static void
 grn_index_column_diff_init_progress(grn_ctx *ctx,
                                     grn_index_column_diff_data *data)
 {
-  data->progress.n_records = grn_table_size(ctx, data->source_table);
-  data->progress.i = 0;
-  data->progress.interval = 10000;
-  data->progress.log_level =
+  GRN_TEXT_INIT(&(data->progress.tag), 0);
+  grn_text_printf(ctx,
+                  &(data->progress.tag),
+                  "[index-column][diff][progress][%.*s]",
+                  data->index.name_size,
+                  data->index.name);
+  GRN_TEXT_PUTC(ctx, &(data->progress.tag), '\0');
+  grn_progress_logger_init(ctx,
+                           &(data->progress.logger),
+                           GRN_TEXT_VALUE(&(data->progress.tag)),
+                           "records",
+                           grn_table_size(ctx, data->source_table));
+  data->progress.logger.log_level =
     grn_index_column_diff_options_get_progress_log_level(ctx, data->options);
-  double n_records_digits = ceil(log10(data->progress.n_records + 1));
-  data->progress.n_records_digits = (int)n_records_digits;
-  grn_timeval_now(ctx, &(data->progress.start_time));
-  data->progress.previous_time = data->progress.start_time;
-}
-
-static double
-grn_index_column_diff_format_time(grn_ctx *ctx,
-                                  double seconds,
-                                  const char **unit)
-{
-  if (seconds < 60) {
-    *unit = "s";
-    return seconds;
-  } else if (seconds < (60 * 60)) {
-    *unit = "m";
-    return seconds / 60;
-  } else if (seconds < (60 * 60 * 24)) {
-    *unit = "h";
-    return seconds / 60 / 60;
-  } else {
-    *unit = "d";
-    return seconds / 60 / 60 / 24;
-  }
-}
-
-static double
-grn_index_column_diff_format_memory(grn_ctx *ctx,
-                                    uint64_t usage,
-                                    const char **unit)
-{
-  if (usage < 1024) {
-    *unit = "B";
-    return (double)usage;
-  } else if (usage < (1024 * 1024)) {
-    *unit = "KiB";
-    return (double)usage / 1024.0;
-  } else if (usage < (1024 * 1024 * 1024)) {
-    *unit = "MiB";
-    return (double)usage / 1024.0 / 1024.0;
-  } else {
-    *unit = "GiB";
-    return (double)usage / 1024.0 / 1024.0 / 1024.0;
-  }
 }
 
 static void
 grn_index_column_diff_progress(grn_ctx *ctx, grn_index_column_diff_data *data)
 {
-  data->progress.i++;
-
-  const unsigned int i = data->progress.i;
-  const unsigned int interval = data->progress.interval;
-  const unsigned int n_records = data->progress.n_records;
-  if (grn_logger_pass(ctx, data->progress.log_level) &&
-      (((i % interval) == 0) || (i == n_records))) {
-    grn_timeval current_time;
-    grn_timeval_now(ctx, &current_time);
-    const grn_timeval *start_time = &(data->progress.start_time);
-    const grn_timeval *previous_time = &(data->progress.previous_time);
-    const double elapsed_seconds =
-      ((double)(current_time.tv_sec) +
-       current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
-      ((double)(start_time->tv_sec) +
-       start_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
-    const double current_interval_seconds =
-      ((double)(current_time.tv_sec) +
-       current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
-      ((double)(previous_time->tv_sec) +
-       previous_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
-    double throughput;
-    if (grn_float_is_zero(current_interval_seconds)) {
-      throughput = interval;
-    } else {
-      throughput = interval / current_interval_seconds;
-    }
-    const double remained_seconds =
-      elapsed_seconds + ((n_records - i) / throughput);
-    const char *elapsed_unit = NULL;
-    const double elapsed_time =
-      grn_index_column_diff_format_time(ctx, elapsed_seconds, &elapsed_unit);
-    const char *remained_unit = NULL;
-    const double remained_time =
-      grn_index_column_diff_format_time(ctx, remained_seconds, &remained_unit);
-    const char *interval_unit = NULL;
-    const double interval_time =
-      grn_index_column_diff_format_time(ctx,
-                                        current_interval_seconds,
-                                        &interval_unit);
-    const char *memory_unit = NULL;
-    const double memory_usage =
-      grn_index_column_diff_format_memory(ctx,
-                                          grn_memory_get_usage(ctx),
-                                          &memory_unit);
-
-    GRN_LOG(ctx,
-            data->progress.log_level,
-            "[index-column][diff][progress][%.*s] "
-            "%*u/%u %3.0f%% %.2f%s/%.2f%s %.2f%s(%.2frecords/s) %.2f%s",
-            data->index.name_size,
-            data->index.name,
-            data->progress.n_records_digits,
-            i,
-            n_records,
-            ((double)i / (double)n_records) * 100,
-            elapsed_time,
-            elapsed_unit,
-            remained_time,
-            remained_unit,
-            interval_time,
-            interval_unit,
-            throughput,
-            memory_usage,
-            memory_unit);
-    data->progress.previous_time = current_time;
-  }
+  data->progress.logger.n_processed_targets++;
+  grn_progress_logger_log(ctx, &(data->progress.logger));
 }
 
 typedef enum {

--- a/lib/progress_logger.c
+++ b/lib/progress_logger.c
@@ -1,0 +1,192 @@
+/*
+  Copyright (C) 2019-2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "grn_progress_logger.h"
+
+#include "grn_float.h"
+
+#include <math.h>
+
+static const grn_log_level grn_progress_logger_log_level_default =
+  GRN_LOG_DEBUG;
+
+void
+grn_progress_logger_init(grn_ctx *ctx,
+                         grn_progress_logger *logger,
+                         const char *tag,
+                         const char *targets_label,
+                         uint32_t n_targets)
+{
+  logger->tag = tag;                     /* Don't own this. */
+  logger->targets_label = targets_label; /* Don't own this. */
+  logger->n_targets = n_targets;
+  logger->n_processed_targets = 0;
+  logger->previous_n_processed_targets = 0;
+  logger->last_logged_n_processed_targets = 0;
+  logger->interval = 1000;
+  logger->log_level = grn_progress_logger_log_level_default;
+  double n_targets_digits = ceil(log10(logger->n_targets + 1));
+  logger->n_targets_digits = (uint32_t)n_targets_digits;
+  grn_timeval_now(ctx, &(logger->start_time));
+  logger->previous_time = logger->start_time;
+}
+
+void
+grn_progress_logger_fin(grn_ctx *ctx, grn_progress_logger *logger)
+{
+}
+
+static double
+grn_progress_logger_format_time(grn_ctx *ctx, double seconds, const char **unit)
+{
+  if (seconds < 60) {
+    *unit = "s";
+    return seconds;
+  } else if (seconds < (60 * 60)) {
+    *unit = "m";
+    return seconds / 60;
+  } else if (seconds < (60 * 60 * 24)) {
+    *unit = "h";
+    return seconds / 60 / 60;
+  } else {
+    *unit = "d";
+    return seconds / 60 / 60 / 24;
+  }
+}
+
+static double
+grn_progress_logger_format_memory(grn_ctx *ctx,
+                                  uint64_t usage,
+                                  const char **unit)
+{
+  if (usage < 1024) {
+    *unit = "B";
+    return (double)usage;
+  } else if (usage < (1024 * 1024)) {
+    *unit = "KiB";
+    return (double)usage / 1024.0;
+  } else if (usage < (1024 * 1024 * 1024)) {
+    *unit = "MiB";
+    return (double)usage / 1024.0 / 1024.0;
+  } else {
+    *unit = "GiB";
+    return (double)usage / 1024.0 / 1024.0 / 1024.0;
+  }
+}
+
+static void
+grn_progress_logger_adjust_interval(grn_ctx *ctx, grn_progress_logger *logger)
+{
+  if (logger->n_processed_targets >= 100000) {
+    logger->interval = 100000;
+  } else if (logger->n_processed_targets >= 10000) {
+    logger->interval = 10000;
+  } else if (logger->n_processed_targets >= 5000) {
+    logger->interval = 5000;
+  }
+}
+
+void
+grn_progress_logger_log(grn_ctx *ctx, grn_progress_logger *logger)
+{
+  if (!grn_logger_pass(ctx, logger->log_level)) {
+    return;
+  }
+
+  const uint32_t n_processed_targets = logger->n_processed_targets;
+  const uint32_t previous_n_processed_targets =
+    logger->previous_n_processed_targets;
+  const uint32_t interval = logger->interval;
+  const uint32_t n_targets = logger->n_targets;
+  logger->previous_n_processed_targets = logger->n_processed_targets;
+  if (n_processed_targets != n_targets) {
+    if (n_processed_targets == previous_n_processed_targets + 1) {
+      /* Step by step logging. */
+      if ((n_processed_targets % interval) != 0) {
+        return;
+      }
+    } else {
+      /* Bulk logging. */
+      if (n_processed_targets <
+          logger->last_logged_n_processed_targets + interval) {
+        return;
+      }
+    }
+  }
+
+  grn_timeval current_time;
+  grn_timeval_now(ctx, &current_time);
+  const grn_timeval *start_time = &(logger->start_time);
+  const grn_timeval *previous_time = &(logger->previous_time);
+  const double elapsed_seconds =
+    ((double)(current_time.tv_sec) +
+     current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
+    ((double)(start_time->tv_sec) +
+     start_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
+  const double current_interval_seconds =
+    ((double)(current_time.tv_sec) +
+     current_time.tv_nsec / GRN_TIME_NSEC_PER_SEC_F) -
+    ((double)(previous_time->tv_sec) +
+     previous_time->tv_nsec / GRN_TIME_NSEC_PER_SEC_F);
+  double throughput;
+  if (grn_float_is_zero(current_interval_seconds)) {
+    throughput = interval;
+  } else {
+    throughput = interval / current_interval_seconds;
+  }
+  const double remained_seconds =
+    elapsed_seconds + ((n_targets - n_processed_targets) / throughput);
+  const char *elapsed_unit = NULL;
+  const double elapsed_time =
+    grn_progress_logger_format_time(ctx, elapsed_seconds, &elapsed_unit);
+  const char *remained_unit = NULL;
+  const double remained_time =
+    grn_progress_logger_format_time(ctx, remained_seconds, &remained_unit);
+  const char *interval_unit = NULL;
+  const double interval_time =
+    grn_progress_logger_format_time(ctx,
+                                    current_interval_seconds,
+                                    &interval_unit);
+  const char *memory_unit = NULL;
+  const double memory_usage =
+    grn_progress_logger_format_memory(ctx,
+                                      grn_memory_get_usage(ctx),
+                                      &memory_unit);
+
+  GRN_LOG(ctx,
+          logger->log_level,
+          "%s %*u/%u %3.0f%% %.2f%s/%.2f%s %.2f%s(%.2f%s/s) %.2f%s",
+          logger->tag,
+          logger->n_targets_digits,
+          n_processed_targets,
+          n_targets,
+          ((double)n_processed_targets / (double)n_targets) * 100,
+          elapsed_time,
+          elapsed_unit,
+          remained_time,
+          remained_unit,
+          interval_time,
+          interval_unit,
+          throughput,
+          logger->targets_label,
+          memory_usage,
+          memory_unit);
+  logger->previous_time = current_time;
+  logger->last_logged_n_processed_targets = n_processed_targets;
+  grn_progress_logger_adjust_interval(ctx, logger);
+}

--- a/test/command/suite/index_column_diff/progress_log_level.expected
+++ b/test/command/suite/index_column_diff/progress_log_level.expected
@@ -8,6 +8,11 @@ column_create Terms data_index COLUMN_INDEX|WITH_POSITION   Data value
 [[0,0.0,0.0],true]
 index_column_diff Terms data_index --progress_log_level error
 [[0,0.0,0.0],[]]
+#|e| [index-column][diff][progress][Terms.data_index]  1000/20001   5% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
+#|e| [index-column][diff][progress][Terms.data_index]  2000/20001  10% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
+#|e| [index-column][diff][progress][Terms.data_index]  3000/20001  15% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
+#|e| [index-column][diff][progress][Terms.data_index]  4000/20001  20% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
+#|e| [index-column][diff][progress][Terms.data_index]  5000/20001  25% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
 #|e| [index-column][diff][progress][Terms.data_index] 10000/20001  50% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
 #|e| [index-column][diff][progress][Terms.data_index] 20000/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB
 #|e| [index-column][diff][progress][Terms.data_index] 20001/20001 100% 0.00s/0.00s 0.00s(0.00records/s) 0.00MiB


### PR DESCRIPTION
We'll reuse this for other progress logs. For example, we'll use this for progress log of static index construction.