### PR TITLE
ci release: split Launchpad upload into per code name jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Keep in sync with packages/launchpad-helper.rb:ubuntu_targets_default
         code-name:
           - jammy
           - noble

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,19 @@ jobs:
             release-artifacts/*/*
   launchpad:
     name: Launchpad
+    if: |
+      github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs: publish
     environment: release
     timeout-minutes: 10
-    if: |
-      github.ref_type == 'tag'
+    strategy:
+      fail-fast: false
+      matrix:
+        code-name:
+          - jammy
+          - noble
+          - resolute
     steps:
       - uses: actions/checkout@v7
       - name: Download source archive
@@ -147,7 +154,7 @@ jobs:
         run: |
           echo "${LAUNCHPAD_DEPLOY_KEY}" | gpg --import
           echo "trusted-key ${LAUNCHPAD_UPLOADER_PGP_KEY}" > ~/.gnupg/gpg.conf
-          rake -C packages ubuntu
+          rake -C packages ubuntu:upload:${{ matrix.code-name }}
   x:
     name: X
     runs-on: ubuntu-latest


### PR DESCRIPTION
We split the job based on the following workflow:
https://github.com/enactic/openarm_can/blob/a30364622ca939b8c8a741167c317b3e95e38a49/.github/workflows/package.yaml#L258-L306

Launchpad is unstable and uploads often fail.
Split it up so it can be rerun for each code name.