### PR TITLE
maintenance 14.0.6: ci: pin the version of Apache Arrow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -116,7 +116,7 @@ jobs:
             cmake \
             gdb \
             gettext \
-            libarrow-dev \
+            libarrow-dev=16.1.0-1 \
             libevent-dev \
             libluajit-5.1-dev \
             liblz4-dev \

--- a/packages/yum/almalinux-8/Dockerfile
+++ b/packages/yum/almalinux-8/Dockerfile
@@ -10,11 +10,13 @@ RUN \
   dnf install -y ${quiet} \
     epel-release \
     'dnf-command(config-manager)' \
+    https://packages.apache.org/artifactory/arrow/almalinux/8/apache-arrow-release-latest.rpm \
     https://packages.groonga.org/almalinux/8/groonga-release-latest.noarch.rpm && \
   dnf config-manager --set-enabled powertools && \
   dnf groupinstall -y ${quiet} "Development Tools" && \
   dnf install -y ${quiet} \
-    arrow-devel-${APACHE_ARROW_VERSION} \
+    arrow-devel-16.1.0-1.el8.x86_64 \
+    arrow16-libs-16.1.0-1.el8.x86_64 \
     ccache \
     cmake \
     gcc-c++ \

--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -29,6 +29,11 @@ case ${os} in
         ;;
       8)
         DNF="dnf --enablerepo=powertools"
+        ${DNF} install -y \
+          https://packages.apache.org/artifactory/arrow/${os}/${version}/apache-arrow-release-latest.rpm
+        ${DNF} install -y \
+          arrow-devel-16.1.0-1.el8.x86_64 \
+          arrow16-libs-16.1.0-1.el8.x86_64
         ;;
       *)
         DNF="dnf --enablerepo=crb"


### PR DESCRIPTION
Normally, both arrow-devel and arrow-libs are installed automatically as dependency of Groonga.
However, when installed this way, the latest version is also installed even if we pin Groonga to 14.0.6.

We want to restrict their versions to 16.1.0 to ensure compatibility.
We can install them at version 16.1.0 by pinning them to 16.1.0 when the packages are installed.