### PR TITLE
TokenLanguageModelKNN: add "centroid_column" option

### DIFF
--- a/test/command/suite/language_model/centroid_column/invalid_column_type.expected
+++ b/test/command/suite/language_model/centroid_column/invalid_column_type.expected
@@ -1,0 +1,31 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],2]
+table_create RaBitQ TABLE_HASH_KEY UInt32   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "centroid_column", "centroid",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ centroid COLUMN_VECTOR Binary
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[tokenizer][language-model] centroid column must be Float32 vector: <RaBitQ.centroid>: <Binary>: <VECTOR>"
+  ],
+  false
+]
+#|e| [tokenizer][language-model] centroid column must be Float32 vector: <RaBitQ.centroid>: <Binary>: <VECTOR>

--- a/test/command/suite/language_model/centroid_column/invalid_column_type.test
+++ b/test/command/suite/language_model/centroid_column/invalid_column_type.test
@@ -1,0 +1,26 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY UInt32 \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "centroid_column", "centroid", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+column_create RaBitQ centroid COLUMN_VECTOR Binary
+column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/centroid_column/invalid_lexicon_type.expected
+++ b/test/command/suite/language_model/centroid_column/invalid_lexicon_type.expected
@@ -1,0 +1,31 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],2]
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "centroid_column", "centroid",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ centroid COLUMN_VECTOR Float32
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[tokenizer][language-model] lexicon key type must be UInt32 with centroid column: <RaBitQ.centroid>: <ShortBinary>"
+  ],
+  false
+]
+#|e| [tokenizer][language-model] lexicon key type must be UInt32 with centroid column: <RaBitQ.centroid>: <ShortBinary>

--- a/test/command/suite/language_model/centroid_column/invalid_lexicon_type.test
+++ b/test/command/suite/language_model/centroid_column/invalid_lexicon_type.test
@@ -1,0 +1,26 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY ShortBinary \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "centroid_column", "centroid", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+column_create RaBitQ centroid COLUMN_VECTOR Float32
+column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/centroid_column/nonexistent.expected
+++ b/test/command/suite/language_model/centroid_column/nonexistent.expected
@@ -1,0 +1,29 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],2]
+table_create RaBitQ TABLE_HASH_KEY UInt32   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "centroid_column", "nonexistent",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[tokenizer][language-model] couldn't find centroid column: <RaBitQ.nonexistent>"
+  ],
+  false
+]
+#|e| [tokenizer][language-model] couldn't find centroid column: <RaBitQ.nonexistent>

--- a/test/command/suite/language_model/centroid_column/nonexistent.test
+++ b/test/command/suite/language_model/centroid_column/nonexistent.test
@@ -1,0 +1,25 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY UInt32 \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "centroid_column", "nonexistent", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+column_create RaBitQ data_text COLUMN_INDEX Data text

--- a/test/command/suite/language_model/centroid_column/valid.expected
+++ b/test/command/suite/language_model/centroid_column/valid.expected
@@ -1,0 +1,76 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],2]
+table_create RaBitQ TABLE_HASH_KEY UInt32   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "centroid_column", "centroid",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ centroid COLUMN_VECTOR Float32
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
+#|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+select Data   --filter 'language_model_knn(text, "male child")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        "This is an apple."
+      ]
+    ]
+  ]
+]
+select Data   --filter 'language_model_knn(text, "fruit")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        2
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        "I am a boy."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/language_model/centroid_column/valid.test
+++ b/test/command/suite/language_model/centroid_column/valid.test
@@ -1,0 +1,36 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY UInt32 \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "centroid_column", "centroid", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+column_create RaBitQ centroid COLUMN_VECTOR Float32
+# This is for waiting for downloading model.
+#@timeout 300
+column_create RaBitQ data_text COLUMN_INDEX Data text
+
+select Data \
+  --filter 'language_model_knn(text, "male child")' \
+  --output_columns text
+
+select Data \
+  --filter 'language_model_knn(text, "fruit")' \
+  --output_columns text


### PR DESCRIPTION
It's for large (1025+ dimensions == 4100+ bytes) embeddings. Groonga's table key must be less or equal than 4KiB. If an embedding is larger than 4KiB, we can't store the embedding as table key.

You can use this option for the case. You can store embeddings to column value not table key. So you can use larger embeddings.