### PR TITLE
cmake: disable GGML_CPU_ALL_VARIANTS on Windows ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1743,7 +1743,12 @@ if(NOT "${GRN_WITH_LLAMA_CPP}" STREQUAL "no")
       string(SUBSTRING "${GRN_LLAMA_CPP_BUNDLED_VERSION}" 1 -1
                        GGML_BUILD_NUMBER)
       set(GGML_CPU_ALL_VARIANTS ON)
-      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      if(WIN32 AND GRN_SYSTEM_PROCESSOR STREQUAL "arm64")
+        # GGML_CPU_ALL_VARIANTS doesn't support Windows ARM64 yet
+        #
+        # https://github.com/ggml-org/llama.cpp/blob/master/.github/workflows/release.yml#L288
+        set(GGML_CPU_ALL_VARIANTS OFF)
+      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         if(GRN_SYSTEM_PROCESSOR STREQUAL "x86_64")
           # GCC 11.5 or later is needed for "-mavxvnni" and so on
           if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.5")
@@ -1781,13 +1786,6 @@ if(NOT "${GRN_WITH_LLAMA_CPP}" STREQUAL "no")
             set(GGML_CPU_ALL_VARIANTS OFF)
           endif()
         else()
-          set(GGML_CPU_ALL_VARIANTS OFF)
-        endif()
-      elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # GGML_CPU_ALL_VARIANTS doesn't support Windows ARM64 yet
-        #
-        # https://github.com/ggml-org/llama.cpp/blob/master/.github/workflows/release.yml#L288
-        if(WIN32 AND GRN_SYSTEM_PROCESSOR STREQUAL "arm64")
           set(GGML_CPU_ALL_VARIANTS OFF)
         endif()
       endif()


### PR DESCRIPTION
GitHub: GH-2646

## Issue

When building with `GGML_CPU_ALL_VARIANTS=ON` on Windows ARM64, the build fails with:

```
CMake Error at ggml/src/CMakeLists.txt:367 (message):
  Unsupported ARM target OS: Windows
```

## Cause

llama.cpp's GGML_CPU_ALL_VARIANTS feature doesn't
support Windows ARM64 yet. It only supports ARM on Linux, Android, and macOS.
Even llama.cpp's own CI explicitly disables
`GGML_CPU_ALL_VARIANTS` for Windows ARM64 builds too.

ref: https://github.com/ggml-org/llama.cpp/blob/ece0f5c1771f1835e66900d4168233f0430d819d/ggml/src/CMakeLists.txt#L343-L368
ref: https://github.com/ggml-org/llama.cpp/blob/master/.github/workflows/release.yml#L288