### PR TITLE
packages yum: add a missing dependecy package

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -81,6 +81,7 @@ if [ "${run_test}" = "yes" ]; then
 
   ${DNF} install -y \
     gcc \
+    libffi-devel \
     make
   if [ ${os} != "amazon-linux" ]; then
     ${DNF} install -y redhat-rpm-config


### PR DESCRIPTION
fiddle-1.1.8 require "ffi.h" when building gem.
fiddle is used by grntest.