### PR TITLE
extractor: add extractor implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2025  Sutou Kouhei <kou@clear-code.com>
+# Copyright (C) 2023-2026  Sutou Kouhei <kou@clear-code.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -35,6 +35,7 @@ repos:
           ?include/groonga/distance\.h|
           ?include/groonga/error\.h|
           ?include/groonga/expr\.h|
+          ?include/groonga/extractor\.h|
           ?include/groonga/float\.h|
           ?include/groonga/geo\.h|
           ?include/groonga/groonga\.h|
@@ -84,6 +85,8 @@ repos:
           ?lib/error\.c|
           ?lib/expr\.c|
           ?lib/expr_executor\.cpp|
+          ?lib/extractor\.c|
+          ?lib/extractors\.c|
           ?lib/geo\.c|
           ?lib/generated_column\.c|
           ?lib/grn\.h|
@@ -103,6 +106,8 @@ repos:
           ?lib/grn_error\.h|
           ?lib/grn_expr\.h|
           ?lib/grn_expr_executor\.h|
+          ?lib/grn_extractor\.h|
+          ?lib/grn_extractors\.h|
           ?lib/grn_generated_column\.h|
           ?lib/grn_geo\.h|
           ?lib/grn_hash\.h|

--- a/include/groonga/Makefile.am
+++ b/include/groonga/Makefile.am
@@ -19,6 +19,7 @@ groonga_include_HEADERS =			\
 	dump.h					\
 	error.h					\
 	expr.h					\
+	extractor.h				\
 	file_reader.h				\
 	float.h					\
 	h3.h					\

--- a/include/groonga/extractor.h
+++ b/include/groonga/extractor.h
@@ -1,0 +1,145 @@
+/*
+  Copyright (C) 2026  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include <groonga/tokenizer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief This is an opaque data to pass data to an extractor from
+ *        Groonga.
+ *
+ * This is used for \ref grn_extractor_extract_func.
+ *
+ * \see grn_extractor_set_extract_func
+ *
+ * \since 16.0.1
+ */
+typedef struct grn_extract_data grn_extract_data;
+
+/**
+ * \brief Return the extract target value.
+ *
+ * This is owned by \ref grn_extract_data. You must not free it.
+ *
+ * \param ctx The context object.
+ * \param data The data.
+ *
+ * \return The extract target value.
+ *
+ * \since 16.0.1
+ */
+GRN_PLUGIN_EXPORT grn_obj *
+grn_extract_data_get_value(grn_ctx *ctx, grn_extract_data *data);
+
+/**
+ * \brief Return the table that extracts target value belongs to.
+ *
+ * \param ctx The context object.
+ * \param data The data.
+ *
+ * \return The table that extract target value belongs to.
+ *
+ * \since 16.0.1
+ */
+GRN_PLUGIN_EXPORT grn_obj *
+grn_extract_data_get_table(grn_ctx *ctx, grn_extract_data *data);
+
+/**
+ * \brief Return the index of the target extractor in the table.
+ *
+ * \param ctx The context object.
+ * \param data The data.
+ *
+ * \return The index of the target extractor in the table.
+ *
+ * \since 16.0.1
+ */
+GRN_PLUGIN_EXPORT uint32_t
+grn_extract_data_get_index(grn_ctx *ctx, grn_extract_data *data);
+
+/**
+ * \brief A function that implements extraction feature for an
+ *        extractor.
+ *
+ * If the `extractor` can extract a content from the `data`, the
+ * `extractor` must extract a content from the `data` and return it as
+ * a \ref grn_obj that is created by \ref grn_obj_open.
+ *
+ * If the `extractor` can't extract a content from the `data`, the
+ * `extractor` must return `NULL`.
+ *
+ * \param ctx The context object.
+ * \param extractor The extractor.
+ * \param data The data to be extracted.
+ *
+ * \return The extracted value as a \ref grn_obj, `NULL` if the extractor
+ *         doesn't extract anything or has any error.
+ *
+ *         You must free the returned value by \ref GRN_OBJ_FIN when
+ *         it's no longer needed.
+ *
+ * \since 16.0.1
+ */
+typedef grn_obj *
+grn_extractor_extract_func(grn_ctx *ctx,
+                           grn_obj *extractor,
+                           grn_extract_data *data);
+
+/**
+ * \brief Create an extractor.
+ *
+ * You must set at least an extract function to the created extractor
+ * by \ref grn_extractor_set_extract_func.
+ *
+ * \param ctx The context object.
+ * \param name The name of the new extractor.
+ * \param name_length The byte size of `name`.You can use `-1` if
+ *                    `name` is a `\0`-terminated string.
+ *
+ * \return The next extractor.
+ *
+ * \since 16.0.1
+ */
+GRN_PLUGIN_EXPORT grn_obj *
+grn_extractor_create(grn_ctx *ctx, const char *name, int name_length);
+
+/**
+ * \brief Set an extract function to an extractor.
+ *
+ * \param ctx The context object.
+ * \param extractor The extractor.
+ * \param extract The function to extract a content.
+ *
+ * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on
+ *         error.
+ *
+ * \since 16.0.1
+ */
+GRN_PLUGIN_EXPORT grn_rc
+grn_extractor_set_extract_func(grn_ctx *ctx,
+                               grn_obj *extractor,
+                               grn_extractor_extract_func *extract);
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/groonga/groonga.h
+++ b/include/groonga/groonga.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2018  Brazil
-  Copyright (C) 2018-2025  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -149,6 +149,7 @@ typedef enum {
   GRN_CONNECTION_RESET = -80,
   GRN_BLOSC_ERROR = -81,
   GRN_OPENZL_ERROR = -82,
+  GRN_EXTRACTOR_ERROR = -83,
 } grn_rc;
 
 GRN_API grn_rc

--- a/lib/c_sources.am
+++ b/lib/c_sources.am
@@ -17,6 +17,8 @@ libgroonga_c_sources =				\
 	error.c					\
 	expr.c					\
 	expr_code.c				\
+	extractor.c				\
+	extractors.c				\
 	file_lock.c				\
 	file_reader.c				\
 	float.c					\
@@ -47,6 +49,8 @@ libgroonga_c_sources =				\
 	grn_expr.h				\
 	grn_expr_code.h				\
 	grn_expr_executor.h			\
+	grn_extractor.h				\
+	grn_extractors.h			\
 	grn_file_lock.h				\
 	grn_float.h				\
 	grn_generated_column.h			\

--- a/lib/db.c
+++ b/lib/db.c
@@ -26,6 +26,7 @@
 #include "grn_config.h"
 #include "grn_db.h"
 #include "grn_obj.h"
+#include "grn_extractors.h"
 #include "grn_hash.h"
 #include "grn_http_client.h"
 #include "grn_pat.h"
@@ -667,6 +668,7 @@ grn_db_open(grn_ctx *ctx, const char *path)
     grn_db_init_builtin_window_functions(ctx);
     grn_db_init_builtin_token_filters(ctx);
     grn_db_init_builtin_aggregators(ctx);
+    grn_db_init_builtin_extractors(ctx);
 
     if (grn_table_size(ctx, (grn_obj *)s) > n_records) {
       need_flush = true;
@@ -8190,12 +8192,12 @@ grn_obj_get_info(grn_ctx *ctx,
           break;
         }
         if (extractors) {
-          size_t n = GRN_PTR_VECTOR_SIZE(extractors);
+          grn_table_module *raw_extractors =
+            (grn_table_module *)GRN_BULK_HEAD(extractors);
+          size_t n = GRN_BULK_VSIZE(extractors) / sizeof(grn_table_module);
           size_t i;
           for (i = 0; i < n; i++) {
-            grn_table_module *extractor_module =
-              (grn_table_module *)GRN_PTR_VALUE_AT(extractors, i);
-            grn_obj *extractor = extractor_module->proc;
+            grn_obj *extractor = raw_extractors[i].proc;
             GRN_PTR_PUT(ctx, valuebuf, extractor);
           }
         }
@@ -15258,6 +15260,7 @@ grn_db_init_builtin_types(grn_ctx *ctx)
   grn_db_init_builtin_window_functions(ctx);
   grn_db_init_builtin_token_filters(ctx);
   grn_db_init_builtin_aggregators(ctx);
+  grn_db_init_builtin_extractors(ctx);
   for (id = grn_db_curr_id(ctx, db) + 1; id < GRN_N_RESERVED_TYPES; id++) {
     grn_itoh(id, buf + 3, 2);
     grn_obj_register(ctx, db, buf, 5);

--- a/lib/error.c
+++ b/lib/error.c
@@ -488,14 +488,17 @@ grn_rc_to_string(grn_rc rc)
   case GRN_ZSTD_ERROR:
     message = "Zstandard error";
     break;
-  case GRN_OPENZL_ERROR:
-    message = "OpenZL error";
-    break;
   case GRN_CONNECTION_RESET:
     message = "connection reset";
     break;
   case GRN_BLOSC_ERROR:
     message = "Blosc error";
+    break;
+  case GRN_OPENZL_ERROR:
+    message = "OpenZL error";
+    break;
+  case GRN_EXTRACTOR_ERROR:
+    message = "extractor error";
     break;
   }
 

--- a/lib/extractor.c
+++ b/lib/extractor.c
@@ -1,0 +1,93 @@
+/*
+  Copyright (C) 2026  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <string.h>
+
+#include "grn.h"
+#include "grn_db.h"
+#include "grn_extractor.h"
+
+grn_obj *
+grn_extract_data_get_value(grn_ctx *ctx, grn_extract_data *data)
+{
+  return data->value;
+}
+
+grn_obj *
+grn_extract_data_get_table(grn_ctx *ctx, grn_extract_data *data)
+{
+  return data->table;
+}
+
+uint32_t
+grn_extract_data_get_index(grn_ctx *ctx, grn_extract_data *data)
+{
+  return data->index;
+}
+
+grn_obj *
+grn_extractor_create(grn_ctx *ctx, const char *name, int length)
+{
+  GRN_API_ENTER;
+  grn_obj *extractor = grn_proc_create(ctx,
+                                       name,
+                                       length,
+                                       GRN_PROC_EXTRACTOR,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       0,
+                                       NULL);
+  if (!extractor) {
+    if (length < 0) {
+      length = (int)strlen(name);
+    }
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_EXTRACTOR_ERROR,
+                     "[extractor][create] failed to create: <%.*s>",
+                     length,
+                     name);
+  }
+
+  GRN_API_RETURN(extractor);
+}
+
+grn_rc
+grn_extractor_set_extract_func(grn_ctx *ctx,
+                               grn_obj *extractor,
+                               grn_extractor_extract_func *extract)
+{
+  GRN_API_ENTER;
+  if (extractor) {
+    ((grn_proc *)extractor)->callbacks.extractor.extract = extract;
+  } else {
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
+                     "[extractor][extract][set] extractor is NULL");
+  }
+  GRN_API_RETURN(ctx->rc);
+}
+
+grn_obj *
+grn_extractor_extract(grn_ctx *ctx, grn_obj *extractor, grn_extract_data *data)
+{
+  GRN_API_ENTER;
+  grn_obj *value =
+    ((grn_proc *)extractor)->callbacks.extractor.extract(ctx, extractor, data);
+  GRN_API_RETURN(value);
+}

--- a/lib/extractors.c
+++ b/lib/extractors.c
@@ -1,0 +1,349 @@
+/*
+  Copyright (C) 2026  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "grn_extractor.h"
+#include "grn_extractors.h"
+
+typedef struct {
+  bool remove_tag;
+  bool expand_character_reference;
+} html_extract_options;
+
+static void
+html_extract_options_init(grn_ctx *ctx, html_extract_options *options)
+{
+  options->remove_tag = true;
+  options->expand_character_reference = true;
+}
+
+static void
+html_extract_options_fin(grn_ctx *ctx, html_extract_options *options)
+{
+}
+
+static void
+html_extract_close_options(grn_ctx *ctx, void *data)
+{
+  html_extract_options *options = data;
+  html_extract_options_fin(ctx, options);
+  GRN_FREE(options);
+}
+
+static void *
+html_extract_open_options(grn_ctx *ctx,
+                          grn_obj *extractor,
+                          grn_obj *raw_options,
+                          void *user_data)
+{
+  const char *tag = "[extractor][html]";
+  html_extract_options *options = GRN_CALLOC(sizeof(html_extract_options));
+  if (!options) {
+    ERR(GRN_NO_MEMORY_AVAILABLE,
+        "%s failed to allocate memory for options",
+        tag);
+    return NULL;
+  }
+
+  html_extract_options_init(ctx, options);
+
+  GRN_OPTION_VALUES_EACH_BEGIN(ctx, raw_options, i, name, name_length)
+  {
+    grn_raw_string name_raw;
+    name_raw.value = name;
+    name_raw.length = name_length;
+
+    if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw, "remove_tag")) {
+      options->remove_tag =
+        grn_vector_get_element_bool(ctx, raw_options, i, options->remove_tag);
+    } else if (GRN_RAW_STRING_EQUAL_CSTRING(name_raw,
+                                            "expand_character_reference")) {
+      options->expand_character_reference =
+        grn_vector_get_element_bool(ctx,
+                                    raw_options,
+                                    i,
+                                    options->expand_character_reference);
+    }
+  }
+  GRN_OPTION_VALUES_EACH_END();
+
+  return options;
+}
+
+static bool
+html_expand_numeric_char_ref(grn_ctx *ctx, grn_obj *buffer, uint32_t code_point)
+{
+  /* Special code points.
+   * See also:
+   * https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
+   */
+  switch (code_point) {
+  case 0x80:
+    code_point = 0x20AC;
+    break;
+  case 0x82:
+    code_point = 0x201A;
+    break;
+  case 0x83:
+    code_point = 0x0192;
+    break;
+  case 0x84:
+    code_point = 0x201E;
+    break;
+  case 0x85:
+    code_point = 0x2026;
+    break;
+  case 0x86:
+    code_point = 0x2020;
+    break;
+  case 0x87:
+    code_point = 0x2021;
+    break;
+  case 0x88:
+    code_point = 0x02C6;
+    break;
+  case 0x89:
+    code_point = 0x2030;
+    break;
+  case 0x8A:
+    code_point = 0x0160;
+    break;
+  case 0x8B:
+    code_point = 0x2039;
+    break;
+  case 0x8C:
+    code_point = 0x0152;
+    break;
+  case 0x8E:
+    code_point = 0x017D;
+    break;
+  case 0x91:
+    code_point = 0x2018;
+    break;
+  case 0x92:
+    code_point = 0x2019;
+    break;
+  case 0x93:
+    code_point = 0x201C;
+    break;
+  case 0x94:
+    code_point = 0x201D;
+    break;
+  case 0x95:
+    code_point = 0x2022;
+    break;
+  case 0x96:
+    code_point = 0x2013;
+    break;
+  case 0x97:
+    code_point = 0x2014;
+    break;
+  case 0x98:
+    code_point = 0x02DC;
+    break;
+  case 0x99:
+    code_point = 0x2122;
+    break;
+  case 0x9A:
+    code_point = 0x0161;
+    break;
+  case 0x9B:
+    code_point = 0x203A;
+    break;
+  case 0x9C:
+    code_point = 0x0153;
+    break;
+  case 0x9E:
+    code_point = 0x017E;
+    break;
+  case 0x9F:
+    code_point = 0x0178;
+    break;
+  default:
+    break;
+  }
+  grn_text_code_point(ctx, buffer, code_point);
+  return true;
+}
+
+#include "normalizer_html_expand_named_char_ref.c"
+
+typedef enum {
+  HTML_STATE_TEXT,
+  HTML_STATE_IN_TAG,
+  HTML_STATE_IN_CHAR_REF,
+} html_state;
+
+static grn_obj *
+html_extract(grn_ctx *ctx, grn_obj *extractor, grn_extract_data *data)
+{
+  const char *tag = "[extractor][html]";
+
+  grn_obj *value = grn_extract_data_get_value(ctx, data);
+  if (!grn_type_id_is_text_family(ctx, value->header.domain)) {
+    /* Do nothing */
+    return NULL;
+  }
+
+  grn_obj *table = grn_extract_data_get_table(ctx, data);
+  if (!table) {
+    ERR(GRN_INVALID_ARGUMENT, "%s related table information is missing", tag);
+    return NULL;
+  }
+
+  uint32_t i = grn_extract_data_get_index(ctx, data);
+  html_extract_options *options =
+    grn_table_cache_extractors_options(ctx,
+                                       table,
+                                       i,
+                                       html_extract_open_options,
+                                       html_extract_close_options,
+                                       NULL);
+  if (ctx->rc != GRN_SUCCESS) {
+    return NULL;
+  }
+
+  grn_obj *output = grn_obj_open(ctx, GRN_BULK, 0, GRN_DB_TEXT);
+  const char *current = GRN_TEXT_VALUE(value);
+  const char *end = current + GRN_TEXT_LEN(value);
+
+  html_state state = HTML_STATE_TEXT;
+  const char *start_tag = NULL;
+  const char *start_char_ref = NULL;
+
+  int char_length = 0;
+  for (; current < end; current += char_length) {
+    char_length = grn_charlen(ctx, current, end);
+    if (char_length == 0) {
+      /* Set error? */
+      break;
+    }
+
+    if (char_length == 1) {
+      bool processed = false;
+      switch (state) {
+      case HTML_STATE_IN_TAG:
+        if (*current == '>') {
+          if (!options->remove_tag) {
+            GRN_TEXT_PUT(ctx, output, start_tag, (current - start_tag + 1));
+          }
+          state = HTML_STATE_TEXT;
+          start_tag = NULL;
+          processed = true;
+        }
+        break;
+      case HTML_STATE_IN_CHAR_REF:
+        if (*current == ';') {
+          bool valid = false;
+          if (start_char_ref[1] == '#') {
+            long code_point = -1;
+            if (start_char_ref[2] == 'x' || start_char_ref[2] == 'X') {
+              /* "&#xH...;" */
+              const char *code_point_end = NULL;
+              code_point =
+                grn_htoui(start_char_ref + 3, current, &code_point_end);
+              if (code_point_end != current) {
+                code_point = -1;
+              }
+            } else {
+              /* "&#D...;" */
+              const char *code_point_end = NULL;
+              code_point =
+                grn_atoll(start_char_ref + 2, current, &code_point_end);
+              if (code_point_end != current) {
+                code_point = -1;
+              }
+            }
+            if (code_point >= 0) {
+              valid =
+                html_expand_numeric_char_ref(ctx, output, (uint32_t)code_point);
+            }
+          } else {
+            /* "&NAME;" */
+            valid = html_expand_named_char_ref(
+              ctx,
+              output,
+              start_char_ref + 1,
+              (size_t)(current - start_char_ref - 1));
+          }
+          if (valid) {
+            state = HTML_STATE_TEXT;
+            start_char_ref = NULL;
+            processed = true;
+          }
+        } else if (((current - start_char_ref) == 1 && *current == '#') ||
+                   ('A' <= *current && *current <= 'Z') ||
+                   ('a' <= *current && *current <= 'z') ||
+                   ('0' <= *current && *current <= '9')) {
+          processed = true;
+        }
+        break;
+      default:
+        if (options->remove_tag && *current == '<') {
+          state = HTML_STATE_IN_TAG;
+          start_tag = current;
+          processed = true;
+        } else if (options->expand_character_reference && *current == '&') {
+          state = HTML_STATE_IN_CHAR_REF;
+          start_char_ref = current;
+          processed = true;
+        }
+        break;
+      }
+      if (processed) {
+        continue;
+      }
+    }
+
+    switch (state) {
+    case HTML_STATE_IN_TAG:
+      break;
+    case HTML_STATE_IN_CHAR_REF:
+      {
+        /* "&...(any multibyte character)...;" case: Write it as-is. */
+        size_t length =
+          (size_t)(current - start_char_ref) + (size_t)char_length;
+        GRN_TEXT_PUT(ctx, output, start_char_ref, length);
+        state = HTML_STATE_TEXT;
+        start_char_ref = NULL;
+      }
+      break;
+    default:
+      GRN_TEXT_PUT(ctx, output, current, (size_t)char_length);
+      break;
+    }
+  }
+  if (state == HTML_STATE_IN_TAG) {
+    if (!options->remove_tag) {
+      GRN_TEXT_PUT(ctx, output, start_tag, (size_t)(current - start_tag));
+    }
+  }
+
+  return output;
+}
+
+grn_rc
+grn_db_init_builtin_extractors(grn_ctx *ctx)
+{
+  {
+    grn_obj *extractor;
+    extractor = grn_extractor_create(ctx, "ExtractorHTML", -1);
+    grn_extractor_set_extract_func(ctx, extractor, html_extract);
+  }
+
+  return GRN_SUCCESS;
+}

--- a/lib/grn_db.h
+++ b/lib/grn_db.h
@@ -27,6 +27,7 @@
 #include "grn_store.h"
 
 #include <groonga/command.h>
+#include <groonga/extractor.h>
 #include <groonga/token_filter.h>
 #include <groonga/scorer.h>
 
@@ -463,6 +464,9 @@ struct _grn_proc {
       grn_aggregator_update_func *update;
       grn_aggregator_fin_func *fin;
     } aggregator;
+    struct {
+      grn_extractor_extract_func *extract;
+    } extractor;
   } callbacks;
 
   void *user_data;

--- a/lib/grn_extractor.h
+++ b/lib/grn_extractor.h
@@ -1,0 +1,40 @@
+/*
+  Copyright (C) 2026  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "grn_ctx.h"
+
+#include <groonga/extractor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct grn_extract_data {
+  grn_obj *table;
+  uint32_t index;
+  grn_obj *value;
+};
+
+grn_obj *
+grn_extractor_extract(grn_ctx *ctx, grn_obj *extractor, grn_extract_data *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/grn_extractors.h
+++ b/lib/grn_extractors.h
@@ -1,0 +1,26 @@
+/*
+  Copyright (C) 2026  Sutou Kouhei <kou@clear-code.com>
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+grn_rc
+grn_db_init_builtin_extractors(grn_ctx *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lib/mrb/mrb_ctx.c
+++ b/lib/mrb/mrb_ctx.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2013-2018  Brazil
-  Copyright (C) 2018-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -1132,6 +1132,15 @@ grn_mrb_ctx_to_exception(mrb_state *mrb)
                  MESSAGE_SIZE,
                  MESSAGE_SIZE,
                  "OpenZL error: <%s>(%d)",
+                 utf8_error_message,
+                 ctx->rc);
+    break;
+  case GRN_EXTRACTOR_ERROR:
+    error_class = mrb_class_get_under(mrb, module, "ExtractorError");
+    grn_snprintf(message,
+                 MESSAGE_SIZE,
+                 MESSAGE_SIZE,
+                 "extractor error: <%s>(%d)",
                  utf8_error_message,
                  ctx->rc);
     break;


### PR DESCRIPTION
This also includes a built-in extractor. It's `ExtractorHTML` that extracts text data in an HTML. We have `NormalizerHTML` but it should have implemented as an extractor.