### PR TITLE
ci windows: enable test on ARM64 (CLANGARM64)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -570,10 +570,6 @@ jobs:
         with:
           repository: msys2/MINGW-packages
           path: ci/msys2/MINGW-packages
-      # TODO: Remove gobject-introspection, glib2, and pkgconf packages
-      #       after these gems are released:
-      #       - gobject-introspection
-      #       - glib2
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
@@ -588,8 +584,6 @@ jobs:
             git
             msys2-devel
             pactoys
-            ${{ matrix.package-prefix }}-gobject-introspection
-            ${{ matrix.package-prefix }}-glib2
       - name: Prepare
         shell: msys2 {0}
         run: |


### PR DESCRIPTION
## Issue

Previously, Windows ARM64 CI tests were skipped because the `rubygems-requirements-system` gem didn't support MSYS2 platform, causing native package installation to fail:

```
MAKEFLAGS=-j$(nproc) gem install \
    fiddle \
    grntest \
    pkg-config \
    red-arrow
  ruby -e "require 'arrow'"
ERROR:  Error installing red-arrow:
	ERROR: Failed to build gem native extension.

    current directory: C:/a/_temp/msys64/clangarm64/lib/ruby/gems/3.4.0/gems/gobject-introspection-4.3.3/ext/gobject-introspection
C:/a/_temp/msys64/clangarm64/bin/ruby.exe extconf.rb
...
checking for gobject-introspection-1.0... no (nonexistent)
installing 'gobject-introspection' native package... failed
Failed to run 'pacman -S --noconfirm gobject-introspection'.
```

## Solution

Now, the `rubygems-requirements-system` automatically install dependent packages because it has already supported MSYS2 platform at https://github.com/ruby-gnome/rubygems-requirements-system/pull/16: