### PR TITLE
packages almalinux-8: use gcc-toolset-12 to fix build errors

### DIFF
--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -1,6 +1,9 @@
 ARG FROM=almalinux:8
 FROM ${FROM}
 
+ENV \
+  SCL=gcc-toolset-12
+
 ARG DEBUG
 ARG APACHE_ARROW_VERSION
 
@@ -15,11 +18,11 @@ RUN \
   dnf config-manager --set-enabled powertools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \
+    ${SCL} \
     arrow-compute-devel-${APACHE_ARROW_VERSION} \
     ccache \
     cmake \
     curl-devel \
-    gcc-c++ \
     intltool \
     libedit-devel \
     libevent-devel \


### PR DESCRIPTION
Since version 24.0.0, Apache Arrow requires `std::span`, which was introduced in C++20.
Ref: https://github.com/apache/arrow/commit/df9dbbc9858fcdc5b5f52545fcedc2c0f492173c

However, the default GCC on AlmaLinux 8 does not support C++20.
To address this, we use `gcc-toolset` to enable a newer GCC version that supports C++20 or later.

Going with `gcc-toolset-12` for now. `gcc-toolset-15` seems to be too new and leads to build errors with `simdjson`.
`gcc-toolset-12` should be enough since it still supports the C++20 features we need.