### PR TITLE
test language-model: use multilingual-e5-base

### DIFF
--- a/test/command/suite/language_model/build/small.expected
+++ b/test/command/suite/language_model/build/small.expected
@@ -13,10 +13,11 @@ load --table Data
 {"text": "Groonga is a full text search engine."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
 select Data   --filter 'language_model_knn(text, "male child")'   --output_columns text
 [
@@ -48,7 +49,7 @@ select Data   --filter 'language_model_knn(text, "male child")'   --output_colum
     ]
   ]
 ]
-select Data   --filter 'language_model_knn(text, "fruit")'   --output_columns text
+select Data   --filter 'language_model_knn(text, "I like fruit")'   --output_columns text
 [
   [
     0,

--- a/test/command/suite/language_model/build/small.test
+++ b/test/command/suite/language_model/build/small.test
@@ -17,8 +17,11 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                             "code_column", "rabitq_code")'
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text
@@ -28,5 +31,5 @@ select Data \
   --output_columns text
 
 select Data \
-  --filter 'language_model_knn(text, "fruit")' \
+  --filter 'language_model_knn(text, "I like fruit")' \
   --output_columns text

--- a/test/command/suite/language_model/prefix.expected
+++ b/test/command/suite/language_model/prefix.expected
@@ -12,7 +12,7 @@ load --table Data
 {"text": "This is an apple."}
 ]
 [[0,0.0,0.0],2]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                                              "code_column", "rabitq_code",                                              "passage_prefix", "passage: ",                                              "query_prefix", "query: ")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]

--- a/test/command/suite/language_model/prefix.test
+++ b/test/command/suite/language_model/prefix.test
@@ -16,10 +16,11 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
-                                             "code_column", "rabitq_code", \
-                                             "passage_prefix", "passage: ", \
-                                             "query_prefix", "query: ")'
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/sort/filtered.expected
+++ b/test/command/suite/language_model/sort/filtered.expected
@@ -13,10 +13,11 @@ load --table Data
 {"text": "This is an apple."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
 select Data   --filter '_id > 1'   --sort_keys '-language_model_knn(text, "male child")'   --output_columns text
 [
@@ -45,7 +46,7 @@ select Data   --filter '_id > 1'   --sort_keys '-language_model_knn(text, "male 
     ]
   ]
 ]
-select Data   --filter '_id > 1'   --sort_keys '-language_model_knn(text, "fruit")'   --output_columns text
+select Data   --filter '_id > 1'   --sort_keys '-language_model_knn(text, "I like fruit")'   --output_columns text
 [
   [
     0,

--- a/test/command/suite/language_model/sort/filtered.test
+++ b/test/command/suite/language_model/sort/filtered.test
@@ -17,8 +17,11 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                             "code_column", "rabitq_code")'
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text
@@ -30,5 +33,5 @@ select Data \
 
 select Data \
   --filter '_id > 1' \
-  --sort_keys '-language_model_knn(text, "fruit")' \
+  --sort_keys '-language_model_knn(text, "I like fruit")' \
   --output_columns text

--- a/test/command/suite/language_model/sort/no_filter.expected
+++ b/test/command/suite/language_model/sort/no_filter.expected
@@ -13,10 +13,11 @@ load --table Data
 {"text": "Groonga is a full text search engine."}
 ]
 [[0,0.0,0.0],3]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
 select Data   --sort_keys '-language_model_knn(text, "male child")'   --output_columns text
 [
@@ -48,7 +49,7 @@ select Data   --sort_keys '-language_model_knn(text, "male child")'   --output_c
     ]
   ]
 ]
-select Data   --sort_keys '-language_model_knn(text, "fruit")'   --output_columns text
+select Data   --sort_keys '-language_model_knn(text, "I like fruit")'   --output_columns text
 [
   [
     0,

--- a/test/command/suite/language_model/sort/no_filter.test
+++ b/test/command/suite/language_model/sort/no_filter.test
@@ -17,8 +17,11 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                             "code_column", "rabitq_code")'
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text
@@ -28,5 +31,5 @@ select Data \
   --output_columns text
 
 select Data \
-  --sort_keys '-language_model_knn(text, "fruit")' \
+  --sort_keys '-language_model_knn(text, "I like fruit")' \
   --output_columns text

--- a/test/command/suite/language_model/update.expected
+++ b/test/command/suite/language_model/update.expected
@@ -12,10 +12,11 @@ load --table Data
 {"text": "I am a queen."}
 ]
 [[0,0.0,0.0],2]
-table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                                              "code_column", "rabitq_code")'
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
 [[0,0.0,0.0],true]
 column_create RaBitQ data_text COLUMN_INDEX Data text
 [[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
 load --table Data
 [

--- a/test/command/suite/language_model/update.test
+++ b/test/command/suite/language_model/update.test
@@ -16,8 +16,11 @@ load --table Data
 ]
 
 table_create RaBitQ TABLE_HASH_KEY ShortBinary \
-  --default_tokenizer 'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
-                                             "code_column", "rabitq_code")'
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
 # This is for waiting for downloading model.
 #@timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/select/function/language_model_vectorize/applier.expected
+++ b/test/command/suite/select/function/language_model_vectorize/applier.expected
@@ -12,7 +12,7 @@ load --table Data
 {"text": "I am a queen."}
 ]
 [[0,0.0,0.0],2]
-select Data   --columns[embeddings].stage output   --columns[embeddings].type Float32   --columns[embeddings].flags COLUMN_VECTOR   --columns[embeddings].value 'language_model_vectorize("hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", text)'   --output_columns 'text, vector_size(embeddings)'
+select Data   --columns[embeddings].stage output   --columns[embeddings].type Float32   --columns[embeddings].flags COLUMN_VECTOR   --columns[embeddings].value 'language_model_vectorize("hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", "passage: " + text)'   --output_columns 'text, vector_size(embeddings)'
 [
   [
     0,
@@ -36,13 +36,14 @@ select Data   --columns[embeddings].stage output   --columns[embeddings].type Fl
       ],
       [
         "I am a king.",
-        384
+        768
       ],
       [
         "I am a queen.",
-        384
+        768
       ]
     ]
   ]
 ]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect

--- a/test/command/suite/select/function/language_model_vectorize/applier.test
+++ b/test/command/suite/select/function/language_model_vectorize/applier.test
@@ -19,5 +19,5 @@ select Data \
   --columns[embeddings].stage output \
   --columns[embeddings].type Float32 \
   --columns[embeddings].flags COLUMN_VECTOR \
-  --columns[embeddings].value 'language_model_vectorize("hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", text)' \
+  --columns[embeddings].value 'language_model_vectorize("hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", "passage: " + text)' \
   --output_columns 'text, vector_size(embeddings)'

--- a/test/command/suite/select/function/language_model_vectorize/function.expected
+++ b/test/command/suite/select/function/language_model_vectorize/function.expected
@@ -12,7 +12,7 @@ load --table Data
 {"text": "I am a queen."}
 ]
 [[0,0.0,0.0],2]
-select Data   --output_columns '       text,       vector_size(language_model_vectorize("hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", text))'
+select Data   --output_columns '       text,       vector_size(language_model_vectorize("hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", "passage: " + text))'
 [
   [
     0,
@@ -36,13 +36,14 @@ select Data   --output_columns '       text,       vector_size(language_model_ve
       ],
       [
         "I am a king.",
-        384
+        768
       ],
       [
         "I am a queen.",
-        384
+        768
       ]
     ]
   ]
 ]
+#|w| load: model vocab missing newline token, using special_pad_id instead
 #|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect

--- a/test/command/suite/select/function/language_model_vectorize/function.test
+++ b/test/command/suite/select/function/language_model_vectorize/function.test
@@ -18,4 +18,4 @@ load --table Data
 select Data \
   --output_columns ' \
       text, \
-      vector_size(language_model_vectorize("hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", text))'
+      vector_size(language_model_vectorize("hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", "passage: " + text))'


### PR DESCRIPTION
It's larger than all-MiniLM-L6-v2 but it provides better performance than all-MiniLM-L6-v2.

`test/command/suite/language_model/build/long.test` keep using all-MiniLM-L6-v2 because multilingual-e5-base is heavy on CI.