### PR TITLE
benchmark: add missing files to release source archive

### DIFF
--- a/benchmark/Makefile.am
+++ b/benchmark/Makefile.am
@@ -16,12 +16,15 @@ noinst_PROGRAMS =				\
 	bench-result-set-raw			\
 	bench-between-sequential		\
 	bench-nfkc				\
-	bench-cache
+	bench-cache				\
+	bench-distance
 endif
 
 EXTRA_DIST =					\
+	CMakeLists.txt				\
 	bench-geo-select.sh			\
 	bench-query-optimizer-ddl.grn		\
+	geo-distance-summary.rb			\
 	geo-select-generate-grn.rb
 
 AM_CPPFLAGS =					\
@@ -73,6 +76,9 @@ nodist_EXTRA_bench_nfkc_SOURCES = $(NONEXISTENT_CXX_SOURCE)
 bench_cache_SOURCES = bench-cache.c
 nodist_EXTRA_bench_cache_SOURCES = $(NONEXISTENT_CXX_SOURCE)
 
+bench_distance_SOURCES = bench-distance.c
+nodist_EXTRA_bench_distance_SOURCES = $(NONEXISTENT_CXX_SOURCE)
+
 benchmarks =					\
 	run-bench-table-factory			\
 	run-bench-geo-distance			\
@@ -84,7 +90,8 @@ benchmarks =					\
 	run-bench-result-set-raw		\
 	run-bench-between-sequential		\
 	run-bench-nfkc				\
-	run-bench-cache
+	run-bench-cache				\
+	run-bench-distance
 
 run-bench-table-factory: bench-table-factory
 	@echo $@:
@@ -172,5 +179,11 @@ run-bench-nfkc: bench-nfkc
 run-bench-cache: bench-cache
 	@echo $@:
 	./bench-cache
+
+run-bench-distance: bench-distance
+	@echo $@:
+	env							\
+	  GRN_RUBY_SCRIPTS_DIR="$(top_srcdir)/lib/mrb/scripts"	\
+	  ./bench-distance
 
 benchmark: $(benchmarks)


### PR DESCRIPTION
Fix: GH-2793.

With this change, the benchmark directory in the source archive will be as follows:

```
groonga-16.0.2/benchmark
├── CMakeLists.txt
├── Makefile.am
├── bench-between-sequential.c
├── bench-cache.c
├── bench-ctx-create.c
├── bench-distance.c
├── bench-geo-distance.c
├── bench-geo-select.c
├── bench-geo-select.sh
├── bench-nfkc.c
├── bench-query-optimizer-ddl.grn
├── bench-query-optimizer.c
├── bench-range-select.c
├── bench-result-set-raw.c
├── bench-result-set.c
├── bench-table-factory.c
├── fixtures
│   ├── Makefile.am
│   └── geo-select
│       ├── 13_2010.CSV.xz
│       ├── Makefile.am
│       ├── README.txt
│       └── format_2010.html
├── geo-distance-summary.rb
├── geo-select-generate-grn.rb
└── lib
    ├── Makefile.am
    ├── bench-reporter.c
    ├── bench-reporter.h
    ├── bench-utils.c
    ├── bench-utils.h
    ├── benchmark.c
    └── benchmark.h
```

The diff as follow:

```diff
groonga-16.0.2/benchmark
+├── CMakeLists.txt
 ├── Makefile.am
 ├── bench-between-sequential.c
 ├── bench-cache.c
 ├── bench-ctx-create.c
+├── bench-distance.c
 ├── bench-geo-distance.c
 ├── bench-geo-select.c
 ├── bench-geo-select.sh
@@ -16,17 +17,15 @@
 ├── bench-table-factory.c
 ├── fixtures
 │   ├── Makefile.am
 │   └── geo-select
 │       ├── 13_2010.CSV.xz
 │       ├── Makefile.am
 │       ├── README.txt
 │       └── format_2010.html
+├── geo-distance-summary.rb
 ├── geo-select-generate-grn.rb
 └── lib
     ├── Makefile.am
     ├── bench-reporter.c
     ├── bench-reporter.h
     ├── bench-utils.c
@@ -34,4 +33,4 @@
     ├── benchmark.c
     └── benchmark.h
```

Reported by Nicolas PARLANT. Thanks!!!