### PR TITLE
store: remove unused but declared variable

### DIFF
--- a/lib/store.c
+++ b/lib/store.c
@@ -780,10 +780,14 @@ struct _grn_ja_einfo {
     (e)->u.h.seg = (_seg);                                                     \
     (e)->u.h.size = (_size);                                                   \
   } while (0)
+#define EHUGE_DEC_SIZE(e, _size)                                               \
+  do {                                                                         \
+    (_size) = (e)->u.h.size;                                                   \
+  } while (0)
 #define EHUGE_DEC(e, _seg, _size)                                              \
   do {                                                                         \
     (_seg) = (e)->u.h.seg;                                                     \
-    (_size) = (e)->u.h.size;                                                   \
+    EHUGE_DEC_SIZE((e), (_size));                                              \
   } while (0)
 #define EINFO_ENC(e, _seg, _pos, _size)                                        \
   do {                                                                         \
@@ -793,11 +797,15 @@ struct _grn_ja_einfo {
     (e)->u.n.pos = (_pos);                                                     \
     (e)->u.n.size = (_size);                                                   \
   } while (0)
+#define EINFO_DEC_POS_SIZE(e, _pos, _size)                                     \
+  do {                                                                         \
+    (_pos) = ((e)->u.n.c1 << 16) + (e)->u.n.pos;                               \
+    (_size) = ((e)->u.n.c2 << 16) + (e)->u.n.size;                             \
+  } while (0)
 #define EINFO_DEC(e, _seg, _pos, _size)                                        \
   do {                                                                         \
     (_seg) = (e)->u.n.seg;                                                     \
-    (_pos) = ((e)->u.n.c1 << 16) + (e)->u.n.pos;                               \
-    (_size) = ((e)->u.n.c2 << 16) + (e)->u.n.size;                             \
+    EINFO_DEC_POS_SIZE((e), (_pos), (_size));                                  \
   } while (0)
 
 typedef struct {
@@ -3601,12 +3609,11 @@ grn_ja_element_info(grn_ctx *ctx,
         ETINY_DEC(ei, *size);
         *pos = 0;
       } else {
-        uint32_t jag;
         if (EHUGE_P(ei)) {
-          EHUGE_DEC(ei, jag, *size);
+          EHUGE_DEC_SIZE(ei, *size);
           *pos = 0;
         } else {
-          EINFO_DEC(ei, jag, *pos, *size);
+          EINFO_DEC_POS_SIZE(ei, *pos, *size);
         }
       }
       grn_io_seg_unref(ctx, ja->io, pseg);


### PR DESCRIPTION
https://jira.mariadb.org/browse/MDEV-39881
See also: https://github.com/MariaDB/server/pull/5303

Groonga does not use `jag` in `grn_ja_element_info()`.
Therefore, we only needed the size.

Patched by Daniel Black. Thanks!!!