### PR TITLE
column-create: add support for progress log of index construction

### DIFF
--- a/test/command/suite/command_list/all.expected
+++ b/test/command/suite/command_list/all.expected
@@ -75,6 +75,9 @@ command_list
         },
         {
           "name": "generator"
+        },
+        {
+          "name": "progress_log_level"
         }
       ]
     },


### PR DESCRIPTION
The progress log's log level is debug by default. You can change it by `progress_log_level` option.