### PR TITLE
io_flush: prevent race conditions occurring when io_flush and table_remove(object remove) run simultaneously

### DIFF
--- a/lib/db.c
+++ b/lib/db.c
@@ -14950,9 +14950,22 @@ grn_obj_flush_recursive_dependent(grn_ctx *ctx, grn_obj *obj)
   data.for_reference = false;
 
   grn_obj *db = grn_ctx_db(ctx);
+  // Keep objct id, but some objects have not object id.
+  // This implementation only for objects with object id.
+  grn_id lock_target_object_id = grn_obj_id(ctx, obj);
   grn_rc rc = grn_obj_flush_lock(ctx, db, traverse_data.tag);
   if (rc != GRN_SUCCESS) {
     GRN_API_RETURN(rc);
+  }
+  // Get object from keeped obect id.
+  // compare object address. if addresses is not match, flush does not execute.
+  grn_obj *lock_target_object = grn_ctx_at(ctx, lock_target_object_id);
+  if (obj != lock_target_object) {
+    ERR(GRN_NO_SUCH_FILE_OR_DIRECTORY,
+        "%s lock target object has been already removed",
+        data.tag);
+    grn_obj_flush_unlock(ctx, db, traverse_data.tag);
+    GRN_API_RETURN(ctx->rc);
   }
   if (obj != db) {
     rc = grn_obj_flush_lock(ctx, obj, traverse_data.tag);


### PR DESCRIPTION
Fix: GH-2783.

TODO:
1. Implementation of tests
2. Double free in `grn_realloc_default()` that is called from `io_flush()` is not yet prevented.

The following crash causes by 2.

```
2026-04-14 03:10:06.545815|C| -- CRASHED!!! --
2026-04-14 03:10:06.549405|C| /usr/local/lib/libgroonga.so.0(+0xa911ea) [0x7121854251ea]
2026-04-14 03:10:06.549440|C| /lib/x86_64-linux-gnu/libc.so.6(+0x45330) [0x712184784330]
2026-04-14 03:10:06.549448|C| /usr/local/lib/libgroonga.so.0(+0xaf8029) [0x71218548c029]
2026-04-14 03:10:06.549453|C| /usr/local/lib/libgroonga.so.0(grn_ii_cursor_close+0x3f) [0x7121854b9260]
2026-04-14 03:10:06.549459|C| /usr/local/lib/libgroonga.so.0(grn_index_cursor_close+0x46) [0x712184ee70d1]
2026-04-14 03:10:06.549464|C| /usr/local/lib/libgroonga.so.0(grn_obj_close+0xb48) [0x712184e59f4e]
2026-04-14 03:10:06.549470|C| /usr/local/lib/libgroonga.so.0(grn_obj_unlink+0x29c) [0x712184e5a86f]
2026-04-14 03:10:06.549475|C| /usr/local/lib/libgroonga.so.0(+0x9a6a81) [0x71218533aa81]
2026-04-14 03:10:06.549480|C| /usr/local/lib/libgroonga.so.0(grn_proc_call+0x27c) [0x712184e6e186]
2026-04-14 03:10:06.549485|C| /usr/local/lib/libgroonga.so.0(grn_command_run+0xd6) [0x712184e1f26f]
2026-04-14 03:10:06.549490|C| /usr/local/lib/libgroonga.so.0(grn_expr_exec+0xc2) [0x712184e6e3dd]
2026-04-14 03:10:06.549495|C| /usr/local/lib/libgroonga.so.0(grn_ctx_qe_exec_uri+0x109f) [0x712185422152]
2026-04-14 03:10:06.549501|C| /usr/local/lib/libgroonga.so.0(grn_ctx_send+0x5a4) [0x712185423e23]
2026-04-14 03:10:06.549506|C| groonga(+0xda8b) [0x62a58e8d0a8b]
2026-04-14 03:10:06.549510|C| groonga(+0x1021d) [0x62a58e8d321d]
2026-04-14 03:10:06.549534|C| groonga(+0x13c37) [0x62a58e8d6c37]
2026-04-14 03:10:06.549537|C| /lib/x86_64-linux-gnu/libc.so.6(+0x9caa4) [0x7121847dbaa4]
2026-04-14 03:10:06.549541|C| /lib/x86_64-linux-gnu/libc.so.6(+0x129c6c) [0x712184868c6c]
2026-04-14 03:10:06.549550|C| ----------------
```