### PR TITLE
language-model: fix crash on empty content

### DIFF
--- a/lib/language_model.cpp
+++ b/lib/language_model.cpp
@@ -583,7 +583,7 @@ namespace grn {
           uint32_t input_size = 0;
           auto input = grn_obj_get_value_(ctx, input_column, id, &input_size);
           if (prefix.empty()) {
-            tokenize(input, tokens);
+            tokenize(std::string_view(input, input_size), tokens);
           } else {
             auto prefixed_input = std::string(prefix);
             prefixed_input.append(input, input_size);

--- a/test/command/suite/language_model/build/empty.expected
+++ b/test/command/suite/language_model/build/empty.expected
@@ -1,0 +1,80 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": ""},
+{"text": "This is an apple."}
+]
+[[0,0.0,0.0],3]
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF",                            "code_column", "rabitq_code")'
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[[0,0.0,0.0],true]
+#|w| load: special_eos_id is not in special_eog_ids - the tokenizer config may be incorrect
+select Data   --filter 'language_model_knn(text, "male child")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        ""
+      ]
+    ]
+  ]
+]
+select Data   --filter 'language_model_knn(text, "I like fruit")'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        ""
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/language_model/build/empty.test
+++ b/test/command/suite/language_model/build/empty.test
@@ -1,0 +1,33 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": ""},
+{"text": "This is an apple."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY ShortBinary \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/all-MiniLM-L6-v2-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code")'
+# This is for waiting for downloading model.
+#@timeout 300
+column_create RaBitQ data_text COLUMN_INDEX Data text
+
+select Data \
+  --filter 'language_model_knn(text, "male child")' \
+  --output_columns text
+
+select Data \
+  --filter 'language_model_knn(text, "I like fruit")' \
+  --output_columns text


### PR DESCRIPTION
When the text is empty, input is `NULL` and it crashes.
`tokenize(input, tokens)` calls `strlen(NULL)` to compute the length, which causes the crash.
Using `std::string_view(input, input_size)` avoids `strlen(NULL)`.