### PR TITLE
windows: fix compilation errors on ARM64

### DIFF
--- a/lib/windows.c
+++ b/lib/windows.c
@@ -404,8 +404,13 @@ grn_windows_log_back_trace(grn_ctx *ctx,
   frame.AddrPC.Offset = context->Rip;
   frame.AddrFrame.Offset = context->Rbp;
   frame.AddrStack.Offset = context->Rsp;
+# elif defined(_M_ARM64)
+  machine_type = IMAGE_FILE_MACHINE_ARM64;
+  frame.AddrPC.Offset = context->Pc;
+  frame.AddrFrame.Offset = context->Fp;
+  frame.AddrStack.Offset = context->Sp;
 # else /* _M_IX86 */
-#  error "Intel x86, Intel Itanium and x64 are only supported architectures"
+#  error "Intel x86, Intel Itanium, x64 and ARM64 are only supported architectures"
 # endif /* _M_IX86 */
 
   DWORD64 previous_address = 0;


### PR DESCRIPTION
## Issue

Compilation fails on ARM64 Windows CI with the following error:

```
lib/windows.c:408:4: error: "Intel x86, Intel Itanium and x64 are only supported architectures"
  408 | #  error "Intel x86, Intel Itanium and x64 are only supported architectures"
      |    ^
1 error generated.
```

## Cause

The stack walking code in `lib/windows.c` only supports Intel x86, Intel Itanium, and x64 architectures. ARM64 architecture was not recognized.

## Solution

Add support for the `_M_ARM64` compiler macro and
configure the StackWalk64 API with ARM64-specific
registers. msys2 packages use the same approach:

- `Pc` (Program Counter)
- `Fp` (Frame Pointer)
- `Sp` (Stack Pointer)

ref: https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-groonga/001-aarch64.patch
ref: https://developer.arm.com/documentation/102374/0103/Registers-in-AArch64---other-registers
ref: https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-arm64_nt_context

Also update the error message to include ARM64 in the list of supported architectures.