### PR TITLE
language_model_knn test: increase the responce read timeout period

### DIFF
--- a/test/command/suite/language_model/options/k/minus/one.test
+++ b/test/command/suite/language_model/options/k/minus/one.test
@@ -31,8 +31,8 @@ table_create RaBitQ TABLE_HASH_KEY ShortBinary \
                            "passage_prefix", "passage: ", \
                            "query_prefix", "query: ")'
 # This is for waiting for downloading model.
-#@sleep 3
 #@timeout 300
+#@read-timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text
 
 select Data \

--- a/test/command/suite/language_model/options/k/minus/three.test
+++ b/test/command/suite/language_model/options/k/minus/three.test
@@ -31,8 +31,8 @@ table_create RaBitQ TABLE_HASH_KEY ShortBinary \
                            "passage_prefix", "passage: ", \
                            "query_prefix", "query: ")'
 # This is for waiting for downloading model.
-#@sleep 3
 #@timeout 300
+#@read-timeout 300
 column_create RaBitQ data_text COLUMN_INDEX Data text
 
 select Data \


### PR DESCRIPTION
Because "column_create"’s response can be slow in language_model/options/k/minus/{one,three}.test