### PR TITLE
ci: include msvcp140_atomic_wait.dll in Windows package

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -904,6 +904,7 @@ jobs:
           $VC_REDIST_VCRUNTIME = "${VC_REDIST_DIR}\vcruntime140.dll"
           $VC_REDIST_VCRUNTIME_1 = "${VC_REDIST_DIR}\vcruntime140_1.dll"
           $VC_REDIST_MSVCP = "${VC_REDIST_DIR}\msvcp140.dll"
+          $VC_REDIST_MSVCP_ATOMIC_WAIT = "${VC_REDIST_DIR}\msvcp140_atomic_wait.dll"
           $VC_REDIST_VCOMP = "${VC_REDIST_DIR_OPEN_MP}\vcomp140.dll"
           Copy-Item `
             ${VC_REDIST_VCRUNTIME} `
@@ -915,6 +916,9 @@ jobs:
           }
           Copy-Item `
             ${VC_REDIST_MSVCP} `
+            "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}\bin"
+          Copy-Item `
+            ${VC_REDIST_MSVCP_ATOMIC_WAIT} `
             "${Env:FULL_INSTALL_FOLDER_WITH_VCRUNTIME}\bin"
           Copy-Item `
             ${VC_REDIST_VCOMP} `


### PR DESCRIPTION
Without this DLL, groonga.exe fails to start with an error saying that MSVCP140_ATOMIC_WAIT.dll was not found.

Checked that groonga.exe starts successfully with this DLL bundled.