### PR TITLE
sharding: extract Groonga::Sharding::DrilldownExecutor from logical_select

### DIFF
--- a/plugins/sharding.rb
+++ b/plugins/sharding.rb
@@ -9,6 +9,7 @@ require "sharding/stream_shard_executor"
 require "sharding/stream_executor"
 
 require "sharding/dynamic_columns"
+require "sharding/drilldown_executor"
 
 require "sharding/logical_parameters"
 

--- a/plugins/sharding/drilldown_executor.rb
+++ b/plugins/sharding/drilldown_executor.rb
@@ -1,0 +1,105 @@
+module Groonga
+  module Sharding
+    # Executes one drilldown against the given target tables: groups
+    # records in all target tables into one result set, applies
+    # dynamic columns and filters the result set.
+    #
+    # This depends only on the given values. It doesn't depend on a
+    # command execution context. So this can be used in a child
+    # context.
+    class DrilldownExecutor
+      include QueryLoggable
+
+      # Temporary tables created by #execute. The caller must close
+      # them after the result set is no longer used.
+      attr_reader :temporary_tables
+
+      # Expressions created by #execute. The caller must close them
+      # after the result set is no longer used.
+      attr_reader :expressions
+
+      # @param target_tables [Array<Groonga::Table>] Tables to be
+      #   grouped. Records in all tables are grouped into one result
+      #   set.
+      # @param keys [Array<String>] Drilldown keys.
+      # @param calc_types [Integer] Groonga::TableGroupFlags::CALC_*
+      # @param calc_target_name [String, nil]
+      # @param filter [String, nil]
+      # @param dynamic_columns [DynamicColumns, nil]
+      # @param query_log_prefix [String]
+      def initialize(target_tables,
+                     keys,
+                     calc_types: TableGroupFlags::CALC_COUNT,
+                     calc_target_name: nil,
+                     filter: nil,
+                     dynamic_columns: nil,
+                     query_log_prefix: "drilldown")
+        @target_tables = target_tables
+        @keys = keys
+        @calc_types = calc_types
+        @calc_target_name = calc_target_name
+        @filter = filter
+        @dynamic_columns = dynamic_columns
+        @query_log_prefix = query_log_prefix
+        @temporary_tables = []
+        @expressions = []
+      end
+
+      # @return [[Groonga::Table, Groonga::Expression]] The result set
+      #   and the condition. The condition is `nil` when `filter`
+      #   isn't specified.
+      def execute
+        result_set = group
+        @temporary_tables << result_set
+        query_logger.log(:size,
+                         ":",
+                         "#{@query_log_prefix}(#{result_set.size})")
+        if @dynamic_columns
+          options = {query_log_prefix: "#{@query_log_prefix}."}
+          @dynamic_columns.apply_initial([[result_set]], options)
+        end
+        return [result_set, nil] if @filter.nil?
+
+        expression = Expression.create(result_set)
+        @expressions << expression
+        expression.parse(@filter)
+        filtered_result_set = result_set.select(expression)
+        @temporary_tables << filtered_result_set
+        query_logger.log(:size,
+                         ":",
+                         "#{@query_log_prefix}.filter(#{filtered_result_set.size})")
+        [filtered_result_set, expression]
+      end
+
+      private
+      def group
+        group_result = TableGroupResult.new
+        begin
+          group_result.key_begin = 0
+          group_result.key_end = @keys.size - 1
+          if @keys.size > 1
+            group_result.max_n_sub_records = 1
+          end
+          group_result.limit = 1
+          group_result.flags = @calc_types
+          @target_tables.each do |table|
+            calc_target = nil
+            calc_target = table.find_column(@calc_target_name) if @calc_target_name
+            group_result.calc_target = calc_target
+            begin
+              table.group(@keys, group_result)
+            ensure
+              calc_target.close if calc_target
+              group_result.calc_target = nil
+            end
+          end
+          result_set = group_result.table
+          group_result.table = nil
+          result_set
+        ensure
+          group_result.close
+        end
+      end
+    end
+  end
+end

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -679,115 +679,66 @@ module Groonga
 
         def execute_plain_drilldown
           drilldown = @context.plain_drilldown
-          query_log_prefix = "drilldown"
-          group_result = TableGroupResult.new
-          begin
-            group_result.key_begin = 0
-            group_result.key_end = 0
-            group_result.limit = 1
-            group_result.flags = drilldown.calc_types
-            drilldown.keys.each do |key|
-              @context.results.each do |result|
-                result_set = result[:result_set]
-                with_calc_target(group_result,
-                                 drilldown.calc_target(result_set)) do
-                  result_set.group([key], group_result)
-                end
-              end
-              result_set = group_result.table
-              query_logger.log(:size,
-                               ":",
-                               "#{query_log_prefix}(#{result_set.size})")
-              result = apply_drilldown_filter(query_log_prefix,
-                                              drilldown,
-                                              result_set)
-              drilldown.temporary_tables << result[:result_set]
-              group_result.table = nil
-              drilldown.results << result
-            end
-          ensure
-            group_result.close
+          target_tables = @context.results.collect do |result|
+            result[:result_set]
+          end
+          drilldown.keys.each do |key|
+            executor = DrilldownExecutor.new(target_tables,
+                                             [key],
+                                             calc_types: drilldown.calc_types,
+                                             calc_target_name: drilldown.calc_target_name,
+                                             filter: drilldown.filter,
+                                             query_log_prefix: "drilldown")
+            result_set, condition = run_drilldown_executor(executor, drilldown)
+            drilldown.results << {
+              result_set: result_set,
+              condition: condition,
+            }
           end
         end
 
         def execute_labeled_drilldowns
           drilldowns = @context.labeled_drilldowns
-
           drilldowns.tsort_each do |drilldown|
-            query_log_prefix = "drilldowns[#{drilldown.label}]"
-            group_result = TableGroupResult.new
-            keys = drilldown.keys
-            begin
-              group_result.key_begin = 0
-              group_result.key_end = keys.size - 1
-              if keys.size > 1
-                group_result.max_n_sub_records = 1
-              end
-              group_result.limit = 1
-              group_result.flags = drilldown.calc_types
-              if drilldown.table
-                target_table = drilldowns[drilldown.table].result_set
-                with_calc_target(group_result,
-                                 drilldown.calc_target(target_table)) do
-                  target_table.group(keys, group_result)
-                end
-              else
-                @context.results.each do |result|
-                  result_set = result[:result_set]
-                  with_calc_target(group_result,
-                                   drilldown.calc_target(result_set)) do
-                    result_set.group(keys, group_result)
-                  end
-                end
-              end
-              result_set = group_result.table
-              query_logger.log(:size,
-                               ":",
-                               "#{query_log_prefix}(#{result_set.size})")
-              options = {query_log_prefix: "#{query_log_prefix}."}
-              drilldown.dynamic_columns.apply_initial([[result_set]],
-                                                      options)
-              result = apply_drilldown_filter(query_log_prefix,
-                                             drilldown,
-                                             result_set)
-              result_set = result[:result_set]
-              drilldown.temporary_tables << result_set
-              group_result.table = nil
-              drilldown.result_set = result_set
-              drilldown.condition = result[:condition]
-            ensure
-              group_result.close
+            execute_labeled_drilldown(drilldowns, drilldown)
+          end
+        end
+
+        def execute_labeled_drilldown(drilldowns, drilldown)
+          target_tables = labeled_drilldown_target_tables(drilldowns,
+                                                          drilldown)
+          executor =
+            DrilldownExecutor.new(target_tables,
+                                  drilldown.keys,
+                                  calc_types: drilldown.calc_types,
+                                  calc_target_name: drilldown.calc_target_name,
+                                  filter: drilldown.filter,
+                                  dynamic_columns: drilldown.dynamic_columns,
+                                  query_log_prefix: "drilldowns[#{drilldown.label}]")
+          result_set, condition = run_drilldown_executor(executor, drilldown)
+          drilldown.result_set = result_set
+          drilldown.condition = condition
+        end
+
+        def labeled_drilldown_target_tables(drilldowns, drilldown)
+          if drilldown.table
+            [drilldowns[drilldown.table].result_set]
+          else
+            @context.results.collect do |result|
+              result[:result_set]
             end
           end
         end
 
-        def with_calc_target(group_result, calc_target)
-          group_result.calc_target = calc_target
+        # Temporary objects created by the executor are kept in the
+        # drilldown to be closed even when the executor raises.
+        def run_drilldown_executor(executor, drilldown)
           begin
-            yield
+            executor.execute
           ensure
-            calc_target.close if calc_target
-            group_result.calc_target = nil
+            drilldown.temporary_tables.concat(executor.temporary_tables)
+            drilldown.expressions.concat(executor.expressions)
           end
-        end
-
-        def apply_drilldown_filter(query_log_prefix, drilldown, result_set)
-          filter = drilldown.filter
-          return {result_set: result_set} if filter.nil?
-
-          expression = Expression.create(result_set)
-          drilldown.expressions << expression
-          expression.parse(filter)
-          filtered_result_set = result_set.select(expression)
-          drilldown.temporary_tables << result_set
-          n_records = filtered_result_set.size
-          query_logger.log(:size,
-                           ":",
-                           "#{query_log_prefix}.filter(#{n_records})")
-          {
-            result_set: filtered_result_set,
-            condition: expression,
-          }
         end
       end
 

--- a/plugins/sharding/sources.am
+++ b/plugins/sharding/sources.am
@@ -11,6 +11,7 @@ sharding_scripts =				\
 	shard_selector.rb			\
 	keys_parsable.rb			\
 	dynamic_columns.rb			\
+	drilldown_executor.rb			\
 	window.rb			\
 	stream_execute_context.rb		\
 	stream_shard_executor.rb		\


### PR DESCRIPTION
`Groonga::Sharding::DrilldownExecutor` executes one drilldown against the given target tables: it groups records in all target tables into one result set, applies dynamic columns and filters the result set. It's extracted from
`Groonga::Sharding::LogicalSelectCommand::Executor`.

`DrilldownExecutor` depends only on the given values not on a command execution context. So it can be used in a child context by `Groonga::TaskExecutor#execute` to run drilldowns in parallel. This is a preparation for it. `Executor` just delegates to `DrilldownExecutor` for now. Behavior isn't changed.

`DrilldownExecutor#execute` returns the result set and the condition expression. Temporary tables and expressions created by the executor are kept in `DrilldownExecutor#temporary_tables` and `DrilldownExecutor#expressions`. The caller must close them. `Executor` adds them to the drilldown execute context even when the executor raises as before.