### PR TITLE
cmake libedit: include cmake file in release tar

### DIFF
--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -1,5 +1,6 @@
 EXTRA_DIST =					\
 	FindGroongaRapidJSON.cmake		\
+	FindGroongalibedit.cmake		\
 	FindGroongalibstemmer.cmake		\
 	FindGroongalz4.cmake			\
 	FindGroongamsgpackc.cmake		\


### PR DESCRIPTION
Currently, the release tarball (e.g. https://packages.groonga.org/source/groonga/groonga-15.2.1.tar.gz) cannot detect libedit due to missing CMake file.

I think this is due to CMake file not included in EXTRA_DIST.