### PR TITLE
xsimd: add support for 14.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
           ?lib/distance_avx\.cpp|
           ?lib/distance_avx2\.cpp|
           ?lib/distance_avx512\.cpp|
-          ?lib/distance_generic\.cpp|
+          ?lib/distance_common\.cpp|
           ?lib/error\.c|
           ?lib/expr\.c|
           ?lib/expr_executor\.cpp|

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1510,9 +1510,9 @@ else()
   set(GRN_WITH_BLOSC FALSE)
 endif()
 
-set(GRN_XSIMD_BUNDLED_VERSION "13.2.0")
+set(GRN_XSIMD_BUNDLED_VERSION "14.0.0")
 set(GRN_XSIMD_BUNDLED_SHA256
-    "edd8cd3d548c185adc70321c53c36df41abe64c1fe2c67bc6d93c3ecda82447a")
+    "17de0236954955c10c09d6938d4c5f3a3b92d31be5dadd1d5d09fc1b15490dce")
 set(GRN_WITH_XSIMD
     "auto"
     CACHE STRING "Support SIMD by xsimd.")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -92,10 +92,10 @@ if(GRN_WITH_XSIMD)
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " ${GRN_C_FLAGS_NEON64}")
   endif()
-  list(APPEND LIBGROONGA_CPP_SOURCES distance_generic.cpp)
+  list(APPEND LIBGROONGA_CPP_SOURCES distance_common.cpp)
   if(GRN_C_COMPILER_GNU_LIKE)
     set_property(
-      SOURCE distance_generic.cpp
+      SOURCE distance_common.cpp
       APPEND_STRING
       PROPERTY COMPILE_FLAGS " -Wno-float-equal")
   endif()

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -128,8 +128,8 @@ EXTRA_DIST =						\
 	distance_avx.cpp				\
 	distance_avx2.cpp				\
 	distance_avx512.cpp				\
+	distance_common.cpp				\
 	distance_neon64.cpp				\
-	distance_generic.cpp				\
 	grn_ecmascript.c				\
 	grn_ecmascript.h				\
 	grn_ecmascript.lemon				\

--- a/lib/distance_common.cpp
+++ b/lib/distance_common.cpp
@@ -103,7 +103,7 @@ namespace grn {
 } // namespace grn
 
 #define GRN_INSTANTIATION_SIMSIMD_ARCH serial
-#define GRN_INSTANTIATION_XSIMD_ARCH   xsimd::generic
+#define GRN_INSTANTIATION_XSIMD_ARCH   xsimd::common
 #include "grn_distance_instantiation.hpp"
 #undef GRN_INSTANTIATION_SIMSIMD_ARCH
 #undef GRN_INSTANTIATION_XSIMD_ARCH

--- a/lib/grn_distance.hpp
+++ b/lib/grn_distance.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2024-2025  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -30,6 +30,12 @@
 
 #ifdef GRN_WITH_XSIMD
 #  include <xsimd/xsimd.hpp>
+#endif
+
+#if defined(GRN_WITH_XSIMD) && XSIMD_VERSION_MAJOR < 14
+namespace xsimd {
+  using common = generic;
+}
 #endif
 
 namespace grn {
@@ -114,7 +120,7 @@ namespace grn {
 #  undef GRN_INSTANTIATION_XSIMD_ARCH
 
 #  define GRN_INSTANTIATION_SIMSIMD_ARCH serial
-#  define GRN_INSTANTIATION_XSIMD_ARCH   xsimd::generic
+#  define GRN_INSTANTIATION_XSIMD_ARCH   xsimd::common
 #  include "grn_distance_instantiation.hpp"
 #  undef GRN_INSTANTIATION_SIMSIMD_ARCH
 #  undef GRN_INSTANTIATION_XSIMD_ARCH
@@ -148,7 +154,7 @@ namespace grn {
 #    ifdef GRN_WITH_SIMD_NEON64
           xsimd::neon64,
 #    endif
-          xsimd::generic>>(l2_norm{});
+          xsimd::common>>(l2_norm{});
         return dispatched(vector_raw, n_elements);
       }
 #  endif
@@ -186,7 +192,7 @@ namespace grn {
 #    ifdef GRN_WITH_SIMD_NEON64
           xsimd::neon64,
 #    endif
-          xsimd::generic>>(difference_l1_norm{});
+          xsimd::common>>(difference_l1_norm{});
         return dispatched(vector_raw1, vector_raw2, n_elements);
       }
 #  endif
@@ -247,7 +253,7 @@ namespace grn {
 #    ifdef GRN_WITH_SIMD_NEON64
           xsimd::neon64,
 #    endif
-          xsimd::generic>>(difference_l2_norm_squared{});
+          xsimd::common>>(difference_l2_norm_squared{});
         return dispatched(vector_raw1, vector_raw2, n_elements);
       }
 #  endif
@@ -308,7 +314,7 @@ namespace grn {
 #    ifdef GRN_WITH_SIMD_NEON64
           xsimd::neon64,
 #    endif
-          xsimd::generic>>(inner_product{});
+          xsimd::common>>(inner_product{});
         return dispatched(vector_raw1, vector_raw2, n_elements);
       }
 #  endif
@@ -368,7 +374,7 @@ namespace grn {
 #    ifdef GRN_WITH_SIMD_NEON64
           xsimd::neon64,
 #    endif
-          xsimd::generic>>(cosine{});
+          xsimd::common>>(cosine{});
         return dispatched(vector_raw1, vector_raw2, n_elements);
       }
 #  endif


### PR DESCRIPTION
GitHub: Fix GH-2689

It renamed `xsimd::generic` to `xsimd::common`.