### PR TITLE
string: merge GRN_CHAR_BLANK when using multiple normalizers

### DIFF
--- a/lib/string.c
+++ b/lib/string.c
@@ -326,9 +326,10 @@ grn_string_open_(grn_ctx *ctx,
         if (previous_types) {
           /*
            * Currently, ctypes are merged only in a limited cases.
-           * Specifically, ctypes are merged only when the number of characters
-           * in the first normalized result is equal to that in the latter
-           * normalized result, and "previous_types" contains a "GRN_CHAR_BLANK".
+           * Specifically, ctypes are merged "GRN_CHAR_BLANK" only when the
+           * number of characters in the first normalized result is equal to
+           * that in the latter normalized result, and "previous_types" contains
+           * a "GRN_CHAR_BLANK".
            *
            * In other words, this works only when NormalizerTable performs
            * normalization without changing the number of characters.
@@ -345,7 +346,7 @@ grn_string_open_(grn_ctx *ctx,
             unsigned int i = 0;
             for (i = 0; i < previous_n_characters; i++) {
               if (previous_types[i] & GRN_CHAR_BLANK) {
-                string_->ctypes[i] |= previous_types[i];
+                string_->ctypes[i] |= GRN_CHAR_BLANK;
               }
             }
           }

--- a/lib/string.c
+++ b/lib/string.c
@@ -343,10 +343,11 @@ grn_string_open_(grn_ctx *ctx,
            */
           if (string_->ctypes &&
               string_->n_characters == previous_n_characters) {
-            unsigned int i = 0;
-            for (i = 0; i < previous_n_characters; i++) {
-              if (previous_types[i] & GRN_CHAR_BLANK) {
-                string_->ctypes[i] |= GRN_CHAR_BLANK;
+            unsigned int character_i = 0;
+            for (character_i = 0; character_i < previous_n_characters;
+                 character_i++) {
+              if (previous_types[character_i] & GRN_CHAR_BLANK) {
+                string_->ctypes[character_i] |= GRN_CHAR_BLANK;
               }
             }
           }

--- a/lib/string.c
+++ b/lib/string.c
@@ -279,6 +279,7 @@ grn_string_open_(grn_ctx *ctx,
     int16_t *previous_checks = NULL;
     uint8_t *previous_types = NULL;
     uint64_t *previous_offsets = NULL;
+    unsigned int previous_n_characters = 0;
     size_t i;
     for (i = 0; i < n; i++) {
       grn_obj *normalizer = GRN_PTR_VALUE_AT(&normalizers, i);
@@ -287,6 +288,7 @@ grn_string_open_(grn_ctx *ctx,
         previous_normalized = string_->normalized;
         previous_normalized_length_in_bytes =
           string_->normalized_length_in_bytes;
+        previous_n_characters = string_->n_characters;
         previous_checks = string_->checks;
         previous_types = string_->ctypes;
         previous_offsets = string_->offsets;
@@ -322,6 +324,29 @@ grn_string_open_(grn_ctx *ctx,
           GRN_FREE(previous_checks);
         }
         if (previous_types) {
+          /*
+           * Currently, ctypes are merged only in a limited case.
+           * Specifically, ctypes are merged only when the number of characters
+           * in the first normalized result is equal to the number of characters
+           * in the latter normalized result.
+           *
+           * In other words, this works only when NormalizerTable performs
+           * normalization without changing the number of characters.
+           *
+           * The latter normalizer is NormalizerTable, and users can define any
+           * normalization pattern in NormalizerTable.
+           *
+           * It is difficult to handle all such cases with single
+           * implementation here.
+           * Therefore, we currently support only the simple case.
+           */
+          if (string_->ctypes &&
+              string_->n_characters == previous_n_characters) {
+            unsigned int i = 0;
+            for (i = 0; i < previous_n_characters; i++) {
+              string_->ctypes[i] |= previous_types[i];
+            }
+          }
           GRN_FREE(previous_types);
         }
         if (previous_offsets) {

--- a/lib/string.c
+++ b/lib/string.c
@@ -325,10 +325,10 @@ grn_string_open_(grn_ctx *ctx,
         }
         if (previous_types) {
           /*
-           * Currently, ctypes are merged only in a limited case.
+           * Currently, ctypes are merged only in a limited cases.
            * Specifically, ctypes are merged only when the number of characters
-           * in the first normalized result is equal to the number of characters
-           * in the latter normalized result.
+           * in the first normalized result is equal to that in the latter
+           * normalized result, and "previous_types" contains a "GRN_CHAR_BLANK".
            *
            * In other words, this works only when NormalizerTable performs
            * normalization without changing the number of characters.
@@ -344,7 +344,9 @@ grn_string_open_(grn_ctx *ctx,
               string_->n_characters == previous_n_characters) {
             unsigned int i = 0;
             for (i = 0; i < previous_n_characters; i++) {
-              string_->ctypes[i] |= previous_types[i];
+              if (previous_types[i] & GRN_CHAR_BLANK) {
+                string_->ctypes[i] |= previous_types[i];
+              }
             }
           }
           GRN_FREE(previous_types);

--- a/lib/string.c
+++ b/lib/string.c
@@ -325,11 +325,11 @@ grn_string_open_(grn_ctx *ctx,
         }
         if (previous_types) {
           /*
-           * Currently, ctypes are merged only in a limited cases.
-           * Specifically, ctypes are merged "GRN_CHAR_BLANK" only when the
+           * Currently, ctypes are merged only in limited cases.
+           * Specifically, we merge only GRN_CHAR_BLANK when the
            * number of characters in the first normalized result is equal to
-           * that in the latter normalized result, and "previous_types" contains
-           * a "GRN_CHAR_BLANK".
+           * that in the latter normalized result, and previous_types has
+           * GRN_CHAR_BLANK set.
            *
            * In other words, this works only when NormalizerTable performs
            * normalization without changing the number of characters.
@@ -337,9 +337,9 @@ grn_string_open_(grn_ctx *ctx,
            * The latter normalizer is NormalizerTable, and users can define any
            * normalization pattern in NormalizerTable.
            *
-           * It is difficult to handle all such cases with single
+           * It is difficult to handle all such cases with a single
            * implementation here.
-           * Therefore, we currently support only the simple case.
+           * Therefore, we currently support only this simple case.
            */
           if (string_->ctypes &&
               string_->n_characters == previous_n_characters) {

--- a/test/command/suite/normalizers/multiple/types.expected
+++ b/test/command/suite/normalizers/multiple/types.expected
@@ -1,13 +1,13 @@
-table_create Nomalizations TABLE_PAT_KEY ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
-column_create Nomalizations normalized COLUMN_SCALAR ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Normalizations
 [
 {"_key": "aBcDe", "normalized": "12345"}
 ]
 [[0,0.0,0.0],1]
-normalize   --string "aBcDe fgH"   --flags WITH_TYPES   --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Nomalizations.normalized")'
+normalize   --string "aBcDe fgH"   --flags WITH_TYPES   --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Normalizations.normalized")'
 [
   [
     0,

--- a/test/command/suite/normalizers/multiple/types.expected
+++ b/test/command/suite/normalizers/multiple/types.expected
@@ -4,10 +4,10 @@ column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Normalizations
 [
-{"_key": "aBcDe", "normalized": "12345"}
+{"_key": "abcde", "normalized": "12345"}
 ]
 [[0,0.0,0.0],1]
-normalize   --string "aBcDe fgH"   --flags WITH_TYPES   --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Normalizations.normalized")'
+normalize   --string "aBcDe fgH"   --flags WITH_TYPES|WITH_CHECKS|REMOVE_BLANK   --normalizers 'NormalizerNFKC, NormalizerTable("normalized", "Normalizations.normalized")'
 [
   [
     0,
@@ -24,8 +24,18 @@ normalize   --string "aBcDe fgH"   --flags WITH_TYPES   --normalizers 'Normalize
       "digit|blank",
       "alpha",
       "alpha",
-      "alpha"
+      "alpha",
       "null"
+    ],
+    "checks": [
+      1,
+      1,
+      1,
+      1,
+      1,
+      2,
+      1,
+      1
     ]
   }
 ]

--- a/test/command/suite/normalizers/multiple/types.expected
+++ b/test/command/suite/normalizers/multiple/types.expected
@@ -1,0 +1,31 @@
+table_create Nomalizations TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Nomalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"_key": "aBcDe", "normalized": "12345"}
+]
+[[0,0.0,0.0],1]
+normalize   --string "aBcDe fgH"   --flags WITH_TYPES   --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Nomalizations.normalized")'
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "normalized": "12345fgh",
+    "types": [
+      "digit",
+      "digit",
+      "digit",
+      "digit",
+      "digit|blank",
+      "alpha",
+      "alpha",
+      "alpha"
+      "null"
+    ]
+  }
+]

--- a/test/command/suite/normalizers/multiple/types.test
+++ b/test/command/suite/normalizers/multiple/types.test
@@ -1,0 +1,11 @@
+table_create Nomalizations TABLE_PAT_KEY ShortText
+column_create Nomalizations normalized COLUMN_SCALAR ShortText
+load --table Normalizations
+[
+{"_key": "aBcDe", "normalized": "12345"}
+]
+
+normalize \
+  --string "aBcDe fgH" \
+  --flags WITH_TYPES \
+  --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Nomalizations.normalized")'

--- a/test/command/suite/normalizers/multiple/types.test
+++ b/test/command/suite/normalizers/multiple/types.test
@@ -2,10 +2,10 @@ table_create Normalizations TABLE_PAT_KEY ShortText
 column_create Normalizations normalized COLUMN_SCALAR ShortText
 load --table Normalizations
 [
-{"_key": "aBcDe", "normalized": "12345"}
+{"_key": "abcde", "normalized": "12345"}
 ]
 
 normalize \
   --string "aBcDe fgH" \
-  --flags WITH_TYPES \
-  --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Normalizations.normalized")'
+  --flags WITH_TYPES|WITH_CHECKS|REMOVE_BLANK \
+  --normalizers 'NormalizerNFKC, NormalizerTable("normalized", "Normalizations.normalized")'

--- a/test/command/suite/normalizers/multiple/types.test
+++ b/test/command/suite/normalizers/multiple/types.test
@@ -1,5 +1,5 @@
-table_create Nomalizations TABLE_PAT_KEY ShortText
-column_create Nomalizations normalized COLUMN_SCALAR ShortText
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
 load --table Normalizations
 [
 {"_key": "aBcDe", "normalized": "12345"}
@@ -8,4 +8,4 @@ load --table Normalizations
 normalize \
   --string "aBcDe fgH" \
   --flags WITH_TYPES \
-  --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Nomalizations.normalized")'
+  --normalizers 'NormalizerNFKC150, NormalizerTable("normalized", "Normalizations.normalized")'

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.expected
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.expected
@@ -2,6 +2,11 @@ table_create Normalizations TABLE_PAT_KEY ShortText
 [[0,0.0,0.0],true]
 column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+load --table Normalizations
+[
+{"_key": "aBcDe", "normalized": "12345"}
+]
+[[0,0.0,0.0],1]
 table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer 'NormalizerAuto, NormalizerTable("normalized", "Normalizations.normalized")'
 [[0,0.0,0.0],true]
 table_tokenize Terms "aBcDe fgH" --mode ADD
@@ -13,7 +18,7 @@ table_tokenize Terms "aBcDe fgH" --mode ADD
   ],
   [
     {
-      "value": "abcde",
+      "value": "12345",
       "position": 0,
       "force_prefix": false,
       "force_prefix_search": false

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.expected
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.expected
@@ -1,0 +1,28 @@
+table_create Normalizations TABLE_PAT_KEY ShortText
+[[0,0.0,0.0],true]
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer 'NormalizerAuto, NormalizerTable("normalized", "Normalizations.normalized")'
+[[0,0.0,0.0],true]
+table_tokenize Terms "aBcDe fgH" --mode ADD
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    {
+      "value": "abcde",
+      "position": 0,
+      "force_prefix": false,
+      "force_prefix_search": false
+    },
+    {
+      "value": "fgh",
+      "position": 1,
+      "force_prefix": false,
+      "force_prefix_search": false
+    }
+  ]
+]

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.expected
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.expected
@@ -4,10 +4,10 @@ column_create Normalizations normalized COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Normalizations
 [
-{"_key": "aBcDe", "normalized": "12345"}
+{"_key": "abcde", "normalized": "12345"}
 ]
 [[0,0.0,0.0],1]
-table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer 'NormalizerAuto, NormalizerTable("normalized", "Normalizations.normalized")'
+table_create Terms TABLE_PAT_KEY ShortText   --default_tokenizer TokenBigram   --normalizer 'NormalizerNFKC, NormalizerTable("normalized", "Normalizations.normalized")'
 [[0,0.0,0.0],true]
 table_tokenize Terms "aBcDe fgH" --mode ADD
 [

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.test
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.test
@@ -1,5 +1,9 @@
 table_create Normalizations TABLE_PAT_KEY ShortText
 column_create Normalizations normalized COLUMN_SCALAR ShortText
+load --table Normalizations
+[
+{"_key": "aBcDe", "normalized": "12345"}
+]
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.test
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.test
@@ -2,11 +2,11 @@ table_create Normalizations TABLE_PAT_KEY ShortText
 column_create Normalizations normalized COLUMN_SCALAR ShortText
 load --table Normalizations
 [
-{"_key": "aBcDe", "normalized": "12345"}
+{"_key": "abcde", "normalized": "12345"}
 ]
 
 table_create Terms TABLE_PAT_KEY ShortText \
   --default_tokenizer TokenBigram \
-  --normalizer 'NormalizerAuto, NormalizerTable("normalized", "Normalizations.normalized")'
+  --normalizer 'NormalizerNFKC, NormalizerTable("normalized", "Normalizations.normalized")'
 
 table_tokenize Terms "aBcDe fgH" --mode ADD

--- a/test/command/suite/table_tokenize/with_multiple_normalizer.test
+++ b/test/command/suite/table_tokenize/with_multiple_normalizer.test
@@ -1,0 +1,8 @@
+table_create Normalizations TABLE_PAT_KEY ShortText
+column_create Normalizations normalized COLUMN_SCALAR ShortText
+
+table_create Terms TABLE_PAT_KEY ShortText \
+  --default_tokenizer TokenBigram \
+  --normalizer 'NormalizerAuto, NormalizerTable("normalized", "Normalizations.normalized")'
+
+table_tokenize Terms "aBcDe fgH" --mode ADD


### PR DESCRIPTION
Fix: GH-2853

This is a limited fix.

Currently, ctypes are merged only in limited cases.
Specifically, we merge only GRN_CHAR_BLANK when the number of characters in the first normalized result is equal to that in the latter normalized result, and previous_types has GRN_CHAR_BLANK set.

In other words, this works only when NormalizerTable performs normalization without changing the number of characters.
The latter normalizer is NormalizerTable, and users can define any normalization pattern in NormalizerTable.

It is difficult to handle all such cases with a single implementation here.
Therefore, we currently support only this simple case.

Reported by askdkc. Tanks!!!