### PR TITLE
packages almalinux-8: use bundled simdjson

### DIFF
--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -33,7 +33,6 @@ RUN \
     python2-devel \
     rapidjson-devel \
     ruby \
-    simdjson-devel \
     tar \
     xxhash-devel \
     zlib-devel && \


### PR DESCRIPTION
Switch to bundled simdjson (v3.13.0) because the system version (v3.6.3) is incompatible with gcc-toolset-15.
The newer bundled version resolves the build errors observed with gcc-toolset-15.

TODO: Test on CI.