### PR TITLE
expr: fix double free of temporary hash in sort_keys

### DIFF
--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8165,8 +8165,19 @@ grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
     grn_obj *copied_entry = (grn_obj *)copied_value;
     switch (entry->header.type) {
     case GRN_PTR:
-      GRN_OBJ_INIT(copied_entry, GRN_PTR, 0, GRN_ID_NIL);
-      GRN_PTR_SET(ctx, copied_entry, GRN_PTR_VALUE(entry));
+      {
+        grn_obj *pointee = GRN_PTR_VALUE(entry);
+        if (pointee && grn_expr_is_options(ctx, pointee)) {
+          pointee = grn_expr_copy_options(ctx, pointee);
+          if (!pointee) {
+            break;
+          }
+          GRN_PTR_INIT(copied_entry, GRN_OBJ_OWN, GRN_ID_NIL);
+        } else {
+          GRN_PTR_INIT(copied_entry, 0, GRN_ID_NIL);
+        }
+        GRN_PTR_SET(ctx, copied_entry, pointee);
+      }
       break;
     case GRN_VECTOR:
       GRN_OBJ_INIT(copied_entry, entry->header.type, 0, entry->header.domain);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8135,20 +8135,20 @@ grn_expr_is_options(grn_ctx *ctx, grn_obj *obj)
 }
 
 static grn_obj *
-grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
+grn_expr_copy_options(grn_ctx *ctx, grn_obj *expr, grn_obj *options)
 {
-  grn_hash *source_hash = (grn_hash *)source;
+  grn_hash *source = (grn_hash *)options;
   grn_hash *copied = grn_hash_create(ctx,
                                      NULL,
-                                     source_hash->key_size,
-                                     source_hash->value_size,
-                                     source_hash->obj.header.flags);
+                                     source->key_size,
+                                     source->value_size,
+                                     source->obj.header.flags);
   if (!copied) {
     ERR(GRN_NO_MEMORY_AVAILABLE, "[expr][copy-options] failed to create hash");
     return NULL;
   }
-  copied->obj.header.domain = source_hash->obj.header.domain;
-  GRN_HASH_EACH_BEGIN(ctx, source_hash, cursor, id)
+  copied->obj.header.domain = source->obj.header.domain;
+  GRN_HASH_EACH_BEGIN(ctx, source, cursor, id)
   {
     void *key;
     unsigned int key_size;
@@ -8168,14 +8168,13 @@ grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
       {
         grn_obj *pointer = GRN_PTR_VALUE(entry);
         if (pointer && grn_expr_is_options(ctx, pointer)) {
-          pointer = grn_expr_copy_options(ctx, pointer);
+          pointer = grn_expr_copy_options(ctx, expr, pointer);
           if (!pointer) {
             break;
           }
-          GRN_PTR_INIT(copied_entry, GRN_OBJ_OWN, GRN_ID_NIL);
-        } else {
-          GRN_PTR_INIT(copied_entry, 0, GRN_ID_NIL);
+          grn_expr_take_obj(ctx, expr, pointer);
         }
+        GRN_PTR_INIT(copied_entry, 0, GRN_ID_NIL);
         GRN_PTR_SET(ctx, copied_entry, pointer);
       }
       break;
@@ -8268,7 +8267,7 @@ grn_expr_slice(grn_ctx *ctx,
         if (grn_obj_is_accessor(ctx, value)) {
           value = grn_accessor_copy(ctx, value);
         } else if (grn_expr_is_options(ctx, value)) {
-          value = grn_expr_copy_options(ctx, value);
+          value = grn_expr_copy_options(ctx, sliced_expr, value);
           if (!value) {
             grn_expr_close(ctx, sliced_expr);
             GRN_API_RETURN(NULL);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8163,6 +8163,7 @@ grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
     }
     grn_obj *entry = (grn_obj *)value;
     grn_obj *copied_entry = (grn_obj *)copied_value;
+    GRN_VOID_INIT(copied_entry);
     switch (entry->header.type) {
     case GRN_PTR:
       {
@@ -8194,6 +8195,13 @@ grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
   }
   GRN_HASH_EACH_END(ctx, cursor);
   if (ctx->rc != GRN_SUCCESS) {
+    GRN_HASH_EACH_BEGIN(ctx, copied, cleanup_cursor, cleanup_id)
+    {
+      void *value;
+      grn_hash_cursor_get_value(ctx, cleanup_cursor, &value);
+      GRN_OBJ_FIN(ctx, (grn_obj *)value);
+    }
+    GRN_HASH_EACH_END(ctx, cleanup_cursor);
     grn_hash_close(ctx, copied);
     return NULL;
   }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8126,6 +8126,69 @@ grn_expr_get_condition(grn_ctx *ctx, grn_obj *expr)
   GRN_API_RETURN(e->condition);
 }
 
+static bool
+grn_expr_is_options(grn_ctx *ctx, grn_obj *obj)
+{
+  return obj->header.type == GRN_TABLE_HASH_KEY &&
+         grn_obj_is_temporary(ctx, obj) &&
+         ((grn_hash *)obj)->value_size == sizeof(grn_obj);
+}
+
+static grn_obj *
+grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
+{
+  grn_hash *source_hash = (grn_hash *)source;
+  grn_hash *copied = grn_hash_create(ctx,
+                                     NULL,
+                                     source_hash->key_size,
+                                     source_hash->value_size,
+                                     source_hash->obj.header.flags);
+  if (!copied) {
+    ERR(GRN_NO_MEMORY_AVAILABLE, "[expr][copy-options] failed to create hash");
+    return NULL;
+  }
+  copied->obj.header.domain = source_hash->obj.header.domain;
+  GRN_HASH_EACH_BEGIN(ctx, source_hash, cursor, id)
+  {
+    void *key;
+    unsigned int key_size;
+    void *value;
+    grn_hash_cursor_get_key_value(ctx, cursor, &key, &key_size, &value);
+    void *copied_value;
+    grn_id copied_id =
+      grn_hash_add(ctx, copied, key, key_size, &copied_value, NULL);
+    if (copied_id == GRN_ID_NIL) {
+      ERR(GRN_NO_MEMORY_AVAILABLE, "[expr][copy-options] failed to add key");
+      break;
+    }
+    grn_obj *entry = (grn_obj *)value;
+    grn_obj *copied_entry = (grn_obj *)copied_value;
+    switch (entry->header.type) {
+    case GRN_PTR:
+      GRN_OBJ_INIT(copied_entry, GRN_PTR, 0, GRN_ID_NIL);
+      GRN_PTR_SET(ctx, copied_entry, GRN_PTR_VALUE(entry));
+      break;
+    case GRN_VECTOR:
+      GRN_OBJ_INIT(copied_entry, entry->header.type, 0, entry->header.domain);
+      grn_vector_copy(ctx, entry, copied_entry);
+      break;
+    default:
+      GRN_OBJ_INIT(copied_entry, entry->header.type, 0, entry->header.domain);
+      GRN_TEXT_PUT(ctx,
+                   copied_entry,
+                   GRN_TEXT_VALUE(entry),
+                   GRN_TEXT_LEN(entry));
+      break;
+    }
+  }
+  GRN_HASH_EACH_END(ctx, cursor);
+  if (ctx->rc != GRN_SUCCESS) {
+    grn_hash_close(ctx, copied);
+    return NULL;
+  }
+  return (grn_obj *)copied;
+}
+
 grn_obj *
 grn_expr_slice(grn_ctx *ctx,
                grn_obj *expr,
@@ -8186,6 +8249,12 @@ grn_expr_slice(grn_ctx *ctx,
       } else {
         if (grn_obj_is_accessor(ctx, value)) {
           value = grn_accessor_copy(ctx, value);
+        } else if (grn_expr_is_options(ctx, value)) {
+          value = grn_expr_copy_options(ctx, value);
+          if (!value) {
+            grn_expr_close(ctx, sliced_expr);
+            GRN_API_RETURN(NULL);
+          }
         } else {
           grn_obj_refer(ctx, value);
         }

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -8163,21 +8163,20 @@ grn_expr_copy_options(grn_ctx *ctx, grn_obj *source)
     }
     grn_obj *entry = (grn_obj *)value;
     grn_obj *copied_entry = (grn_obj *)copied_value;
-    GRN_VOID_INIT(copied_entry);
     switch (entry->header.type) {
     case GRN_PTR:
       {
-        grn_obj *pointee = GRN_PTR_VALUE(entry);
-        if (pointee && grn_expr_is_options(ctx, pointee)) {
-          pointee = grn_expr_copy_options(ctx, pointee);
-          if (!pointee) {
+        grn_obj *pointer = GRN_PTR_VALUE(entry);
+        if (pointer && grn_expr_is_options(ctx, pointer)) {
+          pointer = grn_expr_copy_options(ctx, pointer);
+          if (!pointer) {
             break;
           }
           GRN_PTR_INIT(copied_entry, GRN_OBJ_OWN, GRN_ID_NIL);
         } else {
           GRN_PTR_INIT(copied_entry, 0, GRN_ID_NIL);
         }
-        GRN_PTR_SET(ctx, copied_entry, pointee);
+        GRN_PTR_SET(ctx, copied_entry, pointer);
       }
       break;
     case GRN_VECTOR:

--- a/test/command/suite/language_model/sort/with_k.expected
+++ b/test/command/suite/language_model/sort/with_k.expected
@@ -1,0 +1,50 @@
+plugin_register language_model/knn
+[[0,0.0,0.0],true]
+table_create Data TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Data text COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+[[0,0.0,0.0],true]
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."},
+{"text": "Groonga is a full text search engine."}
+]
+[[0,0.0,0.0],3]
+table_create RaBitQ TABLE_HASH_KEY ShortBinary   --default_tokenizer     'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF",                            "code_column", "rabitq_code",                            "passage_prefix", "passage: ",                            "query_prefix", "query: ")'
+[[0,0.0,0.0],true]
+column_create RaBitQ data_text COLUMN_INDEX Data text
+[[0,0.0,0.0],true]
+#|w| load: model vocab missing newline token, using special_pad_id instead
+select Data   --sort_keys '-language_model_knn(text, "male child", { "k" : 2 })'   --output_columns text
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "text",
+          "ShortText"
+        ]
+      ],
+      [
+        "I am a boy."
+      ],
+      [
+        "This is an apple."
+      ],
+      [
+        "Groonga is a full text search engine."
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/language_model/sort/with_k.test
+++ b/test/command/suite/language_model/sort/with_k.test
@@ -1,0 +1,31 @@
+#@require-env GRN_LANGUAGE_MODEL_DOWNLOAD_CACHE_DIR
+#@require-feature llama.cpp
+
+#@on-error omit
+plugin_register language_model/knn
+#@on-error default
+
+table_create Data TABLE_NO_KEY
+column_create Data text COLUMN_SCALAR ShortText
+column_create Data rabitq_code COLUMN_SCALAR ShortBinary
+
+load --table Data
+[
+{"text": "I am a boy."},
+{"text": "This is an apple."},
+{"text": "Groonga is a full text search engine."}
+]
+
+table_create RaBitQ TABLE_HASH_KEY ShortBinary \
+  --default_tokenizer \
+    'TokenLanguageModelKNN("model", "hf:///groonga/multilingual-e5-base-Q4_K_M-GGUF", \
+                           "code_column", "rabitq_code", \
+                           "passage_prefix", "passage: ", \
+                           "query_prefix", "query: ")'
+# This is for waiting for downloading model.
+#@timeout 300
+column_create RaBitQ data_text COLUMN_INDEX Data text
+
+select Data \
+  --sort_keys '-language_model_knn(text, "male child", { "k" : 2 })' \
+  --output_columns text


### PR DESCRIPTION
For example, if you specify `language_model_knn(text, "male child", { "k" : 2 })` as `sort_keys`.
For the `{ "k" : 2 }` option, in grn_select_sort(), the value is freed after it is parsed, and there is another free operation after processing is complete.

If not copied, this will cause a crash due to a double free, so we make a copy.