### PR TITLE
ii: fix crash when allocation a new segment fails (#2879)

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -7143,7 +7143,7 @@ grn_ii_update_one_internal(
                "<%.*s>(%u): "
                "(%u:%u): "
                "segment:<%u>, "
-               "free:<%u>, "
+               "max-segment:<%u>, "
                "required:<%u>",
                tag,
                name_size,
@@ -7154,7 +7154,7 @@ grn_ii_update_one_internal(
                u->rid,
                u->sid,
                pos,
-               b->header.buffer_free,
+               ii->seg->header->max_segment,
                size);
           GRN_OBJ_FIN(ctx, &term);
           goto exit;
@@ -7267,7 +7267,7 @@ grn_ii_update_one_internal(
                    "(%u:%u): "
                    "segment:<%u>, "
                    "new-segment:<%u>, "
-                   "free:<%u>, "
+                   "max-segment:<%u>, "
                    "required:<%u>",
                    tag,
                    name_size,
@@ -7279,7 +7279,7 @@ grn_ii_update_one_internal(
                    u->sid,
                    pos,
                    a[0],
-                   b->header.buffer_free,
+                   ii->seg->header->max_segment,
                    size);
               GRN_OBJ_FIN(ctx, &term);
             }


### PR DESCRIPTION
The error message refers to "b->header.buffer_free".
However, "b" is uninitialized when the error message is generated.

Therefore, we use maximum segment size instead of "b" in error message.

This commit cherry-picks 615c8a8 into the maintenance/14.0.6 branch.