### PR TITLE
ci arch-linux: use bundled Blosc2 instead of system

### DIFF
--- a/ci/arch-linux/PKGBUILD
+++ b/ci/arch-linux/PKGBUILD
@@ -60,8 +60,8 @@ build() {
     -D CMAKE_INSTALL_PREFIX=/usr
     -D CMAKE_SKIP_RPATH=ON
     -D GRN_WITH_APACHE_ARROW=ON
-    # Thi is a workaround.
-    # Currently, the system-provided Blosc2 is not use when Groonga is built due to the following error.
+    # This is a workaround.
+    # Currently, the system-provided Blosc2 is not used when building Groonga due to the following error.
     #
     # CMake Error at /usr/lib/cmake/Blosc2/Blosc2Targets.cmake:108 (message):
     # The imported target "Blosc2::blosc2_static" references the file

--- a/ci/arch-linux/PKGBUILD
+++ b/ci/arch-linux/PKGBUILD
@@ -60,6 +60,15 @@ build() {
     -D CMAKE_INSTALL_PREFIX=/usr
     -D CMAKE_SKIP_RPATH=ON
     -D GRN_WITH_APACHE_ARROW=ON
+    # Thi is a workaround.
+    # Currently, the system-provided Blosc2 is not use when Groonga is built due to the following error.
+    #
+    # CMake Error at /usr/lib/cmake/Blosc2/Blosc2Targets.cmake:108 (message):
+    # The imported target "Blosc2::blosc2_static" references the file
+    # "/usr/lib/libblosc2.a"
+    #
+    # This is an upstream issue.
+    # So, we use bundled Blosc2 until the upstream issue is resolved.
     -D GRN_WITH_BLOSC=bundled
     -D GRN_WITH_MRUBY=ON
   )

--- a/ci/arch-linux/PKGBUILD
+++ b/ci/arch-linux/PKGBUILD
@@ -60,7 +60,7 @@ build() {
     -D CMAKE_INSTALL_PREFIX=/usr
     -D CMAKE_SKIP_RPATH=ON
     -D GRN_WITH_APACHE_ARROW=ON
-    -D GRN_WITH_BLOSC=system
+    -D GRN_WITH_BLOSC=bundled
     -D GRN_WITH_MRUBY=ON
   )
   cmake "${cmake_options[@]}"


### PR DESCRIPTION
Currently, the system-provided Blosc2 is not use when Groonga is built due to the following error.

```
CMake Error at /usr/lib/cmake/Blosc2/Blosc2Targets.cmake:108 (message):
The imported target "Blosc2::blosc2_static" references the file
"/usr/lib/libblosc2.a"
```

This is an upstream issue.
So, we use bundled Blosc2 until the upstream issue is resolved.