### PR TITLE
ci cmake: stop installing outdated system xsimd

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -127,7 +127,6 @@ jobs:
             build-essential \
             ccache \
             cmake \
-            libxsimd-dev \
             ninja-build
       - uses: actions/checkout@v7
         if: matrix.apache-arrow-main == 'yes'


### PR DESCRIPTION
Currently, we install libxsimd-dev in the "Install common build dependencies" step.
However, the system xsimd version in the CI environment is outdated.

As a result, CMake attempts to use the bundled xsimd instead of the system one.
This cause a conflict because the "add_library" target for xsimd already exist.