### PR TITLE
Fix a compatibility bug of ShortBinary/Binary/LongBinary/JSON

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -452,7 +452,7 @@ grn_db_open_ensure_float32(grn_ctx *ctx, grn_db *db)
 {
   return grn_db_open_ensure_type(ctx,
                                  db,
-                                 GRN_DB_FLAOT32,
+                                 GRN_DB_FLOAT32,
                                  GRN_TYPE_FLOAT32_NAME,
                                  GRN_TYPE_FLOAT32_NAME_LEN,
                                  GRN_TYPE_FLOAT32_FLAGS,


### PR DESCRIPTION
If we upgrade a DB that was created by Groonga 15.2.2 or earlier to Groonga 15.2.3 or 15.2.4, the "schema" command crashed. Because ShortBinary/Binary/LongBinary/JSON type aren't registered to the DB yet.

We need to register them to a DB if they don't exit.