### PR TITLE
benchmark: Remove incorrect G_GNUC_CONST usage

### DIFF
--- a/benchmark/lib/bench-reporter.h
+++ b/benchmark/lib/bench-reporter.h
@@ -47,7 +47,7 @@ struct _BenchReporterClass
   GObjectClass parent_class;
 };
 
-GType           bench_reporter_get_type  (void) G_GNUC_CONST;
+GType           bench_reporter_get_type  (void);
 
 BenchReporter  *bench_reporter_new       (void);
 void            bench_reporter_register  (BenchReporter     *reporter,


### PR DESCRIPTION
GitHub: Fix GH-2857

`bench_reporter_get_type` has global side effects, which makes it ineligible for the `G_GNUC_CONST` compiler attribute.

See https://gitlab.gnome.org/GNOME/glib/-/commit/016829559 for further information about how incorrect usage can lead to issues with development versions of GCC.

See also:
* https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223
* https://gitlab.gnome.org/GNOME/glib/-/work_items/3984
