### PR TITLE
Fix wrong free function

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -2957,7 +2957,7 @@ exit:
   if (ii_cursor) {
     grn_ii_cursor_close(ctx, ii_cursor);
   }
-  grn_obj_unlink(ctx, &source_ids);
+  GRN_OBJ_FIN(ctx, &source_ids);
   {
     int i, n_sources;
     n_sources = GRN_BULK_VSIZE(&sources) / sizeof(grn_obj *);
@@ -2965,7 +2965,7 @@ exit:
       grn_obj *source = GRN_PTR_VALUE_AT(&sources, i);
       grn_obj_unlink(ctx, source);
     }
-    grn_obj_unlink(ctx, &sources);
+    GRN_OBJ_FIN(ctx, &sources);
   }
 }
 


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-39098

See also: https://github.com/MariaDB/server/pull/4836

We should use `GRN_OBJ_FIN()` not `grn_obj_unlink()` for bulk.

Reported by Daniel Black. Thanks!!!