### PR TITLE
sharding logical_select: select shards in parallel

### DIFF
--- a/dockerfiles/alpine.dockerfile
+++ b/dockerfiles/alpine.dockerfile
@@ -58,7 +58,7 @@ RUN \
 RUN \
   gem install \
     bundler \
-    grntest \
+    "grntest:>=1.8.6" \
     groonga-client \
     pkg-config \
     rake

--- a/lib/mrb/mrb_task_executor.cpp
+++ b/lib/mrb/mrb_task_executor.cpp
@@ -60,6 +60,7 @@
 #  include <mruby/irep.h>
 #  include <mruby/proc.h>
 #  include <mruby/string.h>
+#  include <mruby/variable.h>
 
 #  include "mrb_ctx.h"
 #  include "mrb_detached_value.hpp"
@@ -136,6 +137,7 @@ namespace {
     data->ctx = ctx;
     data->executor = grn_ctx_get_task_executor(ctx);
     mrb_data_init(self, data, &mrb_grn_task_executor_type);
+    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "@results"), mrb_hash_new(mrb));
     return self;
   }
 
@@ -218,8 +220,15 @@ namespace {
     return mrb_obj_as_string(mrb, *static_cast<mrb_value *>(user_data));
   }
 
-  /* Keep the error of the child context in the task. It's used to
-   * report the error to the caller's context. */
+  /* Move the error of the child context to the task. It's reported
+   * to the caller's context by report_task_errors() after all tasks
+   * are finished.
+   *
+   * The error must not be propagated to the caller's context by
+   * grn_ctx_release_child() because other tasks may be running.
+   * Groonga APIs called in other tasks use the caller's context for
+   * shared data such as temporary objects and they fail when the
+   * caller's context has an error. So the error is cleared here. */
   void
   record_task_error(Task *task, grn_ctx *ctx)
   {
@@ -228,6 +237,7 @@ namespace {
     task->error_file = ctx->errfile;
     task->error_line = ctx->errline;
     task->error_function = ctx->errfunc;
+    ERRCLR(ctx);
   }
 
   /* Run on a worker thread. This must not touch the caller's
@@ -302,11 +312,10 @@ namespace {
   }
 
   /* Report the first error of tasks to the caller's context if the
-   * error isn't reported yet. An error in a child context is
-   * normally propagated by grn_ctx_release_child() but the error may
-   * be lost. The error message is already logged by the task. So
-   * this doesn't log it again. This must be run on the caller's
-   * thread after all tasks are finished. */
+   * caller's context doesn't have an error yet. The error message is
+   * already logged by the task. So this doesn't log it again. This
+   * must be run on the caller's thread after all tasks are
+   * finished. */
   void
   report_task_errors(TaskExecutorData *data)
   {
@@ -469,21 +478,14 @@ namespace {
     return mrb_nil_value();
   }
 
-  /* Convert the result of the task to a value in the caller's mruby
-   * and remove the task. The task must be finished. */
-  mrb_value
-  take_result(mrb_state *mrb, TaskExecutorData *data, uintptr_t id)
-  {
-    auto it = data->tasks.find(id);
-    if (it == data->tasks.end()) {
-      return mrb_nil_value();
-    }
-    auto result = it->second->result.to_mrb(mrb);
-    data->tasks.erase(it);
-    return result;
-  }
-
-  /* Groonga::TaskExecutor#wait_all: {id => result, ...} */
+  /* Groonga::TaskExecutor#wait_all
+   *
+   * Waits all tasks. Results of succeeded tasks are added to
+   * #results. If one of tasks is failed, an error is raised after
+   * #results is updated. So the caller can release resources such
+   * as temporary tables created by succeeded tasks on error. Note
+   * that the context has the error in this case. So bindings that
+   * raise on the context error can't be used for it. */
   mrb_value
   task_executor_wait_all(mrb_state *mrb, mrb_value self)
   {
@@ -491,20 +493,38 @@ namespace {
     data->executor->wait_all();
     report_task_errors(data);
 
-    auto results =
-      mrb_hash_new_capa(mrb, static_cast<mrb_int>(data->task_ids.size()));
+    auto results = mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@results"));
     for (const auto id : data->task_ids) {
+      auto it = data->tasks.find(id);
+      if (it == data->tasks.end()) {
+        continue;
+      }
+      if (it->second->rc != GRN_SUCCESS) {
+        continue;
+      }
       auto arena_index = mrb_gc_arena_save(mrb);
       mrb_hash_set(mrb,
                    results,
                    mrb_int_value(mrb, static_cast<mrb_int>(id)),
-                   take_result(mrb, data, id));
+                   it->second->result.to_mrb(mrb));
       mrb_gc_arena_restore(mrb, arena_index);
     }
     data->task_ids.clear();
     data->tasks.clear();
     grn_mrb_ctx_check(mrb);
-    return results;
+    return mrb_nil_value();
+  }
+
+  /* Groonga::TaskExecutor#results: {id => result, ...}
+   *
+   * Results of succeeded tasks. Results of failed tasks aren't
+   * included. #wait_all adds results to this. This isn't cleared
+   * automatically. The caller must clear this by `results.clear`
+   * when the caller reuses task IDs. */
+  mrb_value
+  task_executor_get_results(mrb_state *mrb, mrb_value self)
+  {
+    return mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "@results"));
   }
 } // namespace
 
@@ -541,6 +561,11 @@ grn_mrb_task_executor_init(grn_ctx *ctx)
                     klass,
                     "wait_all",
                     task_executor_wait_all,
+                    MRB_ARGS_NONE());
+  mrb_define_method(mrb,
+                    klass,
+                    "results",
+                    task_executor_get_results,
                     MRB_ARGS_NONE());
 }
 #endif

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -354,6 +354,7 @@ module Groonga
       class ExecuteContext
         include KeysParsable
 
+        attr_reader :input
         attr_reader :enumerator
         attr_reader :match_columns
         attr_reader :query
@@ -651,9 +652,7 @@ module Groonga
             end
             @context.dynamic_columns.apply_initial(targets)
           end
-          @context.shard_targets.each do |shard_executor, target_table|
-            shard_executor.execute
-          end
+          execute_shards
 
           if @context.shard_results.empty?
             result_set = HashTable.create(:flags => ObjectFlags::WITH_SUBREC,
@@ -673,6 +672,103 @@ module Groonga
             @context.dynamic_columns.apply_filtered(targets)
             @context.shard_results.each do |shard_executor, result_set, condition|
               shard_executor.execute_post(result_set, condition)
+            end
+          end
+        end
+
+        # Selects records in each shard. Shards are processed in
+        # parallel when the task executor is parallel.
+        def execute_shards
+          # A child context isn't used when there is only one shard
+          # because there is nothing to parallelize.
+          task_executor = TaskExecutor.new
+          if !task_executor.parallel? or @context.shard_targets.size == 1
+            @context.shard_targets.each do |shard_executor, _|
+              shard_executor.execute
+            end
+            return
+          end
+
+          input = @context.input
+          range = {
+            min: input[:min],
+            min_border: input[:min_border],
+            max: input[:max],
+            max_border: input[:max_border],
+          }
+          @context.shard_targets.each_with_index do |(shard_executor, target_table), i|
+            shard = shard_executor.shard
+            # The block is evaluated at the top level of a child
+            # context. It must not refer any local variable outside
+            # the block and must use full names for constants.
+            task_executor.execute(i,
+                                  "[logical_select][#{shard.table_name}]",
+                                  shard.table_name,
+                                  target_table.id,
+                                  shard.key.id,
+                                  range,
+                                  shard_executor.cover_type,
+                                  @context.match_columns,
+                                  @context.query,
+                                  @context.filter) do |shard_table_name,
+                                                       table_id,
+                                                       shard_key_id,
+                                                       range_input,
+                                                       cover_type,
+                                                       match_columns,
+                                                       query,
+                                                       filter|
+              require "sharding/range_expression_builder"
+              require "sharding/logical_enumerator"
+              require "sharding/shard_selector"
+              context = Groonga::Context.instance
+              target_range =
+                Groonga::Sharding::LogicalEnumerator::TargetRange.new("logical_select",
+                                                                      range_input)
+              selector = Groonga::Sharding::ShardSelector.new(context[table_id],
+                                                              context[shard_key_id],
+                                                              target_range,
+                                                              cover_type,
+                                                              match_columns: match_columns,
+                                                              query: query,
+                                                              filter: filter,
+                                                              shard_table_name: shard_table_name)
+              begin
+                result_set, condition = selector.select
+                expression_ids = selector.expressions.collect(&:id)
+                # Expressions are closed by the parent context.
+                selector.expressions.clear
+                [result_set.id, condition&.id, expression_ids]
+              ensure
+                selector.expressions.each(&:close)
+              end
+            end
+          end
+          results = task_executor.results
+          begin
+            task_executor.wait_all
+            @context.shard_targets.each_with_index do |(shard_executor, _), i|
+              # The result is deleted from results before it's added
+              # to the context because the result is closed by the
+              # context after this.
+              result_set_id, condition_id, expression_ids = results.delete(i)
+              shard_executor.add_selected(result_set_id,
+                                          condition_id,
+                                          expression_ids)
+            end
+          ensure
+            # Only Groonga::Context#[] and Groonga::Object#close are
+            # used here because the context may have an error and
+            # bindings that check it raise.
+            context = Context.instance
+            results.each_value do |result|
+              result_set_id, condition_id, expression_ids = result
+              expression_ids.each do |expression_id|
+                context[expression_id].close
+              end
+              # The result set is the target table when there is no
+              # condition. It's not created by the task.
+              context[result_set_id].close if condition_id
             end
           end
         end
@@ -745,6 +841,9 @@ module Groonga
       class ShardExecutor
         include QueryLoggable
 
+        attr_reader :shard
+        attr_reader :cover_type
+
         def initialize(context, shard, shard_range)
           @context = context
           @shard = shard
@@ -783,7 +882,7 @@ module Groonga
               if @cover_type == :all
                 @target_table = @target_table.select_all
               else
-                @target_table, _condition = select_shard(shard_key)
+                @target_table = select_range
                 @cover_type = :all
               end
               @temporary_tables << @target_table
@@ -793,10 +892,28 @@ module Groonga
         end
 
         def execute
-          result_set, condition = select_shard(@shard.key,
-                                               match_columns: @match_columns,
+          result_set, condition = select_shard(match_columns: @match_columns,
                                                query: @query,
                                                filter: @filter)
+          if condition.nil?
+            @temporary_tables.delete(@target_table)
+          end
+          add_result(result_set, condition)
+        end
+
+        # Adds the result of ShardSelector#select run in a child
+        # context. Objects are passed by ID because they are created in
+        # the child context. Temporary objects created in a child
+        # context are registered to the parent context. So they can
+        # be used after the child context is released. They must be
+        # closed by the parent context.
+        def add_selected(result_set_id, condition_id, expression_ids)
+          context = Context.instance
+          expression_ids.each do |expression_id|
+            @context.expressions << context[expression_id]
+          end
+          result_set = context[result_set_id]
+          condition = condition_id ? context[condition_id] : nil
           if condition.nil?
             @temporary_tables.delete(@target_table)
           end
@@ -817,9 +934,9 @@ module Groonga
         private
         # Expressions created by the selector are kept in the context
         # to be closed even when the selector raises.
-        def select_shard(shard_key, **options)
+        def select_shard(**options)
           selector = ShardSelector.new(@target_table,
-                                       shard_key,
+                                       @shard.key,
                                        @target_range,
                                        @cover_type,
                                        shard_table_name: @shard.table_name,
@@ -837,6 +954,19 @@ module Groonga
           expression
         end
 
+        # Narrows the shard table by the target range to apply
+        # initial stage dynamic columns. This isn't logged as
+        # "select" like grn_select_create_all_selected_result_table()
+        # in select because this isn't the selection of the command.
+        def select_range
+          expression = create_expression(@target_table)
+          expression.query_log_tag_suffix = "[#{@shard.table_name}]"
+          expression_builder = RangeExpressionBuilder.new(@shard.key,
+                                                          @target_range)
+          expression_builder.build(expression, @shard_range)
+          @target_table.select(expression)
+        end
+
         def apply_post_filter(table)
           expression = create_expression(table)
           expression.query_log_tag_suffix = "[#{@shard.table_name}]"
@@ -845,9 +975,6 @@ module Groonga
         end
 
         def add_result(result_set, condition)
-          query_logger.log(:size, ":",
-                           "select(#{result_set.size})[#{@shard.table_name}]")
-
           if result_set.empty?
             result_set.close
             return

--- a/plugins/sharding/shard_selector.rb
+++ b/plugins/sharding/shard_selector.rb
@@ -7,6 +7,8 @@ module Groonga
     # command execution context. So this can be used in a child
     # context.
     class ShardSelector
+      include QueryLoggable
+
       # Expressions created by #select. The caller must close them
       # after the result set is no longer used.
       attr_reader :expressions
@@ -19,6 +21,8 @@ module Groonga
       #   `max` and `max_border`.
       # @param shard_table_name [String] The shard table name for
       #   query log. `filter(N)[SHARD_TABLE_NAME]` is logged.
+      #   The number of selected records is logged with
+      #   it immediately after selection.
       # @param cover_type [Symbol] How the target range covers the
       #   shard: `:all`, `:partial_min`, `:partial_max` or
       #   `:partial_min_and_max`.
@@ -33,6 +37,7 @@ module Groonga
         @match_columns = match_columns
         @query = query
         @filter = filter
+        @shard_table_name = shard_table_name
         @expressions = []
       end
 
@@ -41,6 +46,15 @@ module Groonga
       #   and the condition is `nil` when the whole target table is
       #   selected without any condition.
       def select
+        result_set, condition = select_internal
+        query_logger.log(:size,
+                         ":",
+                         "select(#{result_set.size})[#{@shard_table_name}]")
+        [result_set, condition]
+      end
+
+      private
+      def select_internal
         expression_builder = RangeExpressionBuilder.new(@shard_key,
                                                         @target_range)
         expression_builder.match_columns = @match_columns
@@ -79,7 +93,6 @@ module Groonga
         end
       end
 
-      private
       def filter_table
         expression = Expression.create(@table)
         @expressions << expression

--- a/test/command/suite/ruby/eval/task_executor/execute_wait_all.expected
+++ b/test/command/suite/ruby/eval/task_executor/execute_wait_all.expected
@@ -1,6 +1,6 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1, 1.5, 'string', :symbol) {|*args| args}; executor.execute(1, '[test]', [1, [2, 3]], {'key' => 'value', 'nested' => {'k' => 1}}, nil, true, false) {|*args| args}; executor.execute(2, '[test]') {'no argument'}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1, 1.5, 'string', :symbol) {|*args| args}; executor.execute(1, '[test]', [1, [2, 3]], {'key' => 'value', 'nested' => {'k' => 1}}, nil, true, false) {|*args| args}; executor.execute(2, '[test]') {'no argument'}; executor.wait_all; executor.results.inspect"
 [
   [
     0,

--- a/test/command/suite/ruby/eval/task_executor/execute_wait_all.test
+++ b/test/command/suite/ruby/eval/task_executor/execute_wait_all.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1, 1.5, 'string', :symbol) {|*args| args}; executor.execute(1, '[test]', [1, [2, 3]], {'key' => 'value', 'nested' => {'k' => 1}}, nil, true, false) {|*args| args}; executor.execute(2, '[test]') {'no argument'}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1, 1.5, 'string', :symbol) {|*args| args}; executor.execute(1, '[test]', [1, [2, 3]], {'key' => 'value', 'nested' => {'k' => 1}}, nil, true, false) {|*args| args}; executor.execute(2, '[test]') {'no argument'}; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/local_variable_in_block.expected
+++ b/test/command/suite/ruby/eval/task_executor/local_variable_in_block.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1) {|x| y = x + 1; [1, 2].collect {|v| [v + x, v + y]}}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1) {|x| y = x + 1; [1, 2].collect {|v| [v + x, v + y]}}; executor.wait_all; executor.results.inspect"
 [[0,0.0,0.0],{"value":"{0 => [[2, 3], [3, 4]]}"}]

--- a/test/command/suite/ruby/eval/task_executor/local_variable_in_block.test
+++ b/test/command/suite/ruby/eval/task_executor/local_variable_in_block.test
@@ -3,4 +3,4 @@ plugin_register ruby/eval
 #@on-error default
 
 # Local variables in the block can be used in nested blocks.
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1) {|x| y = x + 1; [1, 2].collect {|v| [v + x, v + y]}}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]', 1) {|x| y = x + 1; [1, 2].collect {|v| [v + x, v + y]}}; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/no_task.expected
+++ b/test/command/suite/ruby/eval/task_executor/no_task.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.wait_all; executor.results.inspect"
 [[0,0.0,0.0],{"value":"{}"}]

--- a/test/command/suite/ruby/eval/task_executor/no_task.test
+++ b/test/command/suite/ruby/eval/task_executor/no_task.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/outer_local_variable.expected
+++ b/test/command/suite/ruby/eval/task_executor/outer_local_variable.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; outer = 1; executor.execute(0, '[test]') {[outer, [1].collect {|x| outer}].inspect}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; outer = 1; executor.execute(0, '[test]') {[outer, [1].collect {|x| outer}].inspect}; executor.wait_all; executor.results.inspect"
 [[0,0.0,0.0],{"value":"{0 => \"[nil, [nil]]\"}"}]

--- a/test/command/suite/ruby/eval/task_executor/outer_local_variable.test
+++ b/test/command/suite/ruby/eval/task_executor/outer_local_variable.test
@@ -3,4 +3,4 @@ plugin_register ruby/eval
 #@on-error default
 
 # A local variable outside the block is nil in the child context.
-ruby_eval "executor = Groonga::TaskExecutor.new; outer = 1; executor.execute(0, '[test]') {[outer, [1].collect {|x| outer}].inspect}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; outer = 1; executor.execute(0, '[test]') {[outer, [1].collect {|x| outer}].inspect}; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/parallel/execute_wait_all.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/execute_wait_all.expected
@@ -1,6 +1,6 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| executor.execute(i, '[test]', i) {|x| x * 2}}; [executor.parallel?, executor.n_workers, executor.wait_all].inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| executor.execute(i, '[test]', i) {|x| x * 2}}; executor.wait_all; [executor.parallel?, executor.n_workers, executor.results].inspect"
 [
   [
     0,

--- a/test/command/suite/ruby/eval/task_executor/parallel/execute_wait_all.test
+++ b/test/command/suite/ruby/eval/task_executor/parallel/execute_wait_all.test
@@ -3,4 +3,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| executor.execute(i, '[test]', i) {|x| x * 2}}; [executor.parallel?, executor.n_workers, executor.wait_all].inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| executor.execute(i, '[test]', i) {|x| x * 2}}; executor.wait_all; [executor.parallel?, executor.n_workers, executor.results].inspect"

--- a/test/command/suite/ruby/eval/task_executor/parallel/many_tasks.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/many_tasks.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 200.times {|i| executor.execute(i, '[test]', i, 'x' * i) {|x, s| [x, s.size]}}; results = executor.wait_all; [results.size, results.all? {|id, (x, size)| id == x and x == size}].inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 200.times {|i| executor.execute(i, '[test]', i, 'x' * i) {|x, s| [x, s.size]}}; executor.wait_all; results = executor.results; [results.size, results.all? {|id, (x, size)| id == x and x == size}].inspect"
 [[0,0.0,0.0],{"value":"[200, true]"}]

--- a/test/command/suite/ruby/eval/task_executor/parallel/many_tasks.test
+++ b/test/command/suite/ruby/eval/task_executor/parallel/many_tasks.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 200.times {|i| executor.execute(i, '[test]', i, 'x' * i) {|x, s| [x, s.size]}}; results = executor.wait_all; [results.size, results.all? {|id, (x, size)| id == x and x == size}].inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 200.times {|i| executor.execute(i, '[test]', i, 'x' * i) {|x, s| [x, s.size]}}; executor.wait_all; results = executor.results; [results.size, results.all? {|id, (x, size)| id == x and x == size}].inspect"

--- a/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.expected
@@ -1,0 +1,14 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 4.times {|i| executor.execute(i, '[test]', i) {|x| raise 'error in task 2' if x == 2; x * 10}}; begin; executor.wait_all; rescue Groonga::Error => error; Groonga::Context.instance.rc = 0; [error.class.to_s, executor.results].inspect; end"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  {
+    "value": "[\"Groonga::UnknownError\", {0 => 0, 1 => 10, 3 => 30}]"
+  }
+]
+#|e| [test][2] RuntimeError: error in task 2

--- a/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.test
+++ b/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.test
@@ -1,0 +1,8 @@
+#@require-apache-arrow
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+# Results of succeeded tasks are available even when one of tasks is
+# failed. The error in the context is cleared to output the value.
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 4.times {|i| executor.execute(i, '[test]', i) {|x| raise 'error in task 2' if x == 2; x * 10}}; begin; executor.wait_all; rescue Groonga::Error => error; Groonga::Context.instance.rc = 0; [error.class.to_s, executor.results].inspect; end"

--- a/test/command/suite/ruby/eval/task_executor/parallel/temporary_table.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/temporary_table.expected
@@ -11,5 +11,5 @@ load --table Users
 {"_key": "carol", "age": 40}
 ]
 [[0,0.0,0.0],3]
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [20, 30, 40].each_with_index {|age, i| executor.execute(i, '[test]', 'Users', age) {|name, min_age| table = Groonga::Context.instance[name]; expression = Groonga::Expression.create(table); expression.parse('age >= ' + min_age.to_s); table.select(expression).id}}; executor.wait_all.collect {|id, table_id| [id, Groonga::Context.instance[table_id].size]}.inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [20, 30, 40].each_with_index {|age, i| executor.execute(i, '[test]', 'Users', age) {|name, min_age| table = Groonga::Context.instance[name]; expression = Groonga::Expression.create(table); expression.parse('age >= ' + min_age.to_s); table.select(expression).id}}; executor.wait_all; executor.results.collect {|id, table_id| [id, Groonga::Context.instance[table_id].size]}.inspect"
 [[0,0.0,0.0],{"value":"[[0, 3], [1, 2], [2, 1]]"}]

--- a/test/command/suite/ruby/eval/task_executor/parallel/temporary_table.test
+++ b/test/command/suite/ruby/eval/task_executor/parallel/temporary_table.test
@@ -14,4 +14,4 @@ load --table Users
 # Each task selects records in a child context. The result tables are
 # registered to the parent context. So the parent can use them by ID
 # after tasks are finished.
-ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [20, 30, 40].each_with_index {|age, i| executor.execute(i, '[test]', 'Users', age) {|name, min_age| table = Groonga::Context.instance[name]; expression = Groonga::Expression.create(table); expression.parse('age >= ' + min_age.to_s); table.select(expression).id}}; executor.wait_all.collect {|id, table_id| [id, Groonga::Context.instance[table_id].size]}.inspect"
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [20, 30, 40].each_with_index {|age, i| executor.execute(i, '[test]', 'Users', age) {|name, min_age| table = Groonga::Context.instance[name]; expression = Groonga::Expression.create(table); expression.parse('age >= ' + min_age.to_s); table.select(expression).id}}; executor.wait_all; executor.results.collect {|id, table_id| [id, Groonga::Context.instance[table_id].size]}.inspect"

--- a/test/command/suite/ruby/eval/task_executor/require_in_block.expected
+++ b/test/command/suite/ruby/eval/task_executor/require_in_block.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {loaded = require 'sharding/parameters'; [loaded, Groonga::Sharding::Parameters.to_s]}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {loaded = require 'sharding/parameters'; [loaded, Groonga::Sharding::Parameters.to_s]}; executor.wait_all; executor.results.inspect"
 [[0,0.0,0.0],{"value":"{0 => [true, \"Groonga::Sharding::Parameters\"]}"}]

--- a/test/command/suite/ruby/eval/task_executor/require_in_block.test
+++ b/test/command/suite/ruby/eval/task_executor/require_in_block.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {loaded = require 'sharding/parameters'; [loaded, Groonga::Sharding::Parameters.to_s]}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {loaded = require 'sharding/parameters'; [loaded, Groonga::Sharding::Parameters.to_s]}; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/self.expected
+++ b/test/command/suite/ruby/eval/task_executor/self.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {self.inspect}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {self.inspect}; executor.wait_all; executor.results.inspect"
 [[0,0.0,0.0],{"value":"{0 => \"main\"}"}]

--- a/test/command/suite/ruby/eval/task_executor/self.test
+++ b/test/command/suite/ruby/eval/task_executor/self.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {self.inspect}; executor.wait_all.inspect"
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {self.inspect}; executor.wait_all; executor.results.inspect"

--- a/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.expected
+++ b/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.expected
@@ -1,6 +1,6 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executor); executor.execute(0, '[test]') {ASCENDING}; end; end; executor = Groonga::TaskExecutor.new; Groonga::TableCursorFlags.task_executor_test(executor); executor.wait_all.inspect"
+ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executor); executor.execute(0, '[test]') {ASCENDING}; end; end; executor = Groonga::TaskExecutor.new; Groonga::TableCursorFlags.task_executor_test(executor); executor.wait_all; executor.results.inspect"
 [
   [
     [

--- a/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.test
+++ b/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.test
@@ -2,4 +2,4 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executor); executor.execute(0, '[test]') {ASCENDING}; end; end; executor = Groonga::TaskExecutor.new; Groonga::TableCursorFlags.task_executor_test(executor); executor.wait_all.inspect"
+ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executor); executor.execute(0, '[test]') {ASCENDING}; end; end; executor = Groonga::TaskExecutor.new; Groonga::TableCursorFlags.task_executor_test(executor); executor.wait_all; executor.results.inspect"

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
@@ -77,6 +77,7 @@ load --table Logs_20150205
 #@sleep 1
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs \
   --shard_key timestamp \
   --limit 0 \
@@ -106,4 +107,5 @@ logical_select Logs \
   --drilldowns[start].keys 'action' \
   --drilldowns[start].filter "_key @ 'Start'" \
   --drilldowns[start].output_columns _key
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.expected
@@ -92,10 +92,10 @@ logical_select Logs   --shard_key timestamp   --columns[filtered_id].stage filte
 ]
 #>logical_select --columns[filtered_id].flags "COLUMN_SCALAR" --columns[filtered_id].stage "filtered" --columns[filtered_id].type "UInt32" --columns[filtered_id].value "_id" --filter "price < 910" --logical_table "Logs" --output_columns "_id,filtered_id,price" --shard_key "timestamp"
 #:000000000000000 filter(1)[Logs_20170315]: Logs_20170315.price less 910
-#:000000000000000 select(1)[Logs_20170315]
 #:000000000000000 filter(2)[Logs_20170316]: Logs_20170316.price less 910
-#:000000000000000 select(2)[Logs_20170316]
 #:000000000000000 filter(2)[Logs_20170317]: Logs_20170317.price less 910
+#:000000000000000 select(1)[Logs_20170315]
+#:000000000000000 select(2)[Logs_20170316]
 #:000000000000000 select(2)[Logs_20170317]
 #:000000000000000 columns[filtered_id](1)
 #:000000000000000 columns[filtered_id](2)

--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.test
@@ -33,6 +33,7 @@ load --table Logs_20170317
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs \
   --shard_key timestamp \
   --columns[filtered_id].stage filtered \
@@ -41,4 +42,5 @@ logical_select Logs \
   --columns[filtered_id].value '_id' \
   --filter 'price < 910' \
   --output_columns _id,filtered_id,price
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.expected
@@ -39,8 +39,8 @@ logical_select Logs   --shard_key timestamp   --columns[content].stage initial  
 #:000000000000000 columns[content](2)
 #:000000000000000 columns[content](3)
 #:000000000000000 filter(1)[Logs_20170315]: (match columns) match "Book"
-#:000000000000000 select(1)[Logs_20170315]
 #:000000000000000 filter(1)[Logs_20170316]: (match columns) match "Book"
+#:000000000000000 select(1)[Logs_20170315]
 #:000000000000000 select(1)[Logs_20170316]
 #:000000000000000 output(2)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.test
@@ -29,6 +29,7 @@ log_level --level info
 #@add-important-log-levels info
 #@add-ignore-log-pattern /\A\[io\]/
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs \
   --shard_key timestamp \
   --columns[content].stage initial \
@@ -38,6 +39,7 @@ logical_select Logs \
   --match_columns item \
   --output_columns content \
   --query "Book"
+#@sort-query-log-operations none
 #@collect-query-log false
 #@remove-ignore-log-pattern /\A\[io\]/
 #@remove-important-log-levels info

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_limit -2
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_limit 1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_offset -1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/offset/positive.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_offset 1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_sort_keys -_nsubrecs,_key
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.test
@@ -49,6 +49,7 @@ load --table Memos_20150710
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Memos \
   --shard_key created_at \
   --limit 0 \
@@ -56,4 +57,5 @@ logical_select Memos \
   --drilldowns[tag].calc_types 'AVG, MAX, MIN, SUM' \
   --drilldowns[tag].calc_target priority \
   --drilldowns[tag].output_columns _value.tag,_value.user,_max,_min,_sum,_avg
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.test
@@ -46,6 +46,7 @@ load --table Logs_20170317
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs \
   --shard_key timestamp \
   --output_columns _id \
@@ -59,4 +60,5 @@ logical_select Logs \
   --drilldowns[item].columns[price_with_tax].value 'price * 1.08' \
   --drilldowns[real_price].table item \
   --drilldowns[real_price].keys price_with_tax
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.test
@@ -46,6 +46,7 @@ load --table Logs_20170317
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs \
   --shard_key timestamp \
   --output_columns _id \
@@ -58,4 +59,5 @@ logical_select Logs \
   --drilldowns[item].columns[sun].window.sort_keys price \
   --drilldowns[item].sort_keys 'sun' \
   --drilldowns[item].output_columns 'sun, _key, price'
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/filter/key.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/filter/key.test
@@ -75,8 +75,10 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action].keys action \
   --drilldowns[action].filter '_key == "Restart"'
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/negative.test
@@ -87,9 +87,11 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].limit -2
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/positive.test
@@ -87,9 +87,11 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].limit 1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/negative.test
@@ -87,9 +87,11 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].offset -1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/positive.test
@@ -87,9 +87,11 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].offset 1
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/limit/negative.test
@@ -69,6 +69,8 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit -6
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/limit/positive.test
@@ -69,6 +69,8 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 3
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/load_table/key.expected
+++ b/test/command/suite/sharding/logical_select/load_table/key.expected
@@ -65,8 +65,8 @@ logical_select   --logical_table Logs   --shard_key timestamp   --filter true   
 ]
 #>logical_select --filter "true" --limit "0" --load_columns "_key, original_id, timestamp_text" --load_table "Logs" --load_values "cast_loose(ShortText, timestamp, '') + ':' + _id, _id, timestamp" --logical_table "Logs" --shard_key "timestamp"
 #:000000000000000 filter(2)[Logs_20150203]: true
-#:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 filter(1)[Logs_20150204]: true
+#:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(1)[Logs_20150204]
 #:000000000000000 load(2)[Logs_20150203]: [Logs][2]
 #:000000000000000 load(1)[Logs_20150204]: [Logs][3]

--- a/test/command/suite/sharding/logical_select/load_table/key.test
+++ b/test/command/suite/sharding/logical_select/load_table/key.test
@@ -33,6 +33,7 @@ load --table Logs_20150204
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select \
   --logical_table Logs \
   --shard_key timestamp \
@@ -41,6 +42,7 @@ logical_select \
   --load_columns "_key, original_id, timestamp_text" \
   --load_values "cast_loose(ShortText, timestamp, '') + ':' + _id, _id, timestamp" \
   --limit 0
+#@sort-query-log-operations none
 #@collect-query-log false
 
 select --table Logs

--- a/test/command/suite/sharding/logical_select/n_workers/error/invalid_filter.expected
+++ b/test/command/suite/sharding/logical_select/n_workers/error/invalid_filter.expected
@@ -1,0 +1,41 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170315 message COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_20170316 message COLUMN_SCALAR Text
+[[0,0.0,0.0],true]
+column_create Logs_20170316 extra COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "message": "Start"},
+{"timestamp": "2017/03/15 01:00:00", "message": "Shutdown"}
+]
+[[0,0.0,0.0],2]
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 00:00:00", "message": "Start", "extra": 1},
+{"timestamp": "2017/03/16 01:00:00", "message": "Shutdown", "extra": 2}
+]
+[[0,0.0,0.0],2]
+logical_select --n_workers 4 Logs   --shard_key timestamp   --filter 'extra == 1'
+[
+  [
+    [
+      -63,
+      0.0,
+      0.0
+    ],
+    "syntax error: <Syntax error: <extra| |== 1>: [expr][parse] unknown identifier: <extra>>(-63)"
+  ]
+]
+#|e| [expr][parse] unknown identifier: <extra>
+#|e| Syntax error: <extra| |== 1>: [expr][parse] unknown identifier: <extra>

--- a/test/command/suite/sharding/logical_select/n_workers/error/invalid_filter.test
+++ b/test/command/suite/sharding/logical_select/n_workers/error/invalid_filter.test
@@ -1,0 +1,31 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_20170315 TABLE_NO_KEY
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time
+column_create Logs_20170315 message COLUMN_SCALAR Text
+
+table_create Logs_20170316 TABLE_NO_KEY
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time
+column_create Logs_20170316 message COLUMN_SCALAR Text
+column_create Logs_20170316 extra COLUMN_SCALAR UInt32
+
+load --table Logs_20170315
+[
+{"timestamp": "2017/03/15 00:00:00", "message": "Start"},
+{"timestamp": "2017/03/15 01:00:00", "message": "Shutdown"}
+]
+
+load --table Logs_20170316
+[
+{"timestamp": "2017/03/16 00:00:00", "message": "Start", "extra": 1},
+{"timestamp": "2017/03/16 01:00:00", "message": "Shutdown", "extra": 2}
+]
+
+# Only Logs_20170315 doesn't have the "extra" column. So only the task
+# for Logs_20170315 is failed. Logs_20170316 is processed successfully
+# in parallel mode. Its result must be closed.
+logical_select --n_workers 4 Logs \
+  --shard_key timestamp \
+  --filter 'extra == 1'

--- a/test/command/suite/sharding/logical_select/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/offset/negative.test
@@ -69,6 +69,8 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --offset -5
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/offset/positive.test
@@ -69,6 +69,8 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --offset 3
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/offset/with_limit.test
+++ b/test/command/suite/sharding/logical_select/offset/with_limit.test
@@ -69,7 +69,9 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --offset 3 \
   --limit 2
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/sort_keys/shard_key/ascending.test
+++ b/test/command/suite/sharding/logical_select/sort_keys/shard_key/ascending.test
@@ -63,6 +63,8 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
+#@sort-query-log-operations shard
 logical_select Logs timestamp \
   --sort_keys timestamp
+#@sort-query-log-operations none
 #@collect-query-log false

--- a/test/command/suite_benchmark/sharding/logical_select/filter.expected
+++ b/test/command/suite_benchmark/sharding/logical_select/filter.expected
@@ -1,0 +1,124 @@
+plugin_register sharding --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170301 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170301 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170301 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170302 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170302 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170302 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170303 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170303 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170303 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170304 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170304 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170304 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170305 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170305 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170305 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170306 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170306 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170306 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170307 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170307 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170307 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170308 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170308 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170308 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170309 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170309 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170309 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170310 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170310 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170310 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170311 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170311 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170311 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170312 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170312 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170312 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170313 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170313 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170313 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170314 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170314 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170314 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170315 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170316 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170317 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170317 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170318 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170318 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170318 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170319 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170319 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170319 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170320 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170320 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170320 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+logical_count Logs --shard_key timestamp --output_type json
+[[0,0.0,0.0],4000000]

--- a/test/command/suite_benchmark/sharding/logical_select/filter.test
+++ b/test/command/suite_benchmark/sharding/logical_select/filter.test
@@ -1,0 +1,97 @@
+plugin_register sharding --output_type json
+
+table_create Logs_20170301 TABLE_NO_KEY --output_type json
+column_create Logs_20170301 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170301 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170302 TABLE_NO_KEY --output_type json
+column_create Logs_20170302 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170302 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170303 TABLE_NO_KEY --output_type json
+column_create Logs_20170303 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170303 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170304 TABLE_NO_KEY --output_type json
+column_create Logs_20170304 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170304 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170305 TABLE_NO_KEY --output_type json
+column_create Logs_20170305 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170305 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170306 TABLE_NO_KEY --output_type json
+column_create Logs_20170306 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170306 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170307 TABLE_NO_KEY --output_type json
+column_create Logs_20170307 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170307 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170308 TABLE_NO_KEY --output_type json
+column_create Logs_20170308 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170308 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170309 TABLE_NO_KEY --output_type json
+column_create Logs_20170309 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170309 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170310 TABLE_NO_KEY --output_type json
+column_create Logs_20170310 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170310 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170311 TABLE_NO_KEY --output_type json
+column_create Logs_20170311 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170311 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170312 TABLE_NO_KEY --output_type json
+column_create Logs_20170312 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170312 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170313 TABLE_NO_KEY --output_type json
+column_create Logs_20170313 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170313 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170314 TABLE_NO_KEY --output_type json
+column_create Logs_20170314 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170314 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170315 TABLE_NO_KEY --output_type json
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170315 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170316 TABLE_NO_KEY --output_type json
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170316 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170317 TABLE_NO_KEY --output_type json
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170317 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170318 TABLE_NO_KEY --output_type json
+column_create Logs_20170318 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170318 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170319 TABLE_NO_KEY --output_type json
+column_create Logs_20170319 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170319 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170320 TABLE_NO_KEY --output_type json
+column_create Logs_20170320 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170320 price COLUMN_SCALAR UInt32 --output_type json
+
+#@disable-logging
+#@generate-series 1 200000 Logs_20170301 '{"timestamp" => (Time.utc(2017, 3, 1) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170302 '{"timestamp" => (Time.utc(2017, 3, 2) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170303 '{"timestamp" => (Time.utc(2017, 3, 3) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170304 '{"timestamp" => (Time.utc(2017, 3, 4) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170305 '{"timestamp" => (Time.utc(2017, 3, 5) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170306 '{"timestamp" => (Time.utc(2017, 3, 6) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170307 '{"timestamp" => (Time.utc(2017, 3, 7) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170308 '{"timestamp" => (Time.utc(2017, 3, 8) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170309 '{"timestamp" => (Time.utc(2017, 3, 9) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170310 '{"timestamp" => (Time.utc(2017, 3, 10) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170311 '{"timestamp" => (Time.utc(2017, 3, 11) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170312 '{"timestamp" => (Time.utc(2017, 3, 12) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170313 '{"timestamp" => (Time.utc(2017, 3, 13) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170314 '{"timestamp" => (Time.utc(2017, 3, 14) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170315 '{"timestamp" => (Time.utc(2017, 3, 15) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170316 '{"timestamp" => (Time.utc(2017, 3, 16) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170317 '{"timestamp" => (Time.utc(2017, 3, 17) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170318 '{"timestamp" => (Time.utc(2017, 3, 18) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170319 '{"timestamp" => (Time.utc(2017, 3, 19) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170320 '{"timestamp" => (Time.utc(2017, 3, 20) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@enable-logging
+
+logical_count Logs --shard_key timestamp --output_type json
+
+#@start-benchmark 4000000 5 logical-select-filter
+#@disable-logging
+logical_select Logs \
+  --shard_key timestamp \
+  --filter 'price < 10' \
+  --limit 0 \
+  --cache no
+#@enable-logging
+#@finish-benchmark

--- a/test/command/suite_benchmark/sharding/logical_select/n_workers/filter.expected
+++ b/test/command/suite_benchmark/sharding/logical_select/n_workers/filter.expected
@@ -1,0 +1,124 @@
+plugin_register sharding --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170301 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170301 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170301 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170302 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170302 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170302 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170303 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170303 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170303 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170304 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170304 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170304 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170305 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170305 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170305 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170306 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170306 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170306 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170307 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170307 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170307 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170308 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170308 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170308 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170309 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170309 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170309 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170310 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170310 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170310 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170311 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170311 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170311 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170312 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170312 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170312 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170313 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170313 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170313 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170314 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170314 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170314 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170315 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170315 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170316 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170316 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170317 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170317 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170318 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170318 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170318 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170319 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170319 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170319 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+table_create Logs_20170320 TABLE_NO_KEY --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170320 timestamp COLUMN_SCALAR Time --output_type json
+[[0,0.0,0.0],true]
+column_create Logs_20170320 price COLUMN_SCALAR UInt32 --output_type json
+[[0,0.0,0.0],true]
+logical_count Logs --shard_key timestamp --output_type json
+[[0,0.0,0.0],4000000]

--- a/test/command/suite_benchmark/sharding/logical_select/n_workers/filter.test
+++ b/test/command/suite_benchmark/sharding/logical_select/n_workers/filter.test
@@ -1,0 +1,98 @@
+plugin_register sharding --output_type json
+
+table_create Logs_20170301 TABLE_NO_KEY --output_type json
+column_create Logs_20170301 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170301 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170302 TABLE_NO_KEY --output_type json
+column_create Logs_20170302 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170302 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170303 TABLE_NO_KEY --output_type json
+column_create Logs_20170303 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170303 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170304 TABLE_NO_KEY --output_type json
+column_create Logs_20170304 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170304 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170305 TABLE_NO_KEY --output_type json
+column_create Logs_20170305 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170305 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170306 TABLE_NO_KEY --output_type json
+column_create Logs_20170306 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170306 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170307 TABLE_NO_KEY --output_type json
+column_create Logs_20170307 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170307 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170308 TABLE_NO_KEY --output_type json
+column_create Logs_20170308 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170308 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170309 TABLE_NO_KEY --output_type json
+column_create Logs_20170309 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170309 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170310 TABLE_NO_KEY --output_type json
+column_create Logs_20170310 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170310 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170311 TABLE_NO_KEY --output_type json
+column_create Logs_20170311 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170311 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170312 TABLE_NO_KEY --output_type json
+column_create Logs_20170312 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170312 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170313 TABLE_NO_KEY --output_type json
+column_create Logs_20170313 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170313 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170314 TABLE_NO_KEY --output_type json
+column_create Logs_20170314 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170314 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170315 TABLE_NO_KEY --output_type json
+column_create Logs_20170315 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170315 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170316 TABLE_NO_KEY --output_type json
+column_create Logs_20170316 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170316 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170317 TABLE_NO_KEY --output_type json
+column_create Logs_20170317 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170317 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170318 TABLE_NO_KEY --output_type json
+column_create Logs_20170318 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170318 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170319 TABLE_NO_KEY --output_type json
+column_create Logs_20170319 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170319 price COLUMN_SCALAR UInt32 --output_type json
+table_create Logs_20170320 TABLE_NO_KEY --output_type json
+column_create Logs_20170320 timestamp COLUMN_SCALAR Time --output_type json
+column_create Logs_20170320 price COLUMN_SCALAR UInt32 --output_type json
+
+#@disable-logging
+#@generate-series 1 200000 Logs_20170301 '{"timestamp" => (Time.utc(2017, 3, 1) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170302 '{"timestamp" => (Time.utc(2017, 3, 2) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170303 '{"timestamp" => (Time.utc(2017, 3, 3) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170304 '{"timestamp" => (Time.utc(2017, 3, 4) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170305 '{"timestamp" => (Time.utc(2017, 3, 5) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170306 '{"timestamp" => (Time.utc(2017, 3, 6) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170307 '{"timestamp" => (Time.utc(2017, 3, 7) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170308 '{"timestamp" => (Time.utc(2017, 3, 8) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170309 '{"timestamp" => (Time.utc(2017, 3, 9) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170310 '{"timestamp" => (Time.utc(2017, 3, 10) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170311 '{"timestamp" => (Time.utc(2017, 3, 11) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170312 '{"timestamp" => (Time.utc(2017, 3, 12) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170313 '{"timestamp" => (Time.utc(2017, 3, 13) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170314 '{"timestamp" => (Time.utc(2017, 3, 14) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170315 '{"timestamp" => (Time.utc(2017, 3, 15) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170316 '{"timestamp" => (Time.utc(2017, 3, 16) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170317 '{"timestamp" => (Time.utc(2017, 3, 17) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170318 '{"timestamp" => (Time.utc(2017, 3, 18) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170319 '{"timestamp" => (Time.utc(2017, 3, 19) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@generate-series 1 200000 Logs_20170320 '{"timestamp" => (Time.utc(2017, 3, 20) + ((i - 1) * 86400) / 200000).strftime("%Y-%m-%d %H:%M:%S"), "price" => rand(1000)}'
+#@enable-logging
+
+logical_count Logs --shard_key timestamp --output_type json
+
+#@start-benchmark 4000000 5 logical-select-filter-2
+#@disable-logging
+logical_select Logs \
+  --shard_key timestamp \
+  --filter 'price < 10' \
+  --limit 0 \
+  --cache no \
+  --n_workers 2
+#@enable-logging
+#@finish-benchmark


### PR DESCRIPTION
`logical_select` selects records in each shard by
`Groonga::TaskExecutor#execute` when the task executor is parallel
(`--n_workers` is 2 or more with Apache Arrow support) and there are
2 or more shards. Each shard is processed in a child context on a
worker thread. Nothing is changed otherwise.

The block evaluated in a child context receives the target table and
the shard key by ID, the range parameters, the cover type and
`match_columns`/`query`/`filter`. It runs
`Groonga::Sharding::ShardSelector` and returns the result set, the
condition expression and expressions to be closed by ID. Temporary
objects created in a child context are registered to the parent 
context. So the parent context can use and close them after the child
context is released. The parent context adds them to shard results in
shard order as before. So dynamic columns, post filter, drilldowns,
sort and output aren't changed.

`Groonga::TaskExecutor#wait_all` doesn't return results now. Results
of succeeded tasks are available by `Groonga::TaskExecutor#results`.
They are available even when one of tasks is failed. So the caller
can close temporary objects created by succeeded tasks on error.
`results` isn't cleared automatically.

`select(N)[SHARD]` in query log is logged by
`Groonga::Sharding::ShardSelector#select` immediately after selection
not by `ShardExecutor#add_result`. The narrowing for initial stage
dynamic columns doesn't log `select(N)[SHARD]` like
`grn_select_create_all_selected_result_table()` in `select`.

Differences in parallel mode:
  * All shards are processed even if one of them is failed. The first
    error is reported.
  * Query log entries of each shard such as `filter(N)[SHARD]` and
    `select(N)[SHARD]` are logged in finished order.
    `#@sort-query-log-operations shard` is added to tests that compare
    query log of multiple shards for the parallel CI job that uses
    `GRN_N_WORKERS_DEFAULT=-1`.

test/command/suite/sharding/logical_select/n_workers/error/invalid_filter.test
confirms that an error in one shard is reported and the result of                                                                             
another shard is closed.                                                                                                                      
                                                                                                                                                
test/command/suite_benchmark/sharding/logical_select/n_workers/filter.test                                                                    
measures `logical_select` with `--n_workers 2` against 20 shards that                                                                         
have 4,000,000 records in total. It's 1.5x faster than `--n_workers 1`                                                                        
on a 20 cores machine.          
