### PR TITLE
doc news: update release date and version

### DIFF
--- a/doc/locale/ja/LC_MESSAGES/news/16.po
+++ b/doc/locale/ja/LC_MESSAGES/news/16.po
@@ -17,8 +17,8 @@ msgstr ""
 msgid "News - 16 series"
 msgstr "お知らせ - 16系"
 
-msgid "Release 16.0.7 - 2026-07-08"
-msgstr "16.0.7リリース - 2026-07-08"
+msgid "Release 16.0.8 - 2026-07-13"
+msgstr "16.0.8リリース - 2026-07-13"
 
 msgid "Improvements"
 msgstr "改良"

--- a/doc/source/news/16.md
+++ b/doc/source/news/16.md
@@ -1,8 +1,8 @@
 # News - 16 series
 
-(release-16-0-7)=
+(release-16-0-8)=
 
-## Release 16.0.7 - 2026-07-08
+## Release 16.0.8 - 2026-07-13
 
 ### Improvements
 


### PR DESCRIPTION
Because the 16.0.7 release failed due to build error.
We resolved the build error, so we will re-release Groonga as version 16.0.8.