### PR TITLE
http: fix `buffer_offset` not reset

### DIFF
--- a/src/groonga.c
+++ b/src/groonga.c
@@ -2109,6 +2109,7 @@ do_htreq_post_process_body_chunked(grn_ctx *ctx,
         data = NULL;
         data_size = 0;
         GRN_BULK_REWIND(&buffer);
+        buffer_offset = 0;
         continue;
       }
       data++;


### PR DESCRIPTION
The reset of `buffer_offset` was missing, so it is reset.
This process is only used under specific conditions, which is likely why it went unnoticed until now.

Specifically, this applies in the following case:

Full request body:

```text
1\r\n
A\r\n
1\r\n
B\r\n
2\r\n
CC\r\n
```

1. First received.

Only the full first chunk and the size of the second chunk were received, up to the `\r`. The body of the second chunk was not received.

Example:

```
1\r\n
A\r\n
1\r
```

2. Second received.

Received the Body of the second chunk. But only received up to `\r`.

Example:

```
\n
B\r
```

3. Third received.

Received the `\n` from the second chunk and the third chunk.

Example:

```
\n
2\r\n
CC\r\n
```

At this point, when the third chunk is received, the check for the position of `\n` fails, resulting in `chunk end LF doesn't exit` error.
Since the request is actually valid, this error is incorrect.