### PR TITLE
task-executor: add missing `futures_.clear()` in `wait_all()`

### DIFF
--- a/lib/grn_task_executor.hpp
+++ b/lib/grn_task_executor.hpp
@@ -152,6 +152,10 @@ namespace grn {
 #ifdef GRN_WITH_APACHE_ARROW
       if (is_parallel()) {
         thread_pool_->WaitForIdle();
+        {
+          std::unique_lock<std::mutex> lock(futures_mutex_);
+          futures_.clear();
+        }
         return ctx_->rc == GRN_SUCCESS;
       }
 #endif


### PR DESCRIPTION
We can clear all `futures_` after we wait for all tasks.