### PR TITLE
release: use OAuth 2.0 for X announcement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,25 +115,31 @@ jobs:
             --notes-file release-note-without-version.md \
             --title "${title}" \
             release-artifacts/*/*
-      - name: Prepare for Launchpad publishing
-        if: |
-          github.ref_type == 'tag'
+  launchpad:
+    name: Launchpad
+    runs-on: ubuntu-latest
+    needs: publish
+    environment: release
+    timeout-minutes: 10
+    if: |
+      github.ref_type == 'tag'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Download source archive
         run: |
-          cp release-artifacts/release-source/groonga-*.tar.gz ./
+          wget https://github.com/groonga/groonga/releases/download/${GITHUB_REF_NAME}/groonga-${GITHUB_REF_NAME#v}.tar.gz
+      - name: Prepare
+        run: |
           sudo apt update
           sudo apt install -y \
             build-essential \
             debhelper \
             devscripts
       - uses: actions/checkout@v6
-        if: |
-          github.ref_type == 'tag'
         with:
           path: apache-arrow
           repository: apache/arrow
-      - name: Publish to Launchpad
-        if: |
-          github.ref_type == 'tag'
+      - name: Publish
         env:
           APACHE_ARROW_REPOSITORY: ${{ github.workspace }}/apache-arrow
           LAUNCHPAD_DEPLOY_KEY: ${{ secrets.LAUNCHPAD_DEPLOY_KEY }}
@@ -142,16 +148,22 @@ jobs:
           echo "${LAUNCHPAD_DEPLOY_KEY}" | gpg --import
           echo "trusted-key ${LAUNCHPAD_UPLOADER_PGP_KEY}" > ~/.gnupg/gpg.conf
           rake -C packages ubuntu
+  x:
+    name: X
+    runs-on: ubuntu-latest
+    needs: publish
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
           bundler-cache: true
-      - name: Post Announcement
+      - name: Post announcement
         env:
           DRY_RUN: ${{ github.ref_type != 'tag' }}
-          X_API_KEY: ${{ secrets.X_API_KEY }}
-          X_API_KEY_SECRET: ${{ secrets.X_API_KEY_SECRET }}
-          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
-          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+          X_CLIENT_ID: ${{ secrets.X_CLIENT_ID }}
+          X_CLIENT_SECRET: ${{ secrets.X_CLIENT_SECRET }}
+          X_REFRESH_TOKEN: ${{ secrets.X_REFRESH_TOKEN }}
         run: |
           VERSION=${GITHUB_REF_NAME#v} bundle exec rake release:announce

--- a/Rakefile
+++ b/Rakefile
@@ -262,17 +262,18 @@ Groonga #{version} (#{latest_release_date}) has been released!
 See: #{latest_release_url}#{latest_release_anchor}
     ANNOUNCE
 
-    x_credentials = {
-      api_key: ENV["X_API_KEY"],
-      api_key_secret: ENV["X_API_KEY_SECRET"],
-      access_token: ENV["X_ACCESS_TOKEN"],
-      access_token_secret: ENV["X_ACCESS_TOKEN_SECRET"]
-    }
-    x_client = X::Client.new(**x_credentials)
     tweet_body = { text: latest_release_announce }
     if dry_run?
       puts tweet_body
     else
+      x_credentials = {
+        client_id: ENV["X_CLIENT_ID"],
+        client_secret: ENV["X_CLIENT_SECRET"],
+        access_token: "dummy", # Refreshed by refresh token
+        refresh_token: ENV["X_REFRESH_TOKEN"],
+      }
+      x_client = X::Client.new(**x_credentials)
+      x_client.refresh_token!
       x_client.post("tweets", tweet_body.to_json)
     end
   end


### PR DESCRIPTION
Notes:
* We need to update refresh token per 6 months.
* We need $0.2 per post. ($0.015 per post if we don't include URL.) We have only $4.6 budget now. This will run out eventually.
  * See https://docs.x.com/x-api/getting-started/pricing#write-operations for prices.
* `X_CLIENT_ID`/`X_CLIENT_SECRET`/`X_ACCESS_TOKEN`/`X_REFRESH_TOKEN` are defined in organization secrets not repository environment secrets. So we don't need `environment: release` for them.