### PR TITLE
ci: add "-Wno-error=unused-variable"

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -142,6 +142,7 @@ jobs:
             -S apache-arrow/cpp \
             --preset ninja-debug-minimal \
             -DARROW_COMPUTE=ON \
+            -DMAKE_CXX_FLAGS="-Wno-error=unused-variable"
             -DCMAKE_INSTALL_PREFIX=$PWD/install
       - name: Build Apache Arrow
         if: matrix.apache-arrow-main == 'yes'


### PR DESCRIPTION
Currently, Apache Arrow is built by debug mode to display backtrace when occering error. However, -Werror is specified as g++ flag when using debug mode. As a result, unused-variable is handled as error.