### PR TITLE
maintenance 14.0.6: packages yum: pin the version of grntest and its related gems

### DIFF
--- a/packages/yum/test.sh
+++ b/packages/yum/test.sh
@@ -91,7 +91,15 @@ if [ "${run_test}" = "yes" ]; then
     gcc \
     make \
     redhat-rpm-config
-  MAKEFLAGS=-j$(nproc) gem install grntest
+
+  cat > Gemfile <<'EOF'
+source "https://rubygems.org"
+
+gem "json", "2.7.2"
+gem "groonga-command-parser", "1.1.4"
+gem "grntest", "1.7.5"
+EOF
+  MAKEFLAGS=-j$(nproc) bundle install
 
   export TZ=Asia/Tokyo
 


### PR DESCRIPTION
Using json 2.8.0 or later changes how empty arrays are output, causing many tests to fail.
We do not need to fix these failures, and we also want to use the same environment as the 14.0.6 release.
Therefore, we will pin these package versions.

json is installed as a dependency of groonga-command-parser, and groonga-command-parser is installed as adependency of grntest.
Therefore, we will pin the versions of these gems.