### PR TITLE
cmake openzl: suppress the declaration-after-statement warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1215,6 +1215,9 @@ if(NOT "${GRN_WITH_OPENZL}" STREQUAL "no")
             PRIVATE $<$<COMPILE_LANGUAGE:C>:${GRN_OPENZL_SUPPRESS_WARNINGS}>
                     $<$<COMPILE_LANGUAGE:CXX>:${GRN_OPENZL_SUPPRESS_WARNINGS}>)
         endif()
+        target_compile_options(
+          openzl
+          PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-declaration-after-statement>)
       endif()
       if(CMAKE_VERSION VERSION_LESS 3.28)
         set_property(DIRECTORY "${openzl_SOURCE_DIR}" PROPERTY EXCLUDE_FROM_ALL


### PR DESCRIPTION
= Issue
When building Groonga with MariaDB, the bundled OpenZL library fails to compile with an error like:

```
/home/buildbot/_deps/openzl-src/src/openzl/codecs/common/bitstream/ff_bitstream.h:44:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]
```

= Cause
MariaDB enforces `-Wdeclaration-after-statement` as an error, but OpenZL uses C99-style mixed declarations and code.

= Solution
Suppress the `-Wdeclaration-after-statement` warning for the OpenZL target, following the same approach used for bundled H3 and llama.cpp.