### PR TITLE
maintenance 14.0.6: doc: pin the versions of Sphinx and its related packages

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -13,8 +13,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-Jinja2
-Sphinx
-myst-parser[linkify]
-pydata_sphinx_theme
-sphinx-markdown-builder
+Jinja2==3.1.4
+Sphinx==7.4.7
+myst-parser[linkify]==3.0.1
+pydata_sphinx_theme==0.15.4
+sphinx-markdown-builder==0.6.6


### PR DESCRIPTION
Using the latest versions would require changes to support those versions,
so we will use the versions available at 14.0.6 to avoid errors when building the documentation.