### PR TITLE
ci msys2: add support for clamg64

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -564,6 +564,9 @@ jobs:
           - msystem: UCRT64
             package-prefix: mingw-w64-ucrt-x86_64
             runner: windows-latest
+          - msystem: CLANG64
+            package-prefix: mingw-w64-clang-x86_64
+            runner: windows-latest
           - msystem: CLANGARM64
             package-prefix: mingw-w64-clang-aarch64
             runner: windows-11-arm

--- a/ci/msys2/PKGBUILD
+++ b/ci/msys2/PKGBUILD
@@ -55,6 +55,7 @@ build() {
   [[ -d ${srcdir}/build-${CARCH} ]] && rm -rf ${srcdir}/build-${CARCH}
   mkdir -p ${srcdir}/build-${CARCH} && cd ${srcdir}/build-${CARCH}
 
+  CFLAGS+=" -Wno-incompatible-pointer-types" \
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
       ../${_realname}-${pkgver} \


### PR DESCRIPTION
Note that this CI fails at this commit.
A fix will be provided in the following commits.