### PR TITLE
clang-format: add plugins/functions/string.c

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,9 +202,10 @@ repos:
           ?plugins/functions/h3\.c|
           ?plugins/functions/language_model\.c|
           ?plugins/functions/number\.cpp|
+          ?plugins/functions/string\.c|
+          ?plugins/language_model/knn\.cpp|
           ?plugins/tokenizers/h3_index\.c|
           ?plugins/tokenizers/mecab\.c|
-          ?plugins/language_model/knn\.cpp|
           ?src/groonga\.c|
           )
   - repo: https://github.com/cheshirekow/cmake-format-precommit

--- a/plugins/functions/string.c
+++ b/plugins/functions/string.c
@@ -46,7 +46,9 @@ string_n_chars(grn_ctx *ctx, const char *string, size_t string_size)
  * number of characters before the invalid byte sequence.
  */
 static grn_obj *
-func_string_length(grn_ctx *ctx, int n_args, grn_obj **args,
+func_string_length(grn_ctx *ctx,
+                   int n_args,
+                   grn_obj **args,
                    grn_user_data *user_data)
 {
   grn_obj *target;
@@ -54,7 +56,8 @@ func_string_length(grn_ctx *ctx, int n_args, grn_obj **args,
   grn_obj *grn_length;
 
   if (n_args != 1) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "string_length(): wrong number of arguments (%d for 1)",
                      n_args);
     return NULL;
@@ -69,7 +72,8 @@ func_string_length(grn_ctx *ctx, int n_args, grn_obj **args,
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, target);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "string_length(): target object must be a text bulk: "
                      "<%.*s>",
                      (int)GRN_TEXT_LEN(&inspected),
@@ -90,7 +94,9 @@ func_string_length(grn_ctx *ctx, int n_args, grn_obj **args,
 }
 
 static grn_obj *
-func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
+func_string_substring(grn_ctx *ctx,
+                      int n_args,
+                      grn_obj **args,
                       grn_user_data *user_data)
 {
 #define string_substring_tag "[string_substring]"
@@ -107,7 +113,8 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
   grn_obj *substring = NULL;
 
   if (n_args < 2 || n_args > 4) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s "
                      "wrong number of arguments (%d for 2..4)",
                      string_substring_tag,
@@ -129,7 +136,8 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
 
       GRN_TEXT_INIT(&inspected, 0);
       grn_inspect(ctx, &inspected, length_or_options);
-      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
                        "%s "
                        "3rd argument must be a long or a hash table: %.*s",
                        string_substring_tag,
@@ -140,7 +148,7 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
     }
   }
   if (n_args == 4) {
-    //options type will be checked in grn_proc_options_parse
+    // options type will be checked in grn_proc_options_parse
     options = args[3];
   }
 
@@ -162,7 +170,8 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
 
       GRN_TEXT_INIT(&inspected, 0);
       grn_inspect(ctx, &inspected, default_value);
-      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
                        "%s[default_value] must be a text bulk: <%.*s>",
                        string_substring_tag,
                        (int)GRN_TEXT_LEN(&inspected),
@@ -177,7 +186,8 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, target);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s[target] must be a text bulk: <%.*s>",
                      string_substring_tag,
                      (int)GRN_TEXT_LEN(&inspected),
@@ -219,8 +229,7 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
       int char_length = 0;
       size_t n_chars = 0;
 
-      for (;
-           p < end && (char_length = grn_charlen(ctx, p, end));
+      for (; p < end && (char_length = grn_charlen(ctx, p, end));
            p += char_length, n_chars++) {
         if (n_chars == (size_t)from) {
           start = p;
@@ -233,8 +242,7 @@ func_string_substring(grn_ctx *ctx, int n_args, grn_obj **args,
       int char_length = 0;
       size_t n_chars = 0;
 
-      for (;
-           p < end && (char_length = grn_charlen(ctx, p, end));
+      for (; p < end && (char_length = grn_charlen(ctx, p, end));
            p += char_length, n_chars++) {
         if (n_chars == (size_t)length) {
           end = p;
@@ -256,7 +264,8 @@ exit:
 
   if (!substring) {
     if (!default_value) {
-      default_value = grn_plugin_proc_alloc(ctx, user_data, target->header.domain, 0);
+      default_value =
+        grn_plugin_proc_alloc(ctx, user_data, target->header.domain, 0);
       if (!default_value) {
         return NULL;
       }
@@ -271,8 +280,12 @@ exit:
 }
 
 static bool
-string_is_over_n_chars(grn_ctx *ctx, const char *string, size_t string_size,
-                       int64_t max_n_chars, int64_t n_keep_chars, const char **kept_end)
+string_is_over_n_chars(grn_ctx *ctx,
+                       const char *string,
+                       size_t string_size,
+                       int64_t max_n_chars,
+                       int64_t n_keep_chars,
+                       const char **kept_end)
 {
   const char *p = string;
   const char *end = string + string_size;
@@ -303,13 +316,16 @@ string_is_over_n_chars(grn_ctx *ctx, const char *string, size_t string_size,
  * This is the same as Ruby on Rails' String#truncate.
  */
 static grn_obj *
-func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
+func_string_truncate(grn_ctx *ctx,
+                     int n_args,
+                     grn_obj **args,
                      grn_user_data *user_data)
 {
 #define string_truncate_tag "[string_truncate]"
 
   if (n_args < 2 || n_args > 3) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s "
                      "wrong number of arguments (%d for 2..3)",
                      string_truncate_tag,
@@ -327,7 +343,8 @@ func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
     grn_obj inspected;
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, target);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s[target] must be a text bulk: <%.*s>",
                      string_truncate_tag,
                      (int)GRN_TEXT_LEN(&inspected),
@@ -354,7 +371,8 @@ func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
       grn_obj inspected;
       GRN_TEXT_INIT(&inspected, 0);
       grn_inspect(ctx, &inspected, omission);
-      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
                        "%s[omission] must be a text bulk: <%.*s>",
                        string_truncate_tag,
                        (int)GRN_TEXT_LEN(&inspected),
@@ -364,7 +382,11 @@ func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
     }
   }
 
-  int64_t max_n_chars = grn_plugin_proc_get_value_int64(ctx, args[1], 0, string_truncate_tag "[length]");
+  int64_t max_n_chars =
+    grn_plugin_proc_get_value_int64(ctx,
+                                    args[1],
+                                    0,
+                                    string_truncate_tag "[length]");
   if (ctx->rc != GRN_SUCCESS) {
     return NULL;
   }
@@ -378,7 +400,8 @@ func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
     n_omission_chars = string_n_chars(ctx, omission_value, omission_size);
   }
 
-  grn_obj *result = grn_plugin_proc_alloc(ctx, user_data, target->header.domain, 0);
+  grn_obj *result =
+    grn_plugin_proc_alloc(ctx, user_data, target->header.domain, 0);
   if (!result) {
     return NULL;
   }
@@ -411,7 +434,9 @@ func_string_truncate(grn_ctx *ctx, int n_args, grn_obj **args,
 }
 
 static grn_obj *
-func_string_tokenize(grn_ctx *ctx, int n_args, grn_obj **args,
+func_string_tokenize(grn_ctx *ctx,
+                     int n_args,
+                     grn_obj **args,
                      grn_user_data *user_data)
 {
   grn_obj *target;
@@ -419,9 +444,11 @@ func_string_tokenize(grn_ctx *ctx, int n_args, grn_obj **args,
   grn_obj *options = NULL;
 
   if (!(n_args == 2 || n_args == 3)) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
-                     "[string_tokenize] wrong number of arguments (%d for 2..3)",
-                     n_args);
+    GRN_PLUGIN_ERROR(
+      ctx,
+      GRN_INVALID_ARGUMENT,
+      "[string_tokenize] wrong number of arguments (%d for 2..3)",
+      n_args);
     return NULL;
   }
 
@@ -436,7 +463,8 @@ func_string_tokenize(grn_ctx *ctx, int n_args, grn_obj **args,
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, target);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "[string_tokenize][target] must be a text bulk: %.*s",
                      (int)GRN_TEXT_LEN(&inspected),
                      GRN_TEXT_VALUE(&inspected));
@@ -449,10 +477,12 @@ func_string_tokenize(grn_ctx *ctx, int n_args, grn_obj **args,
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, lexicon);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
-                     "[string_tokenize][lexicon] must be a table with key: %.*s",
-                     (int)GRN_TEXT_LEN(&inspected),
-                     GRN_TEXT_VALUE(&inspected));
+    GRN_PLUGIN_ERROR(
+      ctx,
+      GRN_INVALID_ARGUMENT,
+      "[string_tokenize][lexicon] must be a table with key: %.*s",
+      (int)GRN_TEXT_LEN(&inspected),
+      GRN_TEXT_VALUE(&inspected));
     GRN_OBJ_FIN(ctx, &inspected);
     return NULL;
   }
@@ -512,15 +542,20 @@ func_string_tokenize(grn_ctx *ctx, int n_args, grn_obj **args,
 }
 
 static grn_obj *
-string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *user_data)
+string_regexp_slice(grn_ctx *ctx,
+                    int n_args,
+                    grn_obj **args,
+                    grn_user_data *user_data)
 {
 #ifdef GRN_SUPPORT_REGEXP
-#define string_regexp_slice_tag "[string_slice]"
+#  define string_regexp_slice_tag "[string_slice]"
 
-  grn_obj *target_raw, *pattern, *nth_or_name, *default_value = NULL, *result = NULL;
+  grn_obj *target_raw, *pattern, *nth_or_name, *default_value = NULL,
+                                               *result = NULL;
 
   if (!(n_args == 3 || n_args == 4)) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s wrong number of arguments (%d for 3...4)",
                      string_regexp_slice_tag,
                      n_args);
@@ -550,7 +585,8 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
 
       GRN_TEXT_INIT(&inspected, 0);
       grn_inspect(ctx, &inspected, default_value);
-      GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+      GRN_PLUGIN_ERROR(ctx,
+                       GRN_INVALID_ARGUMENT,
                        "%s[default_value] must be a text bulk: <%.*s>",
                        string_regexp_slice_tag,
                        (int)GRN_TEXT_LEN(&inspected),
@@ -560,12 +596,14 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
     }
   }
 
-  if (!grn_obj_is_text_family_bulk(ctx, nth_or_name) && !grn_obj_is_number_family_bulk(ctx, nth_or_name)) {
+  if (!grn_obj_is_text_family_bulk(ctx, nth_or_name) &&
+      !grn_obj_is_number_family_bulk(ctx, nth_or_name)) {
     grn_obj inspected;
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, nth_or_name);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s[nth_or_name] must be a text or number bulk: %.*s",
                      string_regexp_slice_tag,
                      (int)GRN_TEXT_LEN(&inspected),
@@ -574,7 +612,7 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
     return NULL;
   }
 
-  //TODO: should cache
+  // TODO: should cache
   OnigRegex regexp = grn_onigmo_new(ctx,
                                     GRN_TEXT_VALUE(pattern),
                                     GRN_TEXT_LEN(pattern),
@@ -592,8 +630,9 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
   OnigRegion region;
   onig_region_init(&region);
 
-  //Cannot use normalized string.
-  //The matching parts of the original string cannot be inferred from the matching parts of the normalized string.
+  // Cannot use normalized string.
+  // The matching parts of the original string cannot be inferred from the
+  // matching parts of the normalized string.
   OnigPosition position = onig_search(regexp,
                                       target,
                                       target + target_length,
@@ -609,10 +648,8 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
       const char *name = GRN_TEXT_VALUE(nth_or_name);
       size_t name_length = GRN_TEXT_LEN(nth_or_name);
 
-      nth = onig_name_to_backref_number(regexp,
-                                        name,
-                                        name + name_length,
-                                        &region);
+      nth =
+        onig_name_to_backref_number(regexp, name, name + name_length, &region);
 
     } else if (grn_obj_is_number_family_bulk(ctx, nth_or_name)) {
       nth = grn_plugin_proc_get_value_int64(ctx,
@@ -625,7 +662,8 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
       OnigPosition start = region.beg[nth];
       OnigPosition end = region.end[nth];
 
-      result = grn_plugin_proc_alloc(ctx, user_data, target_raw->header.domain, 0);
+      result =
+        grn_plugin_proc_alloc(ctx, user_data, target_raw->header.domain, 0);
       if (!result) {
         goto exit;
       }
@@ -635,7 +673,8 @@ string_regexp_slice(grn_ctx *ctx, int n_args, grn_obj **args, grn_user_data *use
 
   if (!result) {
     if (!default_value) {
-      default_value = grn_plugin_proc_alloc(ctx, user_data, target_raw->header.domain, 0);
+      default_value =
+        grn_plugin_proc_alloc(ctx, user_data, target_raw->header.domain, 0);
       if (!default_value) {
         goto exit;
       }
@@ -649,20 +688,23 @@ exit:
   onig_free(regexp);
 
   return result;
-#undef string_regexp_slice_tag
-#else //GRN_SUPPORT_REGEXP
+#  undef string_regexp_slice_tag
+#else  // GRN_SUPPORT_REGEXP
   return NULL;
-#endif //GRN_SUPPORT_REGEXP
+#endif // GRN_SUPPORT_REGEXP
 }
 
 static grn_obj *
-func_string_slice(grn_ctx *ctx, int n_args, grn_obj **args,
+func_string_slice(grn_ctx *ctx,
+                  int n_args,
+                  grn_obj **args,
                   grn_user_data *user_data)
 {
   const char *tag = "[string_slice]";
 
   if (n_args < 2 || n_args > 4) {
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s "
                      "wrong number of arguments (%d for 2..4)",
                      tag,
@@ -698,7 +740,8 @@ func_string_slice(grn_ctx *ctx, int n_args, grn_obj **args,
 
     GRN_TEXT_INIT(&inspected, 0);
     grn_inspect(ctx, &inspected, args[1]);
-    GRN_PLUGIN_ERROR(ctx, GRN_INVALID_ARGUMENT,
+    GRN_PLUGIN_ERROR(ctx,
+                     GRN_INVALID_ARGUMENT,
                      "%s "
                      "2nd argument must be a text or number bulk: %.*s",
                      tag,
@@ -721,30 +764,55 @@ GRN_PLUGIN_REGISTER(grn_ctx *ctx)
 {
   grn_rc rc = GRN_SUCCESS;
 
-  grn_proc_create(ctx, "string_length", -1,
+  grn_proc_create(ctx,
+                  "string_length",
+                  -1,
                   GRN_PROC_FUNCTION,
                   func_string_length,
-                  NULL, NULL, 0, NULL);
+                  NULL,
+                  NULL,
+                  0,
+                  NULL);
 
-  grn_proc_create(ctx, "string_substring", -1,
+  grn_proc_create(ctx,
+                  "string_substring",
+                  -1,
                   GRN_PROC_FUNCTION,
                   func_string_substring,
-                  NULL, NULL, 0, NULL);
+                  NULL,
+                  NULL,
+                  0,
+                  NULL);
 
-  grn_proc_create(ctx, "string_truncate", -1,
+  grn_proc_create(ctx,
+                  "string_truncate",
+                  -1,
                   GRN_PROC_FUNCTION,
                   func_string_truncate,
-                  NULL, NULL, 0, NULL);
+                  NULL,
+                  NULL,
+                  0,
+                  NULL);
 
-  grn_proc_create(ctx, "string_tokenize", -1,
+  grn_proc_create(ctx,
+                  "string_tokenize",
+                  -1,
                   GRN_PROC_FUNCTION,
                   func_string_tokenize,
-                  NULL, NULL, 0, NULL);
+                  NULL,
+                  NULL,
+                  0,
+                  NULL);
 
-  grn_proc_create(ctx, "string_slice", -1,
+  grn_proc_create(ctx,
+                  "string_slice",
+                  -1,
                   GRN_PROC_FUNCTION,
                   func_string_slice,
-                  NULL, NULL, 0, NULL);
+                  NULL,
+                  NULL,
+                  0,
+                  NULL);
 
   return rc;
 }


### PR DESCRIPTION
Sorted `plugins/*` in alphabetical order.