### PR TITLE
autotools: enable C++20 for builds where supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,6 @@ if test "$HAVE_CXX20" != "1"; then
   m4_ifdef([AX_CXX_COMPILE_STDCXX],
            [AX_CXX_COMPILE_STDCXX([14], [ext], [optional])])
 fi
-
 AC_PROG_CC
 m4_ifdef([AC_PROG_CC_C99],
          [AC_PROG_CC_C99])

--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,7 @@ m4_ifdef([AX_CXX_COMPILE_STDCXX],
          [AX_CXX_COMPILE_STDCXX([20], [ext], [optional])])
 if test "$HAVE_CXX20" != "1"; then
   m4_ifdef([AX_CXX_COMPILE_STDCXX],
-           [AX_CXX_COMPILE_STDCXX([14], [ext], [optional])])
+           [AX_CXX_COMPILE_STDCXX([17], [ext], [optional])])
 fi
 AC_PROG_CC
 m4_ifdef([AC_PROG_CC_C99],

--- a/configure.ac
+++ b/configure.ac
@@ -89,12 +89,13 @@ AC_MSG_RESULT([$solaris])
 
 AC_C_BIGENDIAN
 AC_PROG_CXX
-m4_ifdef([AX_CXX_COMPILE_STDCXX_17],
-         [AX_CXX_COMPILE_STDCXX_17([ext], [optional])])
-if test "$HAVE_CXX17" != "1"; then
-  m4_ifdef([AX_CXX_COMPILE_STDCXX_11],
-           [AX_CXX_COMPILE_STDCXX_11([ext], [optional])])
+m4_ifdef([AX_CXX_COMPILE_STDCXX],
+         [AX_CXX_COMPILE_STDCXX([20], [ext], [optional])])
+if test "$HAVE_CXX20" != "1"; then
+  m4_ifdef([AX_CXX_COMPILE_STDCXX],
+           [AX_CXX_COMPILE_STDCXX([14], [ext], [optional])])
 fi
+
 AC_PROG_CC
 m4_ifdef([AC_PROG_CC_C99],
          [AC_PROG_CC_C99])


### PR DESCRIPTION
Update compiler flags to -std=c++20 from -std=c++17.
Because since version 24.0.0, Apache Arrow requires "std::span", which was introduced in C++20.
Ref: apache/arrow@df9dbbc

This change resolves the following error in Autotools workflow:

```
/usr/include/arrow/buffer.h:239:8: error: 'span' in namespace 'std' does not name a template type
  239 |   std::span<const T> span_as() const {
      |        ^~~~
/usr/include/arrow/buffer.h:239:3: note: 'std::span' is only available from C++20 onwards
  239 |   std::span<const T> span_as() const {
      |   ^~~
/usr/include/arrow/buffer.h:272:8: error: 'span' in namespace 'std' does not name a template type
  272 |   std::span<T> mutable_span_as() {
      |        ^~~~
/usr/include/arrow/buffer.h:272:3: note: 'std::span' is only available from C++20 onwards
  272 |   std::span<T> mutable_span_as() {
      |   ^~~
```

Additionally, use C++17 as the minimum standard, falling back from C++20 where unavailable.
Because we use C++17 as the default version in CMake.

Since the "AX_CXX_COMPILE_STDCXX_20" macro was not being expanded correctly,
I changed the syntax to "AX_CXX_COMPILE_STDCXX([20], ...)" to ensure proper macro expansion.