### PR TITLE
grn_obj_get_info: don't require `obj` for `GRN_INFO_SUPPORT_{LLAMA_CPP,FAISS}`

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -7861,6 +7861,34 @@ grn_obj_get_info(grn_ctx *ctx,
     GRN_BOOL_PUT(ctx, valuebuf, false);
 #endif /* GRN_WITH_APACHE_ARROW */
     break;
+  case GRN_INFO_SUPPORT_LLAMA_CPP:
+    if (!valuebuf &&
+        !(valuebuf = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_BOOL))) {
+      ERR(GRN_INVALID_ARGUMENT,
+          "%s[support-llama-cpp] failed to allocate value buffer",
+          tag);
+      goto exit;
+    }
+#ifdef GRN_WITH_LLAMA_CPP
+    GRN_BOOL_PUT(ctx, valuebuf, true);
+#else
+    GRN_BOOL_PUT(ctx, valuebuf, false);
+#endif
+    break;
+  case GRN_INFO_SUPPORT_FAISS:
+    if (!valuebuf &&
+        !(valuebuf = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_BOOL))) {
+      ERR(GRN_INVALID_ARGUMENT,
+          "%s[support-faiss] failed to allocate value buffer",
+          tag);
+      goto exit;
+    }
+#ifdef GRN_WITH_FAISS
+    GRN_BOOL_PUT(ctx, valuebuf, true);
+#else
+    GRN_BOOL_PUT(ctx, valuebuf, false);
+#endif
+    break;
   default:
     if (!obj) {
       ERR(GRN_INVALID_ARGUMENT, "%s obj is NULL", tag);
@@ -8087,34 +8115,6 @@ grn_obj_get_info(grn_ctx *ctx,
               grn_obj_type_to_string(obj->header.type));
         }
       }
-      break;
-    case GRN_INFO_SUPPORT_LLAMA_CPP:
-      if (!valuebuf &&
-          !(valuebuf = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_BOOL))) {
-        ERR(GRN_INVALID_ARGUMENT,
-            "%s[support-llama-cpp] failed to allocate value buffer",
-            tag);
-        goto exit;
-      }
-#ifdef GRN_WITH_LLAMA_CPP
-      GRN_BOOL_PUT(ctx, valuebuf, true);
-#else
-      GRN_BOOL_PUT(ctx, valuebuf, false);
-#endif
-      break;
-    case GRN_INFO_SUPPORT_FAISS:
-      if (!valuebuf &&
-          !(valuebuf = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_BOOL))) {
-        ERR(GRN_INVALID_ARGUMENT,
-            "%s[support-faiss] failed to allocate value buffer",
-            tag);
-        goto exit;
-      }
-#ifdef GRN_WITH_FAISS
-      GRN_BOOL_PUT(ctx, valuebuf, true);
-#else
-      GRN_BOOL_PUT(ctx, valuebuf, false);
-#endif
       break;
     default:
       /* todo */


### PR DESCRIPTION
Other `GRN_INFO_SUPPORT_*` such as `GRN_INFO_SUPPORT_ZSTD` do so.