### PR TITLE
expr: add grn_expr_set_query_log_tag_suffix()

### DIFF
--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2017  Brazil
-  Copyright (C) 2019-2025  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2019-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -267,6 +267,25 @@ grn_expr_set_query_log_tag_prefix(grn_ctx *ctx,
                                   int prefix_len);
 GRN_API const char *
 grn_expr_get_query_log_tag_prefix(grn_ctx *ctx, grn_obj *expr);
+
+/**
+ * \brief Set the suffix of the tag for query log entries of the
+ *        expression such as `filter(N)`. For example,
+ *        `filter(N)[SUFFIX]: CONDITION` is logged when this is
+ *        `[SUFFIX]`.
+ *
+ * \since 15.1.0
+ */
+GRN_API grn_rc
+grn_expr_set_query_log_tag_suffix(grn_ctx *ctx,
+                                  grn_obj *expr,
+                                  const char *suffix,
+                                  int suffix_len);
+/**
+ * \since 15.1.0
+ */
+GRN_API const char *
+grn_expr_get_query_log_tag_suffix(grn_ctx *ctx, grn_obj *expr);
 
 GRN_API grn_rc
 grn_expr_set_parent(grn_ctx *ctx, grn_obj *expr, grn_obj *parent);

--- a/lib/expr.c
+++ b/lib/expr.c
@@ -600,6 +600,8 @@ grn_expr_open(grn_ctx *ctx,
     GRN_PTR_INIT(&expr->objs, GRN_OBJ_VECTOR, GRN_ID_NIL);
     GRN_TEXT_INIT(&expr->query_log_tag_prefix, 0);
     GRN_TEXT_PUTC(ctx, &expr->query_log_tag_prefix, '\0');
+    GRN_TEXT_INIT(&expr->query_log_tag_suffix, 0);
+    GRN_TEXT_PUTC(ctx, &expr->query_log_tag_suffix, '\0');
     expr->parent = NULL;
     expr->condition = NULL;
     expr->vars = NULL;
@@ -632,6 +634,7 @@ grn_expr_open(grn_ctx *ctx,
     GRN_OBJ_FIN(ctx, &expr->dfi);
     GRN_OBJ_FIN(ctx, &expr->objs);
     GRN_OBJ_FIN(ctx, &expr->query_log_tag_prefix);
+    GRN_OBJ_FIN(ctx, &expr->query_log_tag_suffix);
     GRN_FREE(expr);
     expr = NULL;
   }
@@ -745,6 +748,8 @@ grn_expr_create(grn_ctx *ctx, const char *name, unsigned int name_size)
     GRN_PTR_INIT(&expr->objs, GRN_OBJ_VECTOR, GRN_ID_NIL);
     GRN_TEXT_INIT(&expr->query_log_tag_prefix, 0);
     GRN_TEXT_PUTC(ctx, &expr->query_log_tag_prefix, '\0');
+    GRN_TEXT_INIT(&expr->query_log_tag_suffix, 0);
+    GRN_TEXT_PUTC(ctx, &expr->query_log_tag_suffix, '\0');
     expr->parent = NULL;
     expr->condition = NULL;
     expr->code0 = NULL;
@@ -781,6 +786,7 @@ grn_expr_create(grn_ctx *ctx, const char *name, unsigned int name_size)
     GRN_OBJ_FIN(ctx, &expr->dfi);
     GRN_OBJ_FIN(ctx, &expr->objs);
     GRN_OBJ_FIN(ctx, &expr->query_log_tag_prefix);
+    GRN_OBJ_FIN(ctx, &expr->query_log_tag_suffix);
     GRN_FREE(expr);
     expr = NULL;
   }
@@ -801,6 +807,7 @@ grn_expr_close(grn_ctx *ctx, grn_obj *expr)
   }
   */
   GRN_OBJ_FIN(ctx, &(e->query_log_tag_prefix));
+  GRN_OBJ_FIN(ctx, &(e->query_log_tag_suffix));
   if (e->cache.codes) {
     grn_expr_executor_fin(ctx, &(e->cache.executor));
   }
@@ -8090,6 +8097,41 @@ grn_expr_get_query_log_tag_prefix(grn_ctx *ctx, grn_obj *expr)
   grn_expr *e = (grn_expr *)expr;
   const char *prefix = GRN_TEXT_VALUE(&(e->query_log_tag_prefix));
   GRN_API_RETURN(prefix);
+}
+
+grn_rc
+grn_expr_set_query_log_tag_suffix(grn_ctx *ctx,
+                                  grn_obj *expr,
+                                  const char *suffix,
+                                  int suffix_len)
+{
+  GRN_API_ENTER;
+  if (suffix_len < 0) {
+    if (suffix) {
+      suffix_len = strlen(suffix);
+    } else {
+      suffix_len = 0;
+    }
+  }
+
+  grn_expr *e = (grn_expr *)expr;
+  if (suffix_len == 0) {
+    GRN_BULK_REWIND(&(e->query_log_tag_suffix));
+  } else {
+    GRN_TEXT_SET(ctx, &(e->query_log_tag_suffix), suffix, suffix_len);
+  }
+  GRN_TEXT_PUTC(ctx, &(e->query_log_tag_suffix), '\0');
+
+  GRN_API_RETURN(GRN_SUCCESS);
+}
+
+const char *
+grn_expr_get_query_log_tag_suffix(grn_ctx *ctx, grn_obj *expr)
+{
+  GRN_API_ENTER;
+  grn_expr *e = (grn_expr *)expr;
+  const char *suffix = GRN_TEXT_VALUE(&(e->query_log_tag_suffix));
+  GRN_API_RETURN(suffix);
 }
 
 grn_rc

--- a/lib/grn_expr.h
+++ b/lib/grn_expr.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2013-2018  Brazil
-  Copyright (C) 2018-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -59,6 +59,7 @@ struct _grn_expr {
   } cache;
 
   grn_obj query_log_tag_prefix;
+  grn_obj query_log_tag_suffix;
   grn_obj *parent;
   grn_obj *condition;
 };

--- a/lib/mrb/mrb_expr.c
+++ b/lib/mrb/mrb_expr.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2013-2018  Brazil
-  Copyright (C) 2019-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2019-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -709,6 +709,64 @@ mrb_grn_expression_set_condition(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_grn_expression_get_query_log_tag_prefix(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_obj *expr;
+  const char *prefix;
+
+  expr = DATA_PTR(self);
+  prefix = grn_expr_get_query_log_tag_prefix(ctx, expr);
+  return mrb_str_new_cstr(mrb, prefix);
+}
+
+static mrb_value
+mrb_grn_expression_set_query_log_tag_prefix(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_obj *expr;
+  char *prefix = NULL;
+  mrb_int prefix_length = 0;
+
+  mrb_get_args(mrb, "s!", &prefix, &prefix_length);
+
+  expr = DATA_PTR(self);
+  grn_expr_set_query_log_tag_prefix(ctx, expr, prefix, (int)prefix_length);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
+mrb_grn_expression_get_query_log_tag_suffix(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_obj *expr;
+  const char *suffix;
+
+  expr = DATA_PTR(self);
+  suffix = grn_expr_get_query_log_tag_suffix(ctx, expr);
+  return mrb_str_new_cstr(mrb, suffix);
+}
+
+static mrb_value
+mrb_grn_expression_set_query_log_tag_suffix(mrb_state *mrb, mrb_value self)
+{
+  grn_ctx *ctx = (grn_ctx *)mrb->ud;
+  grn_obj *expr;
+  char *suffix = NULL;
+  mrb_int suffix_length = 0;
+
+  mrb_get_args(mrb, "s!", &suffix, &suffix_length);
+
+  expr = DATA_PTR(self);
+  grn_expr_set_query_log_tag_suffix(ctx, expr, suffix, (int)suffix_length);
+  grn_mrb_ctx_check(mrb);
+
+  return mrb_nil_value();
+}
+
+static mrb_value
 mrb_grn_expression_take_object(mrb_state *mrb, mrb_value self)
 {
   grn_ctx *ctx = (grn_ctx *)mrb->ud;
@@ -1223,6 +1281,26 @@ grn_mrb_expr_init(grn_ctx *ctx)
                     klass,
                     "condition=",
                     mrb_grn_expression_set_condition,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(mrb,
+                    klass,
+                    "query_log_tag_prefix",
+                    mrb_grn_expression_get_query_log_tag_prefix,
+                    MRB_ARGS_NONE());
+  mrb_define_method(mrb,
+                    klass,
+                    "query_log_tag_prefix=",
+                    mrb_grn_expression_set_query_log_tag_prefix,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(mrb,
+                    klass,
+                    "query_log_tag_suffix",
+                    mrb_grn_expression_get_query_log_tag_suffix,
+                    MRB_ARGS_NONE());
+  mrb_define_method(mrb,
+                    klass,
+                    "query_log_tag_suffix=",
+                    mrb_grn_expression_set_query_log_tag_suffix,
                     MRB_ARGS_REQ(1));
   mrb_define_method(mrb,
                     klass,

--- a/lib/table_selector.c
+++ b/lib/table_selector.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2010-2018  Brazil
-  Copyright (C) 2018-2024  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -2356,9 +2356,10 @@ grn_table_selector_select(grn_ctx *ctx,
         ctx,
         GRN_QUERY_LOG_SIZE,
         ":",
-        "%sfilter(%d)%s",
+        "%sfilter(%d)%s%s",
         grn_expr_get_query_log_tag_prefix(ctx, table_selector->expr),
         grn_table_size(ctx, data->result_set),
+        grn_expr_get_query_log_tag_suffix(ctx, table_selector->expr),
         inspect_condition(ctx, &condition_inspect_buffer, si, e));
       if (ctx->rc != GRN_SUCCESS) {
         if (result_set_created) {

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -822,6 +822,7 @@ module Groonga
                                        shard_key,
                                        @target_range,
                                        @cover_type,
+                                       shard_table_name: @shard.table_name,
                                        **options)
           begin
             selector.select
@@ -838,6 +839,7 @@ module Groonga
 
         def apply_post_filter(table)
           expression = create_expression(table)
+          expression.query_log_tag_suffix = "[#{@shard.table_name}]"
           expression.parse(@post_filter)
           table.select(expression)
         end

--- a/plugins/sharding/shard_selector.rb
+++ b/plugins/sharding/shard_selector.rb
@@ -17,15 +17,19 @@ module Groonga
       # @param shard_key [Groonga::Column] The shard key column.
       # @param target_range An object that has `min`, `min_border`,
       #   `max` and `max_border`.
+      # @param shard_table_name [String] The shard table name for
+      #   query log. `filter(N)[SHARD_TABLE_NAME]` is logged.
       # @param cover_type [Symbol] How the target range covers the
       #   shard: `:all`, `:partial_min`, `:partial_max` or
       #   `:partial_min_and_max`.
       def initialize(table, shard_key, target_range, cover_type,
+                     shard_table_name:,
                      match_columns: nil, query: nil, filter: nil)
         @table = table
         @shard_key = shard_key
         @target_range = target_range
         @cover_type = cover_type
+        @shard_table_name = shard_table_name
         @match_columns = match_columns
         @query = query
         @filter = filter
@@ -79,6 +83,7 @@ module Groonga
       def filter_table
         expression = Expression.create(@table)
         @expressions << expression
+        expression.query_log_tag_suffix = "[#{@shard_table_name}]"
         yield(expression)
         [@table.select(expression), expression]
       end

--- a/test/command/suite/ruby/eval/expression/query_log_tag_prefix.expected
+++ b/test/command/suite/ruby/eval/expression/query_log_tag_prefix.expected
@@ -1,0 +1,8 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+ruby_eval "expression = Groonga::Expression.create(Groonga::Context.instance['Memos']); before = expression.query_log_tag_prefix; expression.query_log_tag_prefix = 'tag.'; after = expression.query_log_tag_prefix; expression.query_log_tag_prefix = nil; [before, after, expression.query_log_tag_prefix].inspect"
+[[0,0.0,0.0],{"value":"[\"\", \"tag.\", \"\"]"}]

--- a/test/command/suite/ruby/eval/expression/query_log_tag_prefix.test
+++ b/test/command/suite/ruby/eval/expression/query_log_tag_prefix.test
@@ -1,0 +1,8 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+table_create Memos TABLE_NO_KEY
+column_create Memos price COLUMN_SCALAR UInt32
+
+ruby_eval "expression = Groonga::Expression.create(Groonga::Context.instance['Memos']); before = expression.query_log_tag_prefix; expression.query_log_tag_prefix = 'tag.'; after = expression.query_log_tag_prefix; expression.query_log_tag_prefix = nil; [before, after, expression.query_log_tag_prefix].inspect"

--- a/test/command/suite/ruby/eval/expression/query_log_tag_suffix.expected
+++ b/test/command/suite/ruby/eval/expression/query_log_tag_suffix.expected
@@ -1,0 +1,8 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+table_create Memos TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Memos price COLUMN_SCALAR UInt32
+[[0,0.0,0.0],true]
+ruby_eval "expression = Groonga::Expression.create(Groonga::Context.instance['Memos']); before = expression.query_log_tag_suffix; expression.query_log_tag_suffix = '[tag]'; after = expression.query_log_tag_suffix; expression.query_log_tag_suffix = nil; [before, after, expression.query_log_tag_suffix].inspect"
+[[0,0.0,0.0],{"value":"[\"\", \"[tag]\", \"\"]"}]

--- a/test/command/suite/ruby/eval/expression/query_log_tag_suffix.test
+++ b/test/command/suite/ruby/eval/expression/query_log_tag_suffix.test
@@ -1,0 +1,8 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+table_create Memos TABLE_NO_KEY
+column_create Memos price COLUMN_SCALAR UInt32
+
+ruby_eval "expression = Groonga::Expression.create(Groonga::Context.instance['Memos']); before = expression.query_log_tag_suffix; expression.query_log_tag_suffix = '[tag]'; after = expression.query_log_tag_suffix; expression.query_log_tag_suffix = nil; [before, after, expression.query_log_tag_suffix].inspect"

--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.expected
@@ -91,11 +91,11 @@ logical_select Logs   --shard_key timestamp   --columns[filtered_id].stage filte
   ]
 ]
 #>logical_select --columns[filtered_id].flags "COLUMN_SCALAR" --columns[filtered_id].stage "filtered" --columns[filtered_id].type "UInt32" --columns[filtered_id].value "_id" --filter "price < 910" --logical_table "Logs" --output_columns "_id,filtered_id,price" --shard_key "timestamp"
-#:000000000000000 filter(1): Logs_20170315.price less 910
+#:000000000000000 filter(1)[Logs_20170315]: Logs_20170315.price less 910
 #:000000000000000 select(1)[Logs_20170315]
-#:000000000000000 filter(2): Logs_20170316.price less 910
+#:000000000000000 filter(2)[Logs_20170316]: Logs_20170316.price less 910
 #:000000000000000 select(2)[Logs_20170316]
-#:000000000000000 filter(2): Logs_20170317.price less 910
+#:000000000000000 filter(2)[Logs_20170317]: Logs_20170317.price less 910
 #:000000000000000 select(2)[Logs_20170317]
 #:000000000000000 columns[filtered_id](1)
 #:000000000000000 columns[filtered_id](2)

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.expected
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.expected
@@ -38,9 +38,9 @@ logical_select Logs   --shard_key timestamp   --columns[content].stage initial  
 #:000000000000000 filter(3): true
 #:000000000000000 columns[content](2)
 #:000000000000000 columns[content](3)
-#:000000000000000 filter(1): (match columns) match "Book"
+#:000000000000000 filter(1)[Logs_20170315]: (match columns) match "Book"
 #:000000000000000 select(1)[Logs_20170315]
-#:000000000000000 filter(1): (match columns) match "Book"
+#:000000000000000 filter(1)[Logs_20170316]: (match columns) match "Book"
 #:000000000000000 select(1)[Logs_20170316]
 #:000000000000000 output(2)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/load_table/key.expected
+++ b/test/command/suite/sharding/logical_select/load_table/key.expected
@@ -64,9 +64,9 @@ logical_select   --logical_table Logs   --shard_key timestamp   --filter true   
   ]
 ]
 #>logical_select --filter "true" --limit "0" --load_columns "_key, original_id, timestamp_text" --load_table "Logs" --load_values "cast_loose(ShortText, timestamp, '') + ':' + _id, _id, timestamp" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 filter(2): true
+#:000000000000000 filter(2)[Logs_20150203]: true
 #:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 filter(1): true
+#:000000000000000 filter(1)[Logs_20150204]: true
 #:000000000000000 select(1)[Logs_20150204]
 #:000000000000000 load(2)[Logs_20150203]: [Logs][2]
 #:000000000000000 load(1)[Logs_20150204]: [Logs][3]


### PR DESCRIPTION
`filter(N)` in query log is logged as `PREFIXfilter(N)SUFFIX: CONDITION` now. `grn_expr_set_query_log_tag_prefix()` already exists for the prefix. `grn_expr_set_query_log_tag_suffix()` is added for the suffix.

`Groonga::Expression#query_log_tag_prefix`, `#query_log_tag_prefix=`, `#query_log_tag_suffix` and `#query_log_tag_suffix=` are also added to mruby bindings.

`logical_select` uses the suffix to show which shard is filtered:

    filter(2)[Logs_20170316]: Logs_20170316.price less 910

It's consistent with `select(2)[Logs_20170316]`. This is useful when shards are processed in parallel because query log entries of shards are logged in finished order.

`Groonga::Sharding::ShardSelector` requires `shard_table_name:` for it. `post_filter` in `logical_select` also uses the suffix.