### PR TITLE
language-model: add `n_gpu_layers` option

### DIFF
--- a/include/groonga/language_model.h
+++ b/include/groonga/language_model.h
@@ -84,6 +84,35 @@ grn_language_model_loader_set_model(grn_ctx *ctx,
                                     grn_language_model_loader *loader,
                                     const char *model,
                                     int64_t model_length);
+
+/**
+ * \brief The default N GPU layers to use in language model. In
+ *        general, we use GPU as much as possible by default.
+ *
+ * This value is same as `n_gpu_layers` of
+ * `llama_model_default_params()`.
+ *
+ * \since 15.2.1
+ */
+#define GRN_LANGUAGE_MODEL_LOADER_N_GPU_LAYERS_DEFAULT 999
+
+/**
+ * \brief Set the number of GPU layers to use.
+ *
+ * You can disable GPU by specifying `0` as `n_gpu_layers`.
+ *
+ * \param ctx The context object.
+ * \param loader The loader.
+ * \param n_gpu_layers The number of GPU layers to use.
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.2.1
+ */
+GRN_API grn_rc
+grn_language_model_loader_set_n_gpu_layers(grn_ctx *ctx,
+                                           grn_language_model_loader *loader,
+                                           int32_t n_gpu_layers);
 /**
  * \brief Load a language model.
  *

--- a/lib/grn_language_model.hpp
+++ b/lib/grn_language_model.hpp
@@ -60,6 +60,7 @@ namespace grn {
     load();
 
     std::string model_path;
+    int32_t n_gpu_layers = GRN_LANGUAGE_MODEL_LOADER_N_GPU_LAYERS_DEFAULT;
 
   private:
     grn_ctx *ctx_;

--- a/plugins/language_model/knn.cpp
+++ b/plugins/language_model/knn.cpp
@@ -75,6 +75,7 @@ namespace {
   struct Options {
     /* Input */
     std::string model_name;
+    int32_t n_gpu_layers;
     std::string centroid_column_name;
     uint32_t n_clusters;
     Quantizer quantizer;
@@ -107,6 +108,7 @@ namespace {
   options_init(grn_ctx *ctx, Options *options)
   {
     new (&options->model_name) std::string;
+    options->n_gpu_layers = GRN_LANGUAGE_MODEL_LOADER_N_GPU_LAYERS_DEFAULT;
     new (&options->centroid_column_name) std::string;
     new (&options->code_column_name) std::string;
     new (&options->passage_prefix) std::string;
@@ -267,6 +269,12 @@ namespace {
 
       if (name_raw == "model") {
         set_string(options->model_name, raw_options, i);
+      } else if (name_raw == "n_gpu_layers") {
+        options->n_gpu_layers =
+          grn_vector_get_element_int32(ctx,
+                                       raw_options,
+                                       i,
+                                       options->n_gpu_layers);
       } else if (name_raw == "n_clusters") {
         options->n_clusters =
           grn_vector_get_element_uint32(ctx,
@@ -398,6 +406,9 @@ namespace {
                                         loader,
                                         options->model_name.data(),
                                         options->model_name.size());
+    grn_language_model_loader_set_n_gpu_layers(ctx,
+                                               loader,
+                                               options->n_gpu_layers);
     options->model = grn_language_model_loader_load(ctx, loader);
     grn_language_model_loader_close(ctx, loader);
     if (!options->model) {

--- a/test/command/suite/language_model/n_gpu_layers/disable.expected
+++ b/test/command/suite/language_model/n_gpu_layers/disable.expected
@@ -1,0 +1,51 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."},
+{"text": "Groonga is a full text search engine."}
+]
+[[0,0.0,0.0],3]
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "n_gpu_layers", 0,                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
+#|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+select Data   --filter 'language_model_knn(text, "male child", {})'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        "Groonga is a full text search engine."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/language_model/n_gpu_layers/disable.test
+++ b/test/command/suite/language_model/n_gpu_layers/disable.test
@@ -1,0 +1,32 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."},
+{"text": "Groonga is a full text search engine."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY ShortBinary \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "n_gpu_layers", 0, \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+# This is for waiting for downloading model.
+#@timeout 300
+column_create RaBitQ data_text COLUMN_INDEX Data text
+
+select Data \
+  --filter 'language_model_knn(text, "male child", {})' \
+  --output_columns text


### PR DESCRIPTION
We can disable GPU by specifying `0`.

TODO: Add `n_gpu_layers` option to `language_model_vectorize()`.