### PR TITLE
ci msys2: aligned the dependency definitions with MINGW-packages/mingw-w64-groonga/PKGBUILD

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -680,6 +680,10 @@ jobs:
       - name: "Test: stdio"
         shell: msys2 {0}
         run: |
+          # Temporarily disabled because MeCab is no longer installed as a dependency.
+          # Normally, we would install MeCab separately and run the tests,
+          # but since naist-jdic is not available, the tests would fail even if MeCab were installed.
+          # See: https://github.com/msys2/MINGW-packages/pull/30998
           rm -rf test/command/suite/select/filter/near_phrase/mecab.test \
                  test/command/suite/select/filter/ordered_near_phrase/mecab.test \
                  test/command/suite/select/fuzzy/tokenize.test \

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -680,6 +680,20 @@ jobs:
       - name: "Test: stdio"
         shell: msys2 {0}
         run: |
+          rm -rf test/command/suite/select/filter/near_phrase/mecab.test \
+                 test/command/suite/select/filter/ordered_near_phrase/mecab.test \
+                 test/command/suite/select/fuzzy/tokenize.test \
+                 test/command/suite/select/fuzzy/tokenize_default.test \
+                 test/command/suite/select/output_columns/star/function_call.test \
+                 test/command/suite/select/query/match/with_index/token_mecab/ \
+                 test/command/suite/table_create/default_tokenizer/mecab/ \
+                 test/command/suite/token_filters/nfkc100/unify_kana.test \
+                 test/command/suite/token_filters/nfkc121/unify_kana.test \
+                 test/command/suite/token_filters/nfkc130/unify_kana.test \
+                 test/command/suite/token_filters/nfkc150/unify_kana.test \
+                 test/command/suite/tokenize/output_style/full.test \
+                 test/command/suite/tokenize/output_style/simple.test \
+                 test/command/suite/tokenizers/mecab/
           ruby \
             -r./setup-extpp \
             -S \

--- a/ci/msys2/PKGBUILD
+++ b/ci/msys2/PKGBUILD
@@ -15,11 +15,13 @@ source=(${_realname}-${pkgver}.tar.gz
         001-aarch64.patch)
 depends=("${MINGW_PACKAGE_PREFIX}-arrow"
          "${MINGW_PACKAGE_PREFIX}-blosc2"
+         "${MINGW_PACKAGE_PREFIX}-cc-libs"
+         "${MINGW_PACKAGE_PREFIX}-llama.cpp"
          "${MINGW_PACKAGE_PREFIX}-lz4"
          "${MINGW_PACKAGE_PREFIX}-mecab"
-         "${MINGW_PACKAGE_PREFIX}-mecab-naist-jdic"
          "${MINGW_PACKAGE_PREFIX}-msgpack-c"
-         "${MINGW_PACKAGE_PREFIX}-onigmo"
+         "${MINGW_PACKAGE_PREFIX}-simdjson"
+#         "${MINGW_PACKAGE_PREFIX}-onigmo"
          "${MINGW_PACKAGE_PREFIX}-xxhash"
          "${MINGW_PACKAGE_PREFIX}-zlib"
          "${MINGW_PACKAGE_PREFIX}-zstd")
@@ -27,9 +29,14 @@ makedepends=("git"
              "${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-cmake"
              "${MINGW_PACKAGE_PREFIX}-ninja"
+             "${MINGW_PACKAGE_PREFIX}-mecab"
+             "${MINGW_PACKAGE_PREFIX}-omp"
+             "${MINGW_PACKAGE_PREFIX}-openblas"
              "${MINGW_PACKAGE_PREFIX}-rapidjson"
              "${MINGW_PACKAGE_PREFIX}-ruby"
-             "${MINGW_PACKAGE_PREFIX}-xsimd")
+             "${MINGW_PACKAGE_PREFIX}-xsimd"
+             "${MINGW_PACKAGE_PREFIX}-git")
+optdepends=("${MINGW_PACKAGE_PREFIX}-mecab")
 sha256sums=('SKIP'
             'SKIP')
 validpgpkeys=('2701F317CFCCCB975CADE9C2624CF77434839225') # Groonga Key <packages@groonga.org>


### PR DESCRIPTION
mecab-naist-jdic is removed at https://github.com/msys2/MINGW-packages/pull/30998.
Also, mecab is optdepends in https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-groonga/PKGBUILD.