### PR TITLE
json: add support for loading and dumping "true"/"false"/"null"

### DIFF
--- a/include/groonga.h
+++ b/include/groonga.h
@@ -50,6 +50,7 @@
 #include "groonga/id.h"
 #include "groonga/ii.h"
 #include "groonga/index_column.h"
+#include "groonga/json.h"
 #include "groonga/language_model.h"
 #include "groonga/memory.h"
 #include "groonga/memory_map.h"

--- a/include/groonga/Makefile.am
+++ b/include/groonga/Makefile.am
@@ -29,6 +29,7 @@ groonga_include_HEADERS =			\
 	id.h					\
 	ii.h					\
 	index_column.h				\
+	json.h					\
 	language_model.h			\
 	memory.h				\
 	memory_map.h				\

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -2815,6 +2815,28 @@ grn_ctx_recv_handler_set(grn_ctx *,
 #define GRN_BINARY_VALUE(obj) ((const uint8_t *)GRN_BULK_HEAD(obj))
 #define GRN_BINARY_LEN(obj)   GRN_BULK_VSIZE(obj)
 
+#define GRN_JSON_INIT(obj, flags)                                              \
+  GRN_VALUE_VAR_SIZE_INIT(obj, flags, GRN_DB_JSON)
+#define GRN_JSON_SET_REF(obj, data, len)                                       \
+  do {                                                                         \
+    (obj)->u.b.head = (char *)(data);                                          \
+    (obj)->u.b.curr = (char *)(data) + (len);                                  \
+  } while (0)
+#define GRN_JSON_SET(ctx, obj, data, len)                                      \
+  do {                                                                         \
+    if ((obj)->header.impl_flags & GRN_OBJ_REFER) {                            \
+      GRN_JSON_SET_REF((obj), (data), (len));                                  \
+    } else {                                                                   \
+      grn_bulk_write_from((ctx),                                               \
+                          (obj),                                               \
+                          (const char *)(data),                                \
+                          0,                                                   \
+                          (unsigned int)(len));                                \
+    }                                                                          \
+  } while (0)
+#define GRN_JSON_VALUE(obj) ((const uint8_t *)GRN_BULK_HEAD(obj))
+#define GRN_JSON_LEN(obj)   GRN_BULK_VSIZE(obj)
+
 #define GRN_BOOL_INIT(obj, flags)                                              \
   GRN_VALUE_FIX_SIZE_INIT(obj, flags, GRN_DB_BOOL)
 #define GRN_INT8_INIT(obj, flags)                                              \

--- a/include/groonga/json.h
+++ b/include/groonga/json.h
@@ -1,0 +1,260 @@
+/*
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief JSON parser that parses JSON text (\ref GRN_DB_TEXT) and
+ * stores parsed JSON as \ref GRN_DB_JSON.
+ *
+ * \since 15.2.2
+ */
+typedef struct _grn_json_parser grn_json_parser;
+
+/**
+ * \brief Open a new JSON parser.
+ *
+ * \param ctx The context object.
+ * \param input The JSON text.
+ * \param output The parsed JSON.
+ *
+ * \return A newly created JSON parser on success, `NULL` on error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_json_parser *
+grn_json_parser_open(grn_ctx *ctx, grn_obj *input, grn_obj *output);
+
+/**
+ * \brief Close a JSON parser.
+ *
+ * \param ctx The context object.
+ * \param parser The parser to close.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_rc
+grn_json_parser_close(grn_ctx *ctx, grn_json_parser *parser);
+
+/**
+ * \brief Parse the given JSON text.
+ *
+ * \param ctx The context object.
+ * \param parser The parser.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_rc
+grn_json_parser_parse(grn_ctx *ctx, grn_json_parser *parser);
+
+/**
+ * \brief JSON reader that readers values from parses JSON (\ref
+ * GRN_DB_JSON).
+ *
+ * \since 15.2.2
+ */
+typedef struct _grn_json_reader grn_json_reader;
+
+/**
+ * \brief Open a new JSON reader.
+ *
+ * \param ctx The context object.
+ * \param json The parsed JSON.
+ *
+ * \return A newly created JSON reader on success, `NULL` on error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_json_reader *
+grn_json_reader_open(grn_ctx *ctx, grn_obj *json);
+
+/**
+ * \brief Close a JSON reader.
+ *
+ * \param ctx The context object.
+ * \param reader The reader to close.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_rc
+grn_json_reader_close(grn_ctx *ctx, grn_json_reader *reader);
+
+/**
+ * \brief JSON value type.
+ *
+ * \since 15.2.2
+ */
+typedef enum {
+  GRN_JSON_VALUE_UNKNOWN,
+  GRN_JSON_VALUE_NULL,
+  GRN_JSON_VALUE_FALSE,
+  GRN_JSON_VALUE_TRUE,
+  GRN_JSON_VALUE_INT64,
+  GRN_JSON_VALUE_FLOAT,
+  GRN_JSON_VALUE_ARRAY,
+  GRN_JSON_VALUE_OBJECT,
+} grn_json_value_type;
+
+/**
+ * \brief Move to the next value.
+ *
+ * The initial state doesn't focus on any value. You must call this at
+ * least once. This returns \ref GRN_END_OF_DATA when all values are
+ * processed. So you can use the following loop:
+ *
+ * ```c
+ * grn_json_reader *reader = grn_json_reader_open(ctx, json);
+ * if (!reader) {
+ *   // Process error
+ * }
+ * while (true) {
+ *   grn_rc rc = grn_json_reader_next(ctx, reader);
+ *   if (rc == GRN_END_OF_DATA) {
+ *     break;
+ *   }
+ *   if (rc != GRN_SUCCESS) {
+ *     // Process error.
+ *     break;
+ *   }
+ *   // Process the current value with grn_json_reader_get_type(),
+ *   // grn_json_reader_get_value() and grn_json_reader_get_size().
+ * }
+ * grn_json_reader_close(ctx, reader);
+ * ```
+ *
+ * \param ctx The context object.
+ * \param reader The reader.
+ *
+ * \return \ref GRN_SUCCESS on success, \ref GRN_END_OF_DATA on all
+ *         processed, the appropriate \ref grn_rc on error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_rc
+grn_json_reader_next(grn_ctx *ctx, grn_json_reader *reader);
+
+/**
+ * \brief Return the current value type.
+ *
+ * \param ctx The context object.
+ * \param reader The reader.
+ *
+ * \return If the current value is `null`, \ref GRN_JSON_VALUE_NULL.
+ *
+ *         If the current value is `false`, \ref GRN_JSON_VALUE_FALSE.
+ *
+ *         If the current value is `true`, \ref GRN_JSON_VALUE_TRUE.
+ *
+ *         If the current value is an integer, \ref
+ *         GRN_JSON_VALUE_INT64.
+ *
+ *         If the current value is a floating-point number, \ref
+ *         GRN_JSON_VALUE_FLOAT.
+ *
+ *         If the current value is an array, \ref
+ *         GRN_JSON_VALUE_ARRAY.
+ *
+ *         If the current value is an array, \ref
+ *         GRN_JSON_VALUE_OBJECT.
+ *
+ *         Otherwise, \ref GRN_JSON_VALUE_UNKNOWN.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_json_value_type
+grn_json_reader_get_type(grn_ctx *ctx, grn_json_reader *reader);
+
+/**
+ * \brief Return the current value.
+ *
+ * This is owned by the reader. Caller must not free it. The returned
+ * value is invalid when you call \ref grn_json_reader_next. If you
+ * want to use this after the next \ref grn_json_reader_next call, you
+ * need to copy this by yourself.
+ *
+ * \param ctx The context object.
+ * \param reader The reader.
+ *
+ * \return If the current value is `null`, \ref GRN_DB_VOID bulk.
+ *
+ *         If the current value is `false` or `true`, \ref GRN_DB_BOOL
+ *         bulk.
+ *
+ *         If the current value is an integer, \ref GRN_DB_INT64 bulk.
+ *
+ *         If the current value is a floating-point number, \ref
+ *         GRN_DB_FLOAT bulk.
+ *
+ *         Otherwise, `NULL`. You can get array elements and object
+ *         members by calling \ref grn_json_reader_next.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_obj *
+grn_json_reader_get_value(grn_ctx *ctx, grn_json_reader *reader);
+
+/**
+ * \brief Return the size of the current value.
+ *
+ * \param ctx The context object.
+ * \param reader The reader.
+ *
+ * \return If the current value is an array, the number of elements.
+ *
+ *         If the current value is an object, the number of members.
+ *
+ *         Otherwise, `0`.
+ *
+ * \since 15.2.2
+ */
+GRN_API size_t
+grn_json_reader_get_size(grn_ctx *ctx, grn_json_reader *reader);
+
+/**
+ * \brief Stringify parsed JSON.
+ *
+ * \param ctx The context object.
+ * \param json The JSON to stringify.
+ * \param buffer The output buffer.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 15.2.2
+ */
+GRN_API grn_rc
+grn_json_to_string(grn_ctx *ctx,
+                   grn_obj *json,
+                   grn_obj *buffer);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/groonga/output.h
+++ b/include/groonga/output.h
@@ -173,6 +173,12 @@ grn_output_binary(grn_ctx *ctx,
                   const uint8_t *value,
                   size_t value_len);
 GRN_API void
+grn_output_json(grn_ctx *ctx,
+                grn_obj *outbuf,
+                grn_content_type output_type,
+                const uint8_t *value,
+                size_t value_len);
+GRN_API void
 grn_output_bool(grn_ctx *ctx,
                 grn_obj *outbuf,
                 grn_content_type output_type,

--- a/lib/cpp_sources.am
+++ b/lib/cpp_sources.am
@@ -16,6 +16,7 @@ libgroonga_cpp_source =				\
 	grn_language_model.hpp			\
 	grn_task_executor.hpp			\
 	ii.cpp					\
+	json.cpp				\
 	language_model.cpp			\
 	portability.cpp				\
 	token_column.cpp			\

--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -1,0 +1,545 @@
+/*
+  Copyright (C) 2025  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "grn_ctx.h"
+
+#ifdef GRN_WITH_SIMDJSON
+#  include <string>
+
+#  include <simdjson.h>
+#endif
+
+
+namespace {
+  enum class Type {
+    kObject   = 0,
+    kArray    = 1,
+    kString   = 2,
+    kInteger  = 3,
+    kDouble   = 4,
+    kConstant = 5,
+  };
+
+  namespace metadata {
+    enum class Constant {
+      kTrue = 0,
+      kFalse = 1,
+      kNull = 2,
+    };
+  }
+
+  struct Tag {
+    Type type;
+    bool is_embedded;
+    uint8_t metadata;
+    uint32_t data;
+  };
+
+#ifdef GRN_WITH_SIMDJSON
+  uint32_t
+  pack_tag(Type type, bool is_embedded, uint8_t metadata, uint32_t data) {
+    uint32_t tag = static_cast<uint32_t>(type);
+    if (is_embedded) {
+      tag |= (1 << 3);
+    }
+    tag |= (metadata << 4);
+    tag |= (data << 8);
+    return tag;
+  }
+
+  struct BaseTagWriter {
+    virtual ~BaseTagWriter() = default;
+    virtual void write(Type type, bool is_embedded, uint8_t metadata, uint32_t data) = 0;
+  };
+
+  struct TagWriter : public BaseTagWriter {
+    grn_ctx *ctx_;
+    grn_obj buffer;
+    uint32_t size16;
+    uint32_t size32;
+
+    TagWriter(grn_ctx *ctx) : ctx_(ctx), buffer(), size16(0), size32(0) {
+      GRN_BINARY_INIT(&buffer, 0);
+    }
+
+    ~TagWriter() {
+      GRN_OBJ_FIN(ctx_, &buffer);
+    }
+
+    void write(Type type, bool is_embedded, uint8_t metadata, uint32_t data) override {
+      auto tag = pack_tag(type, is_embedded, metadata, data);
+      if (size32 > 0 || data > 255) {
+        GRN_UINT32_PUT(ctx_, &buffer, tag);
+        size32 += sizeof(uint32_t);
+      } else {
+        GRN_UINT16_PUT(ctx_, &buffer, tag);
+        size16 += sizeof(uint16_t);
+      }
+    }
+  };
+
+  struct RootTagWriter : public BaseTagWriter  {
+    grn_ctx *ctx_;
+    grn_obj buffer;
+
+    RootTagWriter(grn_ctx *ctx) : ctx_(ctx), buffer() {
+      GRN_BINARY_INIT(&buffer, 0);
+    }
+
+    ~RootTagWriter() {
+      GRN_OBJ_FIN(ctx_, &buffer);
+    }
+
+    void write(Type type, bool is_embedded, uint8_t metadata, uint32_t data) override {
+      assert(data == 0); // Root tag's data must be zero
+      auto tag = pack_tag(type, is_embedded, metadata, 0);
+      GRN_UINT8_PUT(ctx_, &buffer, tag);
+    }
+  };
+
+  class JSONParser {
+  public:
+    JSONParser(grn_ctx *ctx,
+               grn_obj *input,
+               grn_obj *output) : ctx_(ctx), input_(input), output_(output), root_tag_writer_(ctx_) {
+    }
+
+    ~JSONParser() = default;
+
+    void parse() {
+      using json_type = simdjson::fallback::ondemand::json_type;
+      const char *tag = "[json-parser][parse]";
+      auto ctx = ctx_;
+
+      auto rc = grn_bulk_reserve(ctx_, input_, simdjson::SIMDJSON_PADDING);
+      if (rc != GRN_SUCCESS) {
+        return;
+      }
+
+      simdjson::ondemand::parser parser;
+      auto document = parser.iterate(GRN_TEXT_VALUE(input_),
+                                     GRN_TEXT_LEN(input_),
+                                     GRN_BULK_WSIZE(input_));
+      if (document.error() != simdjson::SUCCESS) {
+        ERR(GRN_INVALID_ARGUMENT,
+            "%s failed to parse: %s",
+            tag, simdjson::error_message(document.error()));
+        return;
+      }
+
+      json_type type;
+      auto error_code = document.type().get(type);
+      if (error_code != simdjson::SUCCESS) {
+        ERR(GRN_INVALID_ARGUMENT,
+            "%s failed to get root value type: %s", tag, simdjson::error_message(error_code));
+        return;
+      }
+      switch (type) {
+      case json_type::array:
+        ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s array isn't supported yet", tag);
+        return;
+      case json_type::object:
+        ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s object isn't supported yet", tag);
+        return;
+      case json_type::number:
+        ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s number isn't supported yet", tag);
+        return;
+      case json_type::string:
+        ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s string isn't supported yet", tag);
+        return;
+      case json_type::boolean:
+        if (!parse_boolean(root_tag_writer_, document)) {
+          return;
+        }
+        break;
+      case json_type::null:
+        if (!parse_null(root_tag_writer_, document)) {
+          return;
+        }
+        break;
+      default:
+        ERR(GRN_INVALID_ARGUMENT,
+            "%s failed to get root value: %s", tag, simdjson::error_message(document.error()));
+        return;
+      }
+
+      grn_bulk_write(ctx_, output_,
+                     GRN_BULK_HEAD(&(root_tag_writer_.buffer)),
+                     GRN_BULK_VSIZE(&(root_tag_writer_.buffer)));
+    }
+
+  private:
+    grn_ctx *ctx_;
+    grn_obj *input_;
+    grn_obj *output_;
+    RootTagWriter root_tag_writer_;
+
+    template <typename TagWriter, typename Container>
+    bool parse_boolean(TagWriter& tag_writer, Container& container)
+    {
+      const char *tag = "[json-parser][parse][boolean]";
+      auto ctx = ctx_;
+
+      bool value;
+      auto error_code = container.get_bool().get(value);
+      if (error_code != simdjson::SUCCESS) {
+        ERR(GRN_INVALID_ARGUMENT,
+            "%s failed to get value: %s", tag, simdjson::error_message(error_code));
+        return false;
+      }
+      uint8_t metadata = value ?
+        static_cast<uint8_t>(metadata::Constant::kTrue) :
+        static_cast<uint8_t>(metadata::Constant::kFalse);
+      tag_writer.write(Type::kConstant, true, metadata, 0);
+      return true;
+    }
+
+    template <typename TagWriter, typename Container>
+    bool parse_null(TagWriter& tag_writer, Container& container)
+    {
+      const char *tag = "[json-parser][parse][null]";
+      auto ctx = ctx_;
+
+      bool is_null;
+      auto error_code = container.is_null().get(is_null);
+      if (error_code != simdjson::SUCCESS) {
+        ERR(GRN_INVALID_ARGUMENT,
+            "%s failed to get value: %s", tag, simdjson::error_message(error_code));
+        return false;
+      }
+      uint8_t metadata = static_cast<uint8_t>(metadata::Constant::kNull);
+      tag_writer.write(Type::kConstant, true, metadata, 0);
+      return true;
+    }
+  };
+#endif
+
+  class JSONReader {
+  public:
+    JSONReader(grn_ctx *ctx,
+               grn_obj *json) : ctx_(ctx), json_(json), current_offset_(0), current_type_(GRN_JSON_VALUE_UNKNOWN), current_value_(nullptr), current_size_(0) {
+      GRN_VOID_INIT(&null_value_);
+      GRN_BOOL_INIT(&bool_value_, 0);
+      GRN_INT64_INIT(&int64_value_, 0);
+      GRN_FLOAT_INIT(&float_value_, 0);
+    }
+
+    ~JSONReader() {
+      GRN_OBJ_FIN(ctx_, &null_value_);
+      GRN_OBJ_FIN(ctx_, &bool_value_);
+      GRN_OBJ_FIN(ctx_, &int64_value_);
+      GRN_OBJ_FIN(ctx_, &float_value_);
+    };
+
+    grn_rc next() {
+      static const char *tag = "[json-reader][next]";
+      auto ctx = ctx_;
+
+      if (current_offset_ >= GRN_JSON_LEN(json_)) {
+        return GRN_END_OF_DATA;
+      }
+      if (current_offset_ == 0) {
+        auto root_tag = unpack_tag(GRN_JSON_VALUE(json_)[current_offset_]);
+        if (root_tag.type == Type::kConstant) {
+          current_offset_ += sizeof(uint8_t);
+          current_size_ = 0;
+          auto constant_metadata = static_cast<metadata::Constant>(root_tag.metadata);
+          switch (constant_metadata) {
+          case metadata::Constant::kTrue:
+            current_type_ = GRN_JSON_VALUE_TRUE;
+            GRN_BOOL_SET(ctx_, &bool_value_, true);
+            current_value_ = &bool_value_;
+            current_size_ = 0;
+            break;
+          case metadata::Constant::kFalse:
+            current_type_ = GRN_JSON_VALUE_FALSE;
+            GRN_BOOL_SET(ctx_, &bool_value_, false);
+            current_value_ = &bool_value_;
+            current_size_ = 0;
+            break;
+          case metadata::Constant::kNull:
+            current_type_ = GRN_JSON_VALUE_NULL;
+            current_value_ = &null_value_;
+            break;
+          default:
+            ERR(GRN_INVALID_ARGUMENT,
+                "%s invalid constant metadata: %u", tag, root_tag.metadata);
+            return ctx->rc;
+          }
+        } else {
+          ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+              "%s unsupported root value type", tag);
+          return ctx->rc;
+        }
+      } else {
+        ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+            "%s root value is only supported", tag);
+        return ctx->rc;
+      }
+      return ctx->rc;
+    }
+
+    grn_json_value_type type() {
+      return current_type_;
+    }
+
+    grn_obj *value() {
+      return current_value_;
+    }
+
+    size_t size() {
+      return current_size_;
+    }
+
+  private:
+    grn_ctx *ctx_;
+    grn_obj *json_;
+    uint32_t current_offset_;
+    grn_json_value_type current_type_;
+    grn_obj *current_value_;
+    size_t current_size_;
+    grn_obj null_value_;
+    grn_obj bool_value_;
+    grn_obj int64_value_;
+    grn_obj float_value_;
+
+    Tag unpack_tag(uint32_t raw_tag) {
+      Tag tag;
+      tag.type = static_cast<Type>(raw_tag & 0b111);
+      tag.is_embedded = (raw_tag & (0b10000));
+      tag.metadata = ((raw_tag >> 4) & (0b00001111));
+      tag.data = (raw_tag >> 8);
+      return tag;
+    }
+  };
+
+  class JSONStringifier {
+  public:
+    JSONStringifier(grn_ctx *ctx, grn_obj *json, grn_obj *buffer) : ctx_(ctx), json_(json), buffer_(buffer) {
+    }
+    ~JSONStringifier() = default;
+
+    void stringify() {
+      JSONReader reader(ctx_, json_);
+      while (true) {
+        if (!stringify_value(reader)) {
+          break;
+        }
+      }
+    }
+
+    private:
+    grn_ctx *ctx_;
+    grn_obj *json_;
+    grn_obj *buffer_;
+
+    bool stringify_value(JSONReader &reader) {
+      const char *tag = "[json][to-string]";
+
+      auto rc = reader.next();
+      if (rc == GRN_END_OF_DATA) {
+        return false;
+      }
+      if (rc != GRN_SUCCESS) {
+        return false;
+      }
+      switch (reader.type()) {
+      case GRN_JSON_VALUE_NULL:
+        GRN_TEXT_PUTS(ctx_, buffer_, "null");
+        return true;
+      case GRN_JSON_VALUE_FALSE:
+        GRN_TEXT_PUTS(ctx_, buffer_, "false");
+        return true;
+      case GRN_JSON_VALUE_TRUE:
+        GRN_TEXT_PUTS(ctx_, buffer_, "true");
+        return true;
+      case GRN_JSON_VALUE_INT64:
+        grn_text_otoj(ctx_, buffer_, reader.value(), nullptr);
+        return true;
+      case GRN_JSON_VALUE_FLOAT:
+        grn_text_otoj(ctx_, buffer_, reader.value(), nullptr);
+        return true;
+      case GRN_JSON_VALUE_ARRAY:
+      {
+        GRN_TEXT_PUTS(ctx_, buffer_, "[");
+        size_t n = reader.size();
+        for (size_t i = 0; i < n; ++i) {
+          if (i != 0) {
+            GRN_TEXT_PUTS(ctx_, buffer_, ",");
+          }
+          if (!stringify_value(reader)) {
+            return false;
+          }
+        }
+        GRN_TEXT_PUTS(ctx_, buffer_, "]");
+        return true;
+      }
+      case GRN_JSON_VALUE_OBJECT:
+      {
+        GRN_TEXT_PUTS(ctx_, buffer_, "{");
+        size_t n = reader.size();
+        for (size_t i = 0; i < n; ++i) {
+          if (i != 0) {
+            GRN_TEXT_PUTS(ctx_, buffer_, ",");
+          }
+          if (!stringify_value(reader)) {
+            return false;
+          }
+          GRN_TEXT_PUTS(ctx_, buffer_, ":");
+          if (!stringify_value(reader)) {
+            return false;
+          }
+        }
+        GRN_TEXT_PUTS(ctx_, buffer_, "}");
+        return true;
+      }
+      default:
+      {
+        auto ctx = ctx_;
+        ERR(GRN_INVALID_ARGUMENT, "%s invalid JSON", tag);
+        return false;
+      }
+      }
+    }
+  };
+}
+
+extern "C" {
+struct _grn_json_parser {
+#ifdef GRN_WITH_SIMDJSON
+  JSONParser *parser;
+#else
+  void *parser;
+#endif
+  };
+
+grn_json_parser *
+grn_json_parser_open(grn_ctx *ctx,
+                     grn_obj *input,
+                     grn_obj *output)
+{
+  GRN_API_ENTER;
+  grn_json_parser *parser = nullptr;
+#ifdef GRN_WITH_SIMDJSON
+  parser = static_cast<grn_json_parser *>(GRN_MALLOC(sizeof(grn_json_parser)));
+  if (!parser) {
+    GRN_API_RETURN(nullptr);
+  }
+  parser->parser = new JSONParser(ctx, input, output);
+#else
+  const char *tag = "[json-parser][open]";
+  ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s simdjson isn't enabled", tag);
+#endif
+  GRN_API_RETURN(parser);
+}
+
+grn_rc
+grn_json_parser_close(grn_ctx *ctx, grn_json_parser *parser)
+{
+  GRN_API_ENTER;
+#ifdef GRN_WITH_SIMDJSON
+  if (parser) {
+    delete parser->parser;
+    GRN_FREE(parser);
+  }
+#endif
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_rc
+grn_json_parser_parse(grn_ctx *ctx, grn_json_parser *parser)
+{
+  GRN_API_ENTER;
+#ifdef GRN_WITH_SIMDJSON
+  parser->parser->parse();
+#else
+  const char *tag = "[json-parser][parse]";
+  ERR(GRN_FUNCTION_NOT_IMPLEMENTED, "%s simdjson isn't enabled", tag);
+#endif
+  GRN_API_RETURN(ctx->rc);
+}
+
+struct _grn_json_reader {
+  JSONReader *reader;
+};
+
+grn_json_reader *
+grn_json_reader_open(grn_ctx *ctx,
+                     grn_obj *json)
+{
+  GRN_API_ENTER;
+  auto reader = static_cast<grn_json_reader *>(GRN_MALLOC(sizeof(grn_json_reader)));
+  if (!reader) {
+    GRN_API_RETURN(nullptr);
+  }
+  reader->reader = new JSONReader(ctx, json);
+  GRN_API_RETURN(reader);
+}
+
+grn_rc
+grn_json_reader_close(grn_ctx *ctx, grn_json_reader *reader)
+{
+  GRN_API_ENTER;
+  if (reader) {
+    delete reader->reader;
+    GRN_FREE(reader);
+  }
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_rc
+grn_json_reader_next(grn_ctx *ctx, grn_json_reader *reader)
+{
+  GRN_API_ENTER;
+  reader->reader->next();
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_json_value_type
+grn_json_reader_get_type(grn_ctx *ctx, grn_json_reader *reader)
+{
+  GRN_API_ENTER;
+  grn_json_value_type type = reader->reader->type();
+  GRN_API_RETURN(type);
+}
+
+grn_obj *
+grn_json_reader_get_value(grn_ctx *ctx, grn_json_reader *reader)
+{
+  GRN_API_ENTER;
+  grn_obj *value = reader->reader->value();
+  GRN_API_RETURN(value);
+}
+
+size_t
+grn_json_reader_get_size(grn_ctx *ctx, grn_json_reader *reader)
+{
+  GRN_API_ENTER;
+  size_t size = reader->reader->size();
+  GRN_API_RETURN(size);
+}
+
+grn_rc
+grn_json_to_string(grn_ctx *ctx, grn_obj *json, grn_obj *buffer)
+{
+  GRN_API_ENTER;
+  JSONStringifier stringifier(ctx, json, buffer);
+  stringifier.stringify();
+  GRN_API_RETURN(ctx->rc);
+}
+}

--- a/lib/output.c
+++ b/lib/output.c
@@ -940,6 +940,49 @@ grn_output_binary(grn_ctx *ctx,
 }
 
 void
+grn_output_json(grn_ctx *ctx,
+                grn_obj *outbuf,
+                grn_content_type output_type,
+                const uint8_t *value,
+                size_t value_len)
+{
+  put_delimiter(ctx, outbuf, output_type);
+  grn_obj bulk;
+  GRN_JSON_INIT(&bulk, GRN_OBJ_DO_SHALLOW_COPY);
+  GRN_JSON_SET(ctx, &bulk, value, value_len);
+  switch (output_type) {
+  case GRN_CONTENT_JSON:
+    /* TODO: pretty output */
+    grn_json_to_string(ctx, &bulk, outbuf);
+    break;
+  case GRN_CONTENT_TSV:
+    ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+        "[output][json] TSV output isn't supported");
+    break;
+  case GRN_CONTENT_XML:
+    ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+        "[output][json] XML output isn't supported");
+    break;
+  case GRN_CONTENT_MSGPACK:
+    ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+        "[output][json] MessagePack output isn't supported");
+    break;
+  case GRN_CONTENT_GROONGA_COMMAND_LIST:
+    ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+        "[output][json] Groonga command list output isn't supported");
+    break;
+  case GRN_CONTENT_APACHE_ARROW:
+    ERR(GRN_FUNCTION_NOT_IMPLEMENTED,
+        "[output][json] Apache Arrow  output isn't supported");
+    break;
+  case GRN_CONTENT_NONE:
+    break;
+  }
+  GRN_OBJ_FIN(ctx, &bulk);
+  INCR_LENGTH;
+}
+
+void
 grn_output_bool(grn_ctx *ctx,
                 grn_obj *outbuf,
                 grn_content_type output_type,
@@ -1655,6 +1698,13 @@ grn_output_bulk(grn_ctx *ctx,
                       output_type,
                       GRN_BINARY_VALUE(bulk),
                       GRN_BINARY_LEN(bulk));
+    break;
+  case GRN_DB_JSON:
+    grn_output_json(ctx,
+                    outbuf,
+                    output_type,
+                    GRN_JSON_VALUE(bulk),
+                    GRN_JSON_LEN(bulk));
     break;
   default:
     if (format) {

--- a/lib/str.c
+++ b/lib/str.c
@@ -3317,6 +3317,12 @@ grn_text_otoj(grn_ctx *ctx, grn_obj *bulk, grn_obj *obj, grn_obj_format *format)
       grn_obj_cast(ctx, obj, bulk, false);
       GRN_TEXT_PUTC(ctx, bulk, '"');
       break;
+    case GRN_DB_JSON:
+      GRN_TEXT_PUTC(ctx, bulk, '"');
+      /* TODO: Escape " */
+      grn_json_to_string(ctx, obj, bulk);
+      GRN_TEXT_PUTC(ctx, bulk, '"');
+      break;
     default:
       if (format) {
         size_t j;

--- a/test/command/suite/load/json/false.expected
+++ b/test/command/suite/load/json/false.expected
@@ -1,0 +1,20 @@
+table_create Notes TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Notes data COLUMN_SCALAR JSON
+[[0,0.0,0.0],true]
+load --table Notes
+[
+{"data": "false"}
+]
+[[0,0.0,0.0],1]
+select Notes
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["data","JSON"]],[1,false]]]]
+dump
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+["_id","data"],
+[1,"false"]
+]

--- a/test/command/suite/load/json/false.test
+++ b/test/command/suite/load/json/false.test
@@ -1,0 +1,13 @@
+#@require-feature simdjson
+
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+{"data": "false"}
+]
+
+select Notes
+
+dump

--- a/test/command/suite/load/json/null.expected
+++ b/test/command/suite/load/json/null.expected
@@ -1,0 +1,20 @@
+table_create Notes TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Notes data COLUMN_SCALAR JSON
+[[0,0.0,0.0],true]
+load --table Notes
+[
+{"data": "null"}
+]
+[[0,0.0,0.0],1]
+select Notes
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["data","JSON"]],[1,null]]]]
+dump
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+["_id","data"],
+[1,"null"]
+]

--- a/test/command/suite/load/json/null.test
+++ b/test/command/suite/load/json/null.test
@@ -1,0 +1,13 @@
+#@require-feature simdjson
+
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+{"data": "null"}
+]
+
+select Notes
+
+dump

--- a/test/command/suite/load/json/true.expected
+++ b/test/command/suite/load/json/true.expected
@@ -1,0 +1,20 @@
+table_create Notes TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Notes data COLUMN_SCALAR JSON
+[[0,0.0,0.0],true]
+load --table Notes
+[
+{"data": "true"}
+]
+[[0,0.0,0.0],1]
+select Notes
+[[0,0.0,0.0],[[[1],[["_id","UInt32"],["data","JSON"]],[1,true]]]]
+dump
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+["_id","data"],
+[1,"true"]
+]

--- a/test/command/suite/load/json/true.test
+++ b/test/command/suite/load/json/true.test
@@ -1,0 +1,13 @@
+#@require-feature simdjson
+
+table_create Notes TABLE_NO_KEY
+column_create Notes data COLUMN_SCALAR JSON
+
+load --table Notes
+[
+{"data": "true"}
+]
+
+select Notes
+
+dump

--- a/tools/parsed-json.rb
+++ b/tools/parsed-json.rb
@@ -470,7 +470,6 @@ class ParsedJSONWriter
 
     def write(type, is_embedded, metadata, data)
       tag = pack_tag(type, is_embedded, metadata, data)
-      offset = @buffer.bytesize
       if @size32 > 0 or data > 255
         @buffer << [tag].pack("L")
         @size32 += UINT32_SIZE


### PR DESCRIPTION
Other types will be implemented later.

* Is it OK that we output JSON as JSON not string in `select` result?
* We dump JSON as string in `dump`