### PR TITLE
sharding: extract Groonga::Sharding::ShardSelector from logical_select

### DIFF
--- a/plugins/sharding.rb
+++ b/plugins/sharding.rb
@@ -1,5 +1,6 @@
 require "sharding/parameters"
 require "sharding/range_expression_builder"
+require "sharding/shard_selector"
 require "sharding/logical_enumerator"
 require "sharding/keys_parsable"
 require "sharding/window"

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -866,12 +866,12 @@ module Groonga
         private
         # Expressions created by the selector are kept in the context
         # to be closed even when the selector raises.
-        def select_shard(shard_key, options={})
+        def select_shard(shard_key, **options)
           selector = ShardSelector.new(@target_table,
                                        shard_key,
                                        @target_range,
                                        @cover_type,
-                                       options)
+                                       **options)
           begin
             selector.select
           ensure

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -832,11 +832,7 @@ module Groonga
               if @cover_type == :all
                 @target_table = @target_table.select_all
               else
-                expression_builder = RangeExpressionBuilder.new(shard_key,
-                                                                @target_range)
-                expression = create_expression(@target_table)
-                expression_builder.build(expression, @shard_range)
-                @target_table = @target_table.select(expression)
+                @target_table, _condition = select_shard(shard_key)
                 @cover_type = :all
               end
               @temporary_tables << @target_table
@@ -846,24 +842,14 @@ module Groonga
         end
 
         def execute
-          create_expression_builder(@shard.key) do |expression_builder|
-            case @cover_type
-            when :all
-              filter_shard_all(expression_builder)
-            when :partial_min
-              filter_table do |expression|
-                expression_builder.build_partial_min(expression)
-              end
-            when :partial_max
-              filter_table do |expression|
-                expression_builder.build_partial_max(expression)
-              end
-            when :partial_min_and_max
-              filter_table do |expression|
-                expression_builder.build_partial_min_and_max(expression)
-              end
-            end
+          result_set, condition = select_shard(@shard.key,
+                                               match_columns: @match_columns,
+                                               query: @query,
+                                               filter: @filter)
+          if condition.nil?
+            @temporary_tables.delete(@target_table)
           end
+          add_result(result_set, condition)
         end
 
         def execute_post(result_set, condition)
@@ -878,14 +864,18 @@ module Groonga
         end
 
         private
-        def filter_shard_all(expression_builder)
-          if @query.nil? and @filter.nil?
-            @temporary_tables.delete(@target_table)
-            add_result(@target_table, nil)
-          else
-            filter_table do |expression|
-              expression_builder.build_all(expression)
-            end
+        # Expressions created by the selector are kept in the context
+        # to be closed even when the selector raises.
+        def select_shard(shard_key, options={})
+          selector = ShardSelector.new(@target_table,
+                                       shard_key,
+                                       @target_range,
+                                       @cover_type,
+                                       options)
+          begin
+            selector.select
+          ensure
+            @context.expressions.concat(selector.expressions)
           end
         end
 
@@ -893,27 +883,6 @@ module Groonga
           expression = Expression.create(table)
           @context.expressions << expression
           expression
-        end
-
-        def create_expression_builder(shard_key)
-          expression_builder = RangeExpressionBuilder.new(shard_key,
-                                                          @target_range)
-          expression_builder.match_columns = @match_columns
-          expression_builder.query = @query
-          expression_builder.filter = @filter
-          begin
-            yield(expression_builder)
-          ensure
-            expression = expression_builder.match_columns_expression
-            @context.expressions << expression if expression
-          end
-        end
-
-        def filter_table
-          table = @target_table
-          expression = create_expression(table)
-          yield(expression)
-          add_result(table.select(expression), expression)
         end
 
         def apply_post_filter(table)

--- a/plugins/sharding/shard_selector.rb
+++ b/plugins/sharding/shard_selector.rb
@@ -20,14 +20,15 @@ module Groonga
       # @param cover_type [Symbol] How the target range covers the
       #   shard: `:all`, `:partial_min`, `:partial_max` or
       #   `:partial_min_and_max`.
-      def initialize(table, shard_key, target_range, cover_type, options={})
+      def initialize(table, shard_key, target_range, cover_type,
+                     match_columns: nil, query: nil, filter: nil)
         @table = table
         @shard_key = shard_key
         @target_range = target_range
         @cover_type = cover_type
-        @match_columns = options[:match_columns]
-        @query = options[:query]
-        @filter = options[:filter]
+        @match_columns = match_columns
+        @query = query
+        @filter = filter
         @expressions = []
       end
 

--- a/plugins/sharding/shard_selector.rb
+++ b/plugins/sharding/shard_selector.rb
@@ -1,0 +1,86 @@
+module Groonga
+  module Sharding
+    # Selects records in a shard by the target range and the given
+    # condition.
+    #
+    # This depends only on the given values. It doesn't depend on a
+    # command execution context. So this can be used in a child
+    # context.
+    class ShardSelector
+      # Expressions created by #select. The caller must close them
+      # after the result set is no longer used.
+      attr_reader :expressions
+
+      # @param table [Groonga::Table] The target table. It may be a
+      #   shard table or a temporary table that has records of a
+      #   shard table.
+      # @param shard_key [Groonga::Column] The shard key column.
+      # @param target_range An object that has `min`, `min_border`,
+      #   `max` and `max_border`.
+      # @param cover_type [Symbol] How the target range covers the
+      #   shard: `:all`, `:partial_min`, `:partial_max` or
+      #   `:partial_min_and_max`.
+      def initialize(table, shard_key, target_range, cover_type, options={})
+        @table = table
+        @shard_key = shard_key
+        @target_range = target_range
+        @cover_type = cover_type
+        @match_columns = options[:match_columns]
+        @query = options[:query]
+        @filter = options[:filter]
+        @expressions = []
+      end
+
+      # @return [[Groonga::Table, Groonga::Expression]] The result set
+      #   and the condition. The result set is the target table itself
+      #   and the condition is `nil` when the whole target table is
+      #   selected without any condition.
+      def select
+        expression_builder = RangeExpressionBuilder.new(@shard_key,
+                                                        @target_range)
+        expression_builder.match_columns = @match_columns
+        expression_builder.query = @query
+        expression_builder.filter = @filter
+        begin
+          case @cover_type
+          when :all
+            if @query.nil? and @filter.nil?
+              [@table, nil]
+            else
+              filter_table do |expression|
+                expression_builder.build_all(expression)
+              end
+            end
+          when :partial_min
+            filter_table do |expression|
+              expression_builder.build_partial_min(expression)
+            end
+          when :partial_max
+            filter_table do |expression|
+              expression_builder.build_partial_max(expression)
+            end
+          when :partial_min_and_max
+            filter_table do |expression|
+              expression_builder.build_partial_min_and_max(expression)
+            end
+          else
+            message = "[shard-selector] unknown cover type: " +
+                      "<#{@cover_type.inspect}>"
+            raise ArgumentError, message
+          end
+        ensure
+          expression = expression_builder.match_columns_expression
+          @expressions << expression if expression
+        end
+      end
+
+      private
+      def filter_table
+        expression = Expression.create(@table)
+        @expressions << expression
+        yield(expression)
+        [@table.select(expression), expression]
+      end
+    end
+  end
+end

--- a/plugins/sharding/sources.am
+++ b/plugins/sharding/sources.am
@@ -8,6 +8,7 @@ sharding_scripts =				\
 	logical_table_remove.rb			\
 	parameters.rb				\
 	range_expression_builder.rb		\
+	shard_selector.rb			\
 	keys_parsable.rb			\
 	dynamic_columns.rb			\
 	window.rb			\


### PR DESCRIPTION
`Groonga::Sharding::ShardSelector` selects records in a shard by the target range and the given `match_columns`/`query`/`filter`. It's extracted from `Groonga::Sharding::LogicalSelectCommand::ShardExecutor`.

`ShardSelector` depends only on the given values not on a command execution context. So it can be used in a child context by `Groonga::TaskExecutor#execute` to run per shard selection in parallel. This is a preparation for it. `ShardExecutor` just delegates to `ShardSelector` for now. Behavior isn't changed.

`ShardSelector#select` returns the result set and the condition expression. Expressions created by the selector are kept in `ShardSelector#expressions`. The caller must close them. `ShardExecutor` adds them to `ExecuteContext#expressions` even when the selector raises as before.