### PR TITLE
clang-format: add `SeparateDefinitionBlocks: Always`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -36,4 +36,5 @@ PPIndentWidth: 2
 PackConstructorInitializers: CurrentLine
 QualifierAlignment: Custom
 QualifierOrder: ['static', 'inline', 'const', 'type']
+SeparateDefinitionBlocks: Always
 SortIncludes: Never

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -917,12 +917,14 @@ typedef struct _grn_obj_header {
 
 struct _grn_obj {
   grn_obj_header header;
+
   union {
     struct {
       char *head;
       char *curr;
       char *tail;
     } b;
+
     struct {
       grn_obj *body;
       grn_section *sections;

--- a/lib/arrow.cpp
+++ b/lib/arrow.cpp
@@ -1591,6 +1591,7 @@ namespace grnarrow {
       }
       return builder.Finish(array);
     }
+
     arrow::Status
     build_uint64_array(std::vector<grn_id> &ids,
                        grn_obj *grn_column,

--- a/lib/ctx.cpp
+++ b/lib/ctx.cpp
@@ -2365,6 +2365,7 @@ grn_ctx_logv(grn_ctx *ctx, const char *fmt, va_list ap)
 /* This is for clang-format.
  * clang-format can't work with "static __declspec(noinline) void". */
 #  define grn_noinline __declspec(noinline)
+
 static grn_noinline void
 grn_ctx_log_back_trace_windows(grn_ctx *ctx, grn_log_level level)
 {
@@ -2509,6 +2510,7 @@ grn_exception_filter(EXCEPTION_POINTERS *info)
 }
 #elif defined(HAVE_SIGNAL_H) /* WIN32 */
 static bool crashed = false;
+
 static void
 grn_crash_handler(int signal_number, siginfo_t *info, void *context)
 {
@@ -2608,6 +2610,7 @@ grn_set_abrt_handler(void)
 
 #if defined(HAVE_SIGNAL_H) && !defined(WIN32)
 static struct sigaction old_int_handler;
+
 static void
 int_handler(int signal_number, siginfo_t *info, void *context)
 {
@@ -2616,6 +2619,7 @@ int_handler(int signal_number, siginfo_t *info, void *context)
 }
 
 static struct sigaction old_term_handler;
+
 static void
 term_handler(int signal_number, siginfo_t *info, void *context)
 {

--- a/lib/distance.cpp
+++ b/lib/distance.cpp
@@ -27,6 +27,7 @@ namespace grn {
   namespace distance {
 #ifdef GRN_WITH_SIMSIMD
     bool use_simsimd = true;
+
     namespace simsimd {
       simsimd_capability_t capabilities = simsimd_cap_serial_k;
     }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -1591,6 +1591,7 @@ exit:
   }
   GRN_API_RETURN(res);
 }
+
 #undef PUSH_N_ARGS_ARITHMETIC_OP
 #undef APPEND_UNARY_MINUS_OP
 
@@ -4196,6 +4197,7 @@ typedef struct {
   grn_hash *weight_set;
   snip_cond *snip_conds;
   int paren_depth;
+
   struct {
     const char *string;
     size_t string_length;
@@ -4225,10 +4227,12 @@ skip_space(grn_ctx *ctx, efs_info *q)
 
 typedef struct {
   grn_operator mode;
+
   union {
     struct {
       int32_t threshold;
     } similar;
+
     struct {
       int32_t max_interval;
       int32_t additional_last_interval;
@@ -4239,9 +4243,11 @@ typedef struct {
 #  undef near
 #endif
     } near;
+
     struct {
       int32_t policy;
     } term_extract;
+
     struct {
       int32_t threshold;
     } quorum;

--- a/lib/grn_ctx.h
+++ b/lib/grn_ctx.h
@@ -182,6 +182,7 @@ typedef struct {
   uint8_t subrec_offset;
   uint8_t record_unit;
   uint8_t subrec_unit;
+
   struct {
     grn_table_group_flags flags;
     grn_obj *calc_target;
@@ -189,6 +190,7 @@ typedef struct {
     grn_table_group_aggregator **aggregators;
     uint32_t n_aggregators;
   } group;
+
   uint32_t reference_count;
 } grn_db_obj;
 

--- a/lib/grn_ctx_impl.h
+++ b/lib/grn_ctx_impl.h
@@ -52,6 +52,7 @@ extern "C" {
 
 #ifdef GRN_WITH_MEMORY_DEBUG
 typedef struct _grn_alloc_info grn_alloc_info;
+
 struct _grn_alloc_info {
   void *address;
   bool freed;
@@ -66,6 +67,7 @@ struct _grn_alloc_info {
 #endif
 
 typedef struct _grn_mrb_data grn_mrb_data;
+
 struct _grn_mrb_data {
   bool initialized;
 #ifdef GRN_WITH_MRUBY
@@ -75,13 +77,16 @@ struct _grn_mrb_data {
   struct RClass *object_class;
   grn_hash *checked_procs;
   grn_hash *registered_plugins;
+
   struct {
     grn_obj from;
     grn_obj to;
   } buffer;
+
   struct {
     struct RClass *time_class;
   } builtin;
+
   struct {
     struct RClass *operator_class;
   } groonga;
@@ -89,6 +94,7 @@ struct _grn_mrb_data {
 };
 
 typedef struct _grn_lua_data grn_lua_data;
+
 struct _grn_lua_data {
   bool initialized;
 #ifdef GRN_WITH_LUAJIT
@@ -133,12 +139,14 @@ struct _grn_ctx_impl {
   struct {
     grn_obj *buf;
     grn_recv_handler_func func;
+
     union {
       void *ptr;
       int fd;
       uint32_t u32;
       uint64_t u64;
     } data;
+
     grn_content_type type;
     const char *mime_type;
     bool is_pretty;
@@ -158,6 +166,7 @@ struct _grn_ctx_impl {
   struct {
     int flags;
     grn_command_version version;
+
     struct {
       grn_obj *command;
       grn_command_version version;
@@ -209,6 +218,7 @@ struct _grn_ctx_impl {
     grn_critical_section lock;
     grn_obj pool;
   } children;
+
   grn_ctx *parent;
   grn_critical_section temporary_objects_lock;
 

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -273,11 +273,13 @@ grn_table_add_v(grn_ctx *ctx,
                 int key_size,
                 void **value,
                 int *added);
+
 typedef struct {
   bool added;
   bool ignore_empty_normalized_key;
   bool ignored;
 } grn_table_add_options;
+
 grn_id
 grn_table_add_by_key(grn_ctx *ctx,
                      grn_obj *table,
@@ -438,25 +440,31 @@ struct _grn_proc {
       grn_applier_func *applier;
       grn_sorter_func *sorter;
     } function;
+
     struct {
       grn_command_run_func *run;
     } command;
+
     struct {
       grn_tokenizer_build_func *build;
       grn_tokenizer_init_func *init;
       grn_tokenizer_next_func *next;
       grn_tokenizer_fin_func *fin;
     } tokenizer;
+
     struct {
       grn_token_filter_init_func *init;
       grn_token_filter_init_query_func *init_query;
       grn_token_filter_filter_func *filter;
       grn_token_filter_fin_func *fin;
     } token_filter;
+
     struct {
       grn_scorer_score_func *score;
     } scorer;
+
     grn_window_function_func *window_function;
+
     struct {
       grn_aggregator_init_func *init;
       grn_aggregator_update_func *update;

--- a/lib/grn_error.h
+++ b/lib/grn_error.h
@@ -121,6 +121,7 @@ grn_error_set(grn_ctx *ctx,
               const char *function,
               const char *format,
               ...) GRN_ATTRIBUTE_PRINTF(7);
+
 static inline void
 grn_error_set(grn_ctx *ctx,
               grn_log_level level,

--- a/lib/grn_expr_executor.h
+++ b/lib/grn_expr_executor.h
@@ -55,16 +55,19 @@ typedef union {
   struct {
     grn_obj *value;
   } constant;
+
   struct {
     grn_obj *column;
     grn_obj value_buffer;
   } value;
+
   struct {
     grn_obj result_buffer;
     void *regex;
     grn_obj value_buffer;
     grn_obj *normalizer;
   } simple_regexp;
+
   struct {
     grn_obj result_buffer;
     grn_obj *normalizer;
@@ -74,12 +77,15 @@ typedef union {
     unsigned int normalized_sub_text_raw_length_in_bytes;
     grn_obj value_buffer;
   } simple_match;
+
   struct {
     grn_expr_executor_data_simple_proc data;
   } simple_proc;
+
   struct {
     grn_obj result_buffer;
   } simple_condition_constant;
+
   struct {
     grn_obj result_buffer;
     grn_ra *ra;
@@ -89,6 +95,7 @@ typedef union {
     grn_obj constant_buffer;
     grn_operator_exec_func *exec;
   } simple_condition_ra;
+
   struct {
     bool need_exec;
     grn_obj result_buffer;
@@ -96,10 +103,12 @@ typedef union {
     grn_obj constant_buffer;
     grn_operator_exec_func *exec;
   } simple_condition;
+
   struct {
     grn_obj *score_column;
     grn_expr_executor_data_simple_proc data;
   } simple_proc_scorer;
+
   struct {
     grn_obj *score_column;
     grn_obj args;

--- a/lib/grn_ii.h
+++ b/lib/grn_ii.h
@@ -42,8 +42,9 @@ struct _grn_ii {
   grn_table_flags lflags;
   grn_encoding encoding; /* Character encoding */
                          /* This member is used for matching */
-  uint32_t n_elements;   /* Number of elements in postings */
-                         /* rid, [sid], tf, [weight] and [pos] */
+  uint32_t n_elements;   /* Number of elements in postings. rid, [sid], tf,
+                            [weight] and [pos] */
+
   union {
     grn_ii_header_common *common;
     grn_ii_header_normal *normal;

--- a/lib/grn_load.h
+++ b/lib/grn_load.h
@@ -94,6 +94,7 @@ typedef struct {
   grn_loader_stat stat;
   grn_content_type input_type;
   grn_loader_columns_status columns_status;
+
   struct {
     grn_rc rc;
     char buffer[GRN_CTX_MSGSIZE];
@@ -101,6 +102,7 @@ typedef struct {
     const char *file;
     const char *func;
   } error;
+
   bool output_ids;
   bool output_errors;
   bool lock_table;
@@ -112,6 +114,7 @@ typedef struct {
   grn_obj *record_value;
   grn_id id;
   grn_obj *key;
+
   struct {
     const char *column_name;
     uint32_t column_name_size;

--- a/lib/grn_token_cursor.h
+++ b/lib/grn_token_cursor.h
@@ -42,6 +42,7 @@ struct _grn_token_cursor {
   grn_obj_flags table_flags;
   grn_encoding encoding;
   uint32_t flags;
+
   struct {
     grn_obj *object;
     grn_proc_ctx pctx;
@@ -53,10 +54,12 @@ struct _grn_token_cursor {
     grn_token next_token;
     grn_token original_token;
   } tokenizer;
+
   struct {
     grn_obj *objects;
     void **data;
   } token_filter;
+
   struct {
     grn_token_cursor_status status;
     grn_token *token;

--- a/lib/highlighter.c
+++ b/lib/highlighter.c
@@ -55,6 +55,7 @@ struct _grn_highlighter {
   grn_obj raw_keywords;
 
   bool is_sequential_class_tag_mode;
+
   struct {
     grn_obj open;
     grn_obj close;

--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -2584,6 +2584,7 @@ grn_dec_p_for(grn_ctx *ctx, grn_codec_data *data)
   }
   return input;
 }
+
 /* PFor implementation: end */
 
 /* Binary format used in grn_encv()/grn_decv().
@@ -4232,10 +4233,12 @@ typedef struct {
   uint64_t position;
   uint64_t max_position;
   grn_merging_data *merging_data;
+
   struct {
     merger_buffer_data buffer;
     merger_chunk_data chunk;
   } source;
+
   struct {
     uint32_t *record_id_gaps;
     uint32_t *section_id_gaps;
@@ -17700,6 +17703,7 @@ namespace grn::ii {
       if (rc != GRN_SUCCESS) {
         return rc;
       }
+
       struct UserData {
         Builder *builder;
         BlockBuilder *block_builder;
@@ -17708,6 +17712,7 @@ namespace grn::ii {
         bool progress_needed;
         grn_progress *progress;
       } user_data;
+
       user_data.builder = this;
       user_data.block_builder = &block_builder;
       user_data.current_rid = GRN_ID_NIL;

--- a/lib/index_column.c
+++ b/lib/index_column.c
@@ -324,6 +324,7 @@ typedef enum {
   GRN_INDEX_COLUMN_DIFF_TYPE_MISSINGS,
   GRN_INDEX_COLUMN_DIFF_TYPE_LOOK_AHEAD,
 } grn_index_column_diff_type;
+
 /* Except LOOK_AHEAD */
 #define N_GRN_INDEX_COLUMN_DIFF_PERSISTENT_TYPES 2
 
@@ -362,6 +363,7 @@ typedef struct {
   grn_index_column_diff_options *options;
   grn_obj *lexicon;
   grn_ii *ii;
+
   struct {
     char name[GRN_TABLE_MAX_KEY_SIZE];
     int name_size;
@@ -369,6 +371,7 @@ typedef struct {
     bool with_position;
     uint32_t n_elements;
   } index;
+
   bool have_tokenizer;
   size_t n_posting_elements;
   grn_obj *source_table;
@@ -377,15 +380,18 @@ typedef struct {
   grn_hash *posting_lists;
   grn_obj *remains;
   grn_obj *missings;
+
   struct {
     grn_id token_id;
     grn_posting posting;
     grn_hash *token_counters;
   } current;
+
   struct {
     grn_obj value;
     grn_obj postings;
   } buffers;
+
   struct {
     grn_obj tag;
     grn_progress_logger logger;

--- a/lib/json.cpp
+++ b/lib/json.cpp
@@ -671,6 +671,7 @@ namespace {
         buffer_(buffer)
     {
     }
+
     ~JSONStringifier() = default;
 
     void

--- a/lib/language_model.cpp
+++ b/lib/language_model.cpp
@@ -252,6 +252,7 @@ namespace grn {
 #  ifdef _WIN32
     static char *windows_language_models_dir = NULL;
     static char windows_language_models_dir_buffer[PATH_MAX];
+
     namespace {
       const char *
       default_system_language_models_dir()
@@ -292,6 +293,7 @@ namespace grn {
     }
 
     static std::mutex capture_error_mutex;
+
     class CaptureError {
     public:
       CaptureError(grn_ctx *ctx) : lock_(capture_error_mutex)
@@ -408,6 +410,7 @@ namespace grn {
       llama_batch *batch_;
 
       BatchReleaser(llama_batch *batch) : batch_(batch) {}
+
       ~BatchReleaser()
       {
         if (batch_) {
@@ -1007,18 +1010,22 @@ namespace grn {
       std::mutex mutex;
       std::condition_variable cv;
       uintptr_t task_id = 0;
+
       struct ProcessedTask {
         ProcessedTask(grn_ctx *ctx) : ctx_(ctx), ids(), embeddings() {}
+
         ~ProcessedTask()
         {
           for (auto &embedding : embeddings) {
             GRN_OBJ_FIN(ctx_, &embedding);
           }
         }
+
         grn_ctx *ctx_;
         std::vector<grn_id> ids;
         std::vector<grn_obj> embeddings;
       };
+
       std::map<uintptr_t, std::unique_ptr<ProcessedTask>> processed_tasks;
 
       auto execute = [&](uintptr_t task_id, std::vector<grn_id> target_ids) {
@@ -1503,6 +1510,7 @@ struct grn_language_model_ {
   std::shared_ptr<grn::LanguageModel> model;
 
   grn_language_model_() : model(nullptr) {}
+
   ~grn_language_model_() = default;
 };
 
@@ -1510,12 +1518,15 @@ struct grn_language_model_inferencer_ {
   std::shared_ptr<grn::LanguageModelInferencer> inferencer;
 
   grn_language_model_inferencer_() : inferencer(nullptr) {}
+
   ~grn_language_model_inferencer_() = default;
 };
+
 struct grn_language_model_loader_ {
   grn::LanguageModelLoader loader;
 
   grn_language_model_loader_(grn_ctx *ctx) : loader(ctx) {}
+
   ~grn_language_model_loader_() = default;
 };
 

--- a/lib/output.c
+++ b/lib/output.c
@@ -4066,11 +4066,13 @@ grn_output_envelope_close_apache_arrow_trace_log(grn_ctx *ctx, grn_obj *output)
     writer,
     "name",
     grn_ctx_at(ctx, GRN_DB_INT16));
+
   enum value_type {
     VALUE_TYPE_UINT32,
     VALUE_TYPE_SHORT_TEXT,
     N_VALUE_TYPES,
   };
+
   grn_obj *value_types[N_VALUE_TYPES];
   value_types[VALUE_TYPE_UINT32] = grn_ctx_at(ctx, GRN_DB_UINT32);
   value_types[VALUE_TYPE_SHORT_TEXT] = grn_ctx_at(ctx, GRN_DB_SHORT_TEXT);

--- a/lib/pat.c
+++ b/lib/pat.c
@@ -158,11 +158,13 @@ pat_node_get_child(grn_pat *pat,
     return node->node.lr[direction];
   }
 }
+
 static inline grn_id
 pat_node_get_right(grn_pat *pat, pat_node_common *node)
 {
   return pat_node_get_child(pat, node, DIRECTION_RIGHT);
 }
+
 static inline grn_id
 pat_node_get_left(grn_pat *pat, pat_node_common *node)
 {
@@ -227,6 +229,7 @@ pat_node_is_deleting(grn_pat *pat, pat_node_common *node)
     return node->node.bits & PAT_DELETING;
   }
 }
+
 static inline bool
 pat_node_is_key_immediate(grn_pat *pat, pat_node_common *node)
 {
@@ -248,6 +251,7 @@ pat_node_get_key_length(grn_pat *pat, pat_node_common *node)
   }
   return (uint32_t)((bits >> 3) + 1);
 }
+
 static inline uint16_t
 pat_node_get_check(grn_pat *pat, pat_node_common *node)
 {
@@ -257,6 +261,7 @@ pat_node_get_check(grn_pat *pat, pat_node_common *node)
     return node->node.check;
   }
 }
+
 static inline void
 pat_node_set_deleting_on(grn_pat *pat, pat_node_common *node)
 {
@@ -276,6 +281,7 @@ pat_node_set_key_immediate_on(grn_pat *pat, pat_node_common *node)
     node->node.bits |= PAT_IMMEDIATE;
   }
 }
+
 static inline void
 pat_node_set_deleting_off(grn_pat *pat, pat_node_common *node)
 {
@@ -285,6 +291,7 @@ pat_node_set_deleting_off(grn_pat *pat, pat_node_common *node)
     node->node.bits &= ~PAT_DELETING;
   }
 }
+
 static inline void
 pat_node_set_key_immediate_off(grn_pat *pat, pat_node_common *node)
 {
@@ -308,6 +315,7 @@ pat_node_set_key_length(grn_pat *pat,
       (node->node.bits & ((1 << 3) - 1)) | ((key_length - 1) << 3);
   }
 }
+
 static inline void
 pat_node_set_check(grn_pat *pat, pat_node_common *node, uint16_t check)
 {
@@ -3215,6 +3223,7 @@ typedef struct {
   uint32_t max_expansions;
   uint32_t prefix_match_size;
   fuzzy_heap *heap;
+
   struct {
     const char *key;
     uint32_t key_length;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -582,6 +582,7 @@ grn_plugins_init_path(grn_ctx *ctx, grn_obj *path, const char *path_env)
 #ifdef WIN32
 static char *windows_plugins_dir = NULL;
 static char windows_plugins_dir_buffer[PATH_MAX];
+
 static const char *
 grn_plugin_get_default_system_plugins_dir(void)
 {

--- a/lib/proc/proc_select.cpp
+++ b/lib/proc/proc_select.cpp
@@ -267,10 +267,12 @@ namespace {
     grn_obj *type;
     grn_column_flags flags;
     grn_raw_string value;
+
     struct {
       grn_raw_string sort_keys;
       grn_raw_string group_keys;
     } window;
+
     grn_obj dependency_names;
 
   private:
@@ -1201,14 +1203,17 @@ namespace {
     float fuzzy_max_distance_ratio;
     bool fuzzy_with_transposition;
     bool fuzzy_tokenize;
+
     struct {
       grn_obj *match_columns;
       grn_obj *expression;
       grn_obj *query_options_expression;
     } condition;
+
     struct {
       grn_obj *expression;
     } post_condition;
+
     grn_obj *filtered;
     grn_obj *post_filtered;
   };
@@ -1266,6 +1271,7 @@ namespace {
     grn_raw_string output_columns;
     int offset;
     int limit;
+
     struct {
       grn_obj *target;
       grn_obj *initial;
@@ -1273,6 +1279,7 @@ namespace {
       grn_obj *sorted;
       grn_obj *output;
     } tables;
+
     Drilldowns drilldowns;
     DynamicColumns dynamic_columns;
 
@@ -1646,6 +1653,7 @@ namespace {
     Tables tables;
     uint16_t cacheable;
     uint16_t taintable;
+
     struct {
       int n_elements;
       grn_select_output_formatter *formatter;
@@ -1657,6 +1665,7 @@ namespace {
       grn_raw_string columns;
       grn_raw_string values;
     } load;
+
     grn_raw_string table;
     Filter filter;
     grn_raw_string scorer;

--- a/lib/store.c
+++ b/lib/store.c
@@ -757,12 +757,14 @@ struct _grn_ja_einfo {
       uint8_t c1;
       uint8_t c2;
     } n;
+
     struct {
       uint32_t size;
       uint16_t seg;
       uint8_t c1;
       uint8_t c2;
     } h;
+
     uint8_t c[8];
   } u;
 };

--- a/lib/tokenizers.c
+++ b/lib/tokenizers.c
@@ -467,6 +467,7 @@ typedef struct {
   grn_tokenizer_query *query;
   grn_ngram_options options;
   bool overlap;
+
   struct {
     bool ing;
     bool need;
@@ -476,6 +477,7 @@ typedef struct {
     int16_t *checks;
     uint64_t *offsets;
   } loose;
+
   uint32_t pos;
   uint32_t skip;
   unsigned int n_chars;
@@ -1291,9 +1293,11 @@ ngram_fin_deprecated(grn_ctx *ctx,
 typedef struct {
   grn_tokenizer_token token;
   grn_tokenizer_query *query;
+
   struct {
     uint32_t n_skip_tokens;
   } get;
+
   bool is_begin;
   bool is_end;
   bool is_start_token;

--- a/plugins/language_model/knn.cpp
+++ b/plugins/language_model/knn.cpp
@@ -172,6 +172,7 @@ namespace {
   }
 
   const char *TOKENIZER_TAG = "[tokenizer][language-model]";
+
   struct Tokenizer {
     grn_obj *lexicon;
     grn_obj *source_table;
@@ -671,9 +672,11 @@ namespace {
       GRN_BULK_REWIND(&embeddings_);
       {
         bool need_progress = grn_ctx_get_progress_callback(ctx_);
+
         struct UserData {
           grn_tokenizer_build_data *data;
         } user_data;
+
         user_data.data = data_;
         auto progress_callback =
           [](grn_ctx *ctx, grn_progress *progress, void *user_data) {

--- a/src/groonga.c
+++ b/src/groonga.c
@@ -193,6 +193,7 @@ line_editor_prompt(EditLine *e __attribute__((unused)))
 {
   return L"> ";
 }
+
 static const wchar_t *const line_editor_editor = L"emacs";
 
 static void
@@ -818,6 +819,7 @@ typedef struct {
   grn_pat *entries;
   uint64_t earliest_unix_time_msec;
 } request_timer_data;
+
 static request_timer_data the_request_timer_data;
 
 static void *


### PR DESCRIPTION
An empty line is inserted between blocks.
https://clang.llvm.org/docs/ClangFormatStyleOptions.html#separatedefinitionblock

The setting is the same as Mroonga: https://github.com/mroonga/mroonga/pull/1070