### PR TITLE
compressor openzl: add body_element_size to grn_compress_data

### DIFF
--- a/lib/grn_compressor.h
+++ b/lib/grn_compressor.h
@@ -38,11 +38,15 @@ typedef struct grn_compress_data {
   void *body;
   uint32_t body_len;
 
-  /* Only for GRN_COMPRESSION_TYPE_BLOSC: Start */
+  /* Only for GRN_COMPRESSION_TYPE_BLOSC/OPENZL: Start */
   size_t body_n_elements;
   grn_column_flags body_column_flags;
   grn_id body_range;
-  /* Only for GRN_COMPRESSION_TYPE_BLOSC: End */
+  /* Only for GRN_COMPRESSION_TYPE_BLOSC/OPENZL: End */
+
+  /* Only for GRN_COMPRESSION_TYPE_OPENZL: Start */
+  size_t body_element_size;
+  /* Only for GRN_COMPRESSION_TYPE_OPENZL: End */
 
   void *footer;
   uint32_t footer_len;

--- a/lib/store.c
+++ b/lib/store.c
@@ -3816,7 +3816,8 @@ grn_ja_put(grn_ctx *ctx,
   if (data.type == GRN_COMPRESSION_TYPE_NONE) {
     return grn_ja_put_raw(ctx, ja, id, value, value_len, flags, cas);
   } else {
-    if (data.type == GRN_COMPRESSION_TYPE_BLOSC) {
+    if (data.type == GRN_COMPRESSION_TYPE_BLOSC ||
+        data.type == GRN_COMPRESSION_TYPE_OPENZL) {
       if ((ja->header->flags & GRN_OBJ_COLUMN_TYPE_MASK) ==
           GRN_OBJ_COLUMN_VECTOR) {
         size_t element_size = grn_type_id_size(ctx, ja->obj.range);
@@ -3834,6 +3835,9 @@ grn_ja_put(grn_ctx *ctx,
           }
         }
         data.body_n_elements = value_len / element_size;
+        if (data.type == GRN_COMPRESSION_TYPE_OPENZL) {
+          data.body_element_size = element_size;
+        }
       } else {
         data.body_n_elements = 1;
       }


### PR DESCRIPTION
Related: GH-2739

This is preparation for Float32 vector column compression with OpenZL.
`ZL_TypedRef_createNumeric()` requires element size as a parameter, so we store it as `body_element_size` in `grn_compress_data` in advance.