### PR TITLE
ci msys2: build mecab-naist-jdic by ourselves

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.data binary
+ci/msys2/** text eol=lf

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -600,6 +600,19 @@ jobs:
           cd ci/msys2
           sed -i'' -e 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf
           MINGW-packages/.ci/fetch-validpgpkeys.sh
+          # mingw-w64-mecab-naist-jdic was dropped from MSYS2 by
+          # https://github.com/msys2/MINGW-packages/pull/30998 but
+          # mingw-w64-mecab still uses naist-jdic as its default dictionary.
+          # So we build and install it by ourselves.
+          (cd mecab-naist-jdic && \
+             MINGW_ARCH=${{ matrix.msystem }} \
+               makepkg-mingw \
+                 --cleanbuild \
+                 --install \
+                 --nocheck \
+                 --noconfirm \
+                 --noprogressbar \
+                 --syncdeps)
       - name: Prepare ccache
         shell: msys2 {0}
         run: |
@@ -638,7 +651,7 @@ jobs:
             --noprogressbar \
             --upgrade \
             *.pkg.tar.*
-          cp -a *.pkg.tar.* ../../
+          cp -a *.pkg.tar.* mecab-naist-jdic/*.pkg.tar.* ../../
 
       # Artifact
       - uses: actions/upload-artifact@v7

--- a/ci/msys2/mecab-naist-jdic/01-prefix.patch
+++ b/ci/msys2/mecab-naist-jdic/01-prefix.patch
@@ -1,0 +1,16 @@
+--- mecab-naist-jdic-0.6.3b-20111013/Makefile.am.orig	2019-11-08 14:29:32.477853500 +0300
++++ mecab-naist-jdic-0.6.3b-20111013/Makefile.am	2019-11-08 14:30:38.950570300 +0300
+@@ -17,9 +17,9 @@
+ 	./upload.pl -p mecab -n @PACKAGE@ -r @VERSION@ -f @PACKAGE@-@VERSION@.tar.gz
+ 
+ install-exec-hook:
+-	if ! [ -d $(DESTDIR)/etc/mecab/dic/naist-jdic ]; \
+-		then mkdir -p $(DESTDIR)/etc/mecab/dic/naist-jdic; \
++	if ! [ -d $(DESTDIR)$(sysconfdir)/mecab/dic/naist-jdic ]; \
++		then mkdir -p $(DESTDIR)$(sysconfdir)/mecab/dic/naist-jdic; \
+ 	fi
+-	if ! [ -f $(DESTDIR)/etc/mecab/dic/naist-jdic/dicrc ]; \
+-		then $(LN_S) @MECAB_DICDIR@/dicrc $(DESTDIR)/etc/mecab/dic/naist-jdic/dicrc; \
++	if ! [ -f $(DESTDIR)$(sysconfdir)/mecab/dic/naist-jdic/dicrc ]; \
++		then $(LN_S) $(DESTDIR)@MECAB_DICDIR@/dicrc $(DESTDIR)$(sysconfdir)/mecab/dic/naist-jdic/dicrc; \
+ 	fi

--- a/ci/msys2/mecab-naist-jdic/PKGBUILD
+++ b/ci/msys2/mecab-naist-jdic/PKGBUILD
@@ -1,0 +1,55 @@
+# Maintainer: Kentaro Hayashi <hayashi@clear-code.com>
+_realname=mecab-naist-jdic
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.6.3b_20111013
+pkgrel=2
+pkgdesc="NAIST Japanese Dictionary (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://osdn.net/projects/naist-jdic/"
+license=('spdx:BSD-3-Clause-Clear')
+
+# Use https://packages.groonga.org/
+source=("https://packages.groonga.org/source/${_realname}/${_realname}-${pkgver//_/-}.tar.gz"
+        01-prefix.patch)
+
+depends=("${MINGW_PACKAGE_PREFIX}-mecab")
+makedepends=("${MINGW_PACKAGE_PREFIX}-autotools")
+sha256sums=('cb37700dc9a77b953f2bf3b15b49cfecd67848530a2cf8abcb09b594ca5628cc'
+            '997894bac71673d85d43efc88b994e7cc7983ed00fc8398d70bca01134229e77')
+
+prepare() {
+  cd "${_realname}-${pkgver//_/-}"
+  patch -p1 -i "${srcdir}"/01-prefix.patch
+
+  autoreconf -fiv
+}
+
+build() {
+  cd "${_realname}-${pkgver//_/-}"
+
+  ./configure \
+    --prefix=${MINGW_PREFIX} \
+    --sysconfdir=${MINGW_PREFIX}/etc \
+    --build=${MINGW_CHOST} \
+    --host=${MINGW_CHOST} \
+    --target=${MINGW_CHOST} \
+    --with-mecab-config=${MINGW_PREFIX}/bin/mecab-config \
+    --with-dicdir=${MINGW_PREFIX}/lib/mecab/dic/naist-jdic \
+    --with-charset=utf-8
+
+  make
+}
+
+package() {
+  cd "${_realname}-${pkgver//_/-}"
+
+  # First make install fails, retry again.
+  make DESTDIR="${pkgdir}" install || true
+  make DESTDIR="${pkgdir}" install
+
+  for license in AUTHORS COPYING; do
+    install -Dm644 "${srcdir}"/${_realname}-${pkgver//_/-}/${license} "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/${license}"
+  done
+}


### PR DESCRIPTION
MSYS2 dropped mingw-w64-mecab-naist-jdic:

https://github.com/msys2/MINGW-packages/pull/30998

So we build it by ourselves.
Note that mingw-w64-mecab still uses naist-jdic as its default dicdir.