### PR TITLE
ii: fix crash when allocation a new segment fails

### DIFF
--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -7154,7 +7154,7 @@ grn_ii_update_one_internal(
                "<%.*s>(%u): "
                "(%u:%u): "
                "segment:<%u>, "
-               "free:<%u>, "
+               "max-segment:<%u>, "
                "required:<%u>",
                tag,
                name_size,
@@ -7165,7 +7165,7 @@ grn_ii_update_one_internal(
                u->rid,
                u->sid,
                pos,
-               b->header.buffer_free,
+               ii->seg->header->max_segment,
                size);
           GRN_OBJ_FIN(ctx, &term);
           goto exit;

--- a/lib/ii.cpp
+++ b/lib/ii.cpp
@@ -7278,7 +7278,7 @@ grn_ii_update_one_internal(
                    "(%u:%u): "
                    "segment:<%u>, "
                    "new-segment:<%u>, "
-                   "free:<%u>, "
+                   "max-segment:<%u>, "
                    "required:<%u>",
                    tag,
                    name_size,
@@ -7290,7 +7290,7 @@ grn_ii_update_one_internal(
                    u->sid,
                    pos,
                    a[0],
-                   b->header.buffer_free,
+                   ii->seg->header->max_segment,
                    size);
               GRN_OBJ_FIN(ctx, &term);
             }


### PR DESCRIPTION
The error message refers to "b->header.buffer_free". 
However, "b" is uninitialized when the error message is generated.

Therefore, we use maximum segment size instead of "b" in error message.

For other error messages that use "b->header.buffer_free", "b" is guaranteed to exist, so there is no issue there.