### PR TITLE
doc news: update release date and version

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news/16.po
+++ b/doc/locale/ja/LC_MESSAGES/news/16.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "News - 16 series"
 msgstr "お知らせ - 16系"
 
-msgid "Release 16.0.4 - 2026-05-13"
-msgstr "16.0.4リリース - 2026-05-13"
+msgid "Release 16.0.5 - 2026-05-21"
+msgstr "16.0.5リリース - 2026-05-21"
 
 msgid "Fixes"
 msgstr "修正"

--- a/doc/source/news/16.md
+++ b/doc/source/news/16.md
@@ -1,8 +1,8 @@
 # News - 16 series
 
-(release-16-0-4)=
+(release-16-0-5)=
 
-## Release 16.0.4 - 2026-05-13
+## Release 16.0.5 - 2026-05-21
 
 ### Fixes
 


### PR DESCRIPTION
Because 16.0.4 release failed.
We could not deploy the apt packages to packages.groonga.org because of the disk was full.
We freed up some space, so we will re-release Groonga as 16.0.5.
