### PR TITLE
logical_select: add `--shard[LABEL].table`

### DIFF
--- a/plugins/sharding.rb
+++ b/plugins/sharding.rb
@@ -1,6 +1,7 @@
 require "sharding/parameters"
 require "sharding/range_expression_builder"
 require "sharding/shard_selector"
+require "sharding/specified_shard"
 require "sharding/logical_enumerator"
 require "sharding/keys_parsable"
 require "sharding/window"

--- a/plugins/sharding/logical_enumerator.rb
+++ b/plugins/sharding/logical_enumerator.rb
@@ -33,8 +33,12 @@ module Groonga
         context = Context.instance
         each_shard_with_around(order) do |prev_shard, current_shard, next_shard|
           shard_range_data = current_shard.range_data
-          shard_range = nil
+          unless shard_range_data
+            yield(current_shard, nil)
+            next
+          end
 
+          shard_range = nil
           if shard_range_data.day.nil?
             if order == :ascending
               if next_shard
@@ -69,7 +73,7 @@ module Groonga
         unref_immediately = @options.fetch(:unref_immediately, false)
         shards = [nil]
         begin
-          each_prefix_shard(order) do |shard|
+          each_shard(order) do |shard|
             previous_shard = shards.last
             if previous_shard
               shard.previous_shard = previous_shard
@@ -94,6 +98,14 @@ module Groonga
         end
       end
 
+      def each_shard(order, &block)
+        if @specified_shards.empty?
+          each_prefix_shard(order, &block)
+        else
+          each_specified_shard(order, &block)
+        end
+      end
+
       def each_prefix_shard(order)
         context = Context.instance
         prefix = "#{@logical_table}_"
@@ -103,6 +115,17 @@ module Groonga
           shard_range_data = parse_shard_range_data(name[prefix.size..-1])
           next unless shard_range_data
           yield(Shard.new(name, @shard_key_name, shard_range_data))
+        end
+      end
+
+      def each_specified_shard(order)
+        specified_shards = @specified_shards
+        specified_shards = specified_shards.reverse if order == :descending
+        specified_shards.each do |specified_shard|
+          # TODO:
+          # Generate `range_data` from the labels.
+          # Or specify it using something like `shard[xxx].range`.
+          yield(Shard.new(specified_shard.table_name, @shard_key_name, nil))
         end
       end
 
@@ -119,7 +142,8 @@ module Groonga
 
       def initialize_parameters
         @logical_table = @input[:logical_table]
-        if @logical_table.nil?
+        @specified_shards = @options.fetch(:specified_shards, [])
+        if @logical_table.nil? and @specified_shards.empty?
           raise InvalidArgument, "[#{@command_name}] logical_table is missing"
         end
 
@@ -277,6 +301,18 @@ module Groonga
 
         def cover_type(shard_range)
           return :all if @min.nil? and @max.nil?
+
+          unless shard_range
+            # If you are not able to set `shard_range` for `--shard[xxx].table`,
+            # use only `@min` and `@max` as conditions.
+            if @min and @max
+              return :partial_min_and_max
+            elsif @min
+              return :partial_min
+            else
+              return :partial_max
+            end
+          end
 
           if @min and @max
             return :none unless in_min?(shard_range)

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -111,6 +111,10 @@ module Groonga
         end
         dynamic_columns = DynamicColumns.parse("[logical_select]", input)
         key << dynamic_columns.cache_key
+        specified_shards = SpecifiedShard.parse("[logical_select]", input)
+        specified_shards.each do |specified_shard|
+          key << "#{specified_shard.table_name}\0"
+        end
         key
       end
 
@@ -377,7 +381,10 @@ module Groonga
         attr_reader :expressions
         def initialize(input)
           @input = input
-          @enumerator = LogicalEnumerator.new("logical_select", @input)
+          @enumerator =
+            LogicalEnumerator.new("logical_select",
+                                  @input,
+                                  specified_shards: SpecifiedShard.parse("[logical_select]", @input))
           @match_columns = @input[:match_columns]
           @query = @input[:query]
           @filter = @input[:filter]

--- a/plugins/sharding/sources.am
+++ b/plugins/sharding/sources.am
@@ -9,6 +9,7 @@ sharding_scripts =				\
 	parameters.rb				\
 	range_expression_builder.rb		\
 	shard_selector.rb			\
+	specified_shard.rb			\
 	keys_parsable.rb			\
 	dynamic_columns.rb			\
 	drilldown_executor.rb			\

--- a/plugins/sharding/specified_shard.rb
+++ b/plugins/sharding/specified_shard.rb
@@ -1,0 +1,60 @@
+module Groonga
+  module Sharding
+    class SpecifiedShard
+      class << self
+        def parse(tag, input)
+          shards = []
+          labeled_arguments = LabeledArguments.new(input, /shards?/)
+          labeled_arguments.each do |label, arguments|
+            shards << new(tag, label, arguments)
+          end
+
+          # Numeric labels such as 1, 2 and 10 are sorted numerically.
+          # Other labels are sorted as strings.
+          numeric = shards.all? do |shard|
+            /\A\d+\z/.match?(shard.label)
+          end
+          if numeric
+            shards.sort_by {|shard| shard.label.to_i}
+          else
+            shards.sort_by(&:label)
+          end
+        end
+      end
+
+      attr_reader :label
+      attr_reader :table_name
+      def initialize(tag, label, arguments)
+        @tag = tag
+        @label = label
+        @table_name = arguments["table"]
+        validate_table_name
+      end
+
+      private
+      def validate_table_name
+        if @table_name.nil?
+          raise InvalidArgument, "#{error_message_tag} table is missing"
+        end
+
+        table = Context.instance[@table_name]
+        begin
+          unless table
+            raise InvalidArgument, "#{error_message_tag} table doesn't exist: <#{@table_name}>"
+          end
+          unless table.is_a?(Table)
+            raise InvalidArgument, "#{error_message_tag} table must be a table: <#{@table_name}>"
+          end
+        ensure
+          table.unref if table
+        end
+
+        true
+      end
+
+      def error_message_tag
+        "#{@tag}[shards][#{@label}]"
+      end
+    end
+  end
+end

--- a/test/command/suite/sharding/logical_select/shard/basic.expected
+++ b/test/command/suite/sharding/logical_select/shard/basic.expected
@@ -1,0 +1,154 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period1 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period2 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period2 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period3 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period3 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+[[0,0.0,0.0],true]
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+[[0,0.0,0.0],4]
+logical_select   --shard_key timestamp   --shard[20150203].table Logs_period1   --shard[20150204].table Logs_period2   --shard[20150205].table Logs_period3
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "memo",
+          "ShortText"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        1,
+        "2015-02-03 12:49:00",
+        1422935340.0
+      ],
+      [
+        2,
+        "2015-02-03 23:59:59",
+        1422975599.0
+      ],
+      [
+        1,
+        "2015-02-04 00:00:00",
+        1422975600.0
+      ],
+      [
+        2,
+        "2015-02-04 13:49:00",
+        1423025340.0
+      ],
+      [
+        3,
+        "2015-02-04 13:50:00",
+        1423025400.0
+      ],
+      [
+        1,
+        "2015-02-05 13:49:00",
+        1423111740.0
+      ],
+      [
+        2,
+        "2015-02-05 13:50:00",
+        1423111800.0
+      ],
+      [
+        3,
+        "2015-02-05 13:51:00",
+        1423111860.0
+      ],
+      [
+        4,
+        "2015-02-05 13:52:00",
+        1423111920.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/basic.test
+++ b/test/command/suite/sharding/logical_select/shard/basic.test
@@ -1,0 +1,75 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+table_create Times_period1 TABLE_PAT_KEY Time
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+
+table_create Logs_period2 TABLE_NO_KEY
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+table_create Times_period2 TABLE_PAT_KEY Time
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+
+table_create Logs_period3 TABLE_NO_KEY
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+table_create Times_period3 TABLE_PAT_KEY Time
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+
+logical_select \
+  --shard_key timestamp \
+  --shard[20150203].table Logs_period1 \
+  --shard[20150204].table Logs_period2 \
+  --shard[20150205].table Logs_period3

--- a/test/command/suite/sharding/logical_select/shard/invalid/missing_table.expected
+++ b/test/command/suite/sharding/logical_select/shard/invalid/missing_table.expected
@@ -1,0 +1,8 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+logical_select   --shard_key timestamp   --shard[1].dummy Logs_period1.timestamp
+[[[-22,0.0,0.0],"[logical_select][shards][1] table is missing"]]

--- a/test/command/suite/sharding/logical_select/shard/invalid/missing_table.test
+++ b/test/command/suite/sharding/logical_select/shard/invalid/missing_table.test
@@ -1,0 +1,10 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+
+logical_select \
+  --shard_key timestamp \
+  --shard[1].dummy Logs_period1.timestamp

--- a/test/command/suite/sharding/logical_select/shard/invalid/nonexistent_table.expected
+++ b/test/command/suite/sharding/logical_select/shard/invalid/nonexistent_table.expected
@@ -1,0 +1,13 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+logical_select   --shard_key timestamp   --shard[1].table Nonexistent
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[logical_select][shards][1] table doesn't exist: <Nonexistent>"
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/invalid/nonexistent_table.test
+++ b/test/command/suite/sharding/logical_select/shard/invalid/nonexistent_table.test
@@ -1,0 +1,7 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+logical_select \
+  --shard_key timestamp \
+  --shard[1].table Nonexistent

--- a/test/command/suite/sharding/logical_select/shard/invalid/not_table.expected
+++ b/test/command/suite/sharding/logical_select/shard/invalid/not_table.expected
@@ -1,0 +1,17 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+logical_select   --shard_key timestamp   --shard[1].table Logs_period1.timestamp
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[logical_select][shards][1] table must be a table: <Logs_period1.timestamp>"
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/invalid/not_table.test
+++ b/test/command/suite/sharding/logical_select/shard/invalid/not_table.test
@@ -1,0 +1,10 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+
+logical_select \
+  --shard_key timestamp \
+  --shard[1].table Logs_period1.timestamp

--- a/test/command/suite/sharding/logical_select/shard/label/non_numeric.expected
+++ b/test/command/suite/sharding/logical_select/shard/label/non_numeric.expected
@@ -1,0 +1,154 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period1 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period2 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period2 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period3 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period3 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+[[0,0.0,0.0],true]
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+[[0,0.0,0.0],4]
+logical_select   --shard_key timestamp   --shard[period3].table Logs_period3   --shard[period2].table Logs_period2   --shard[period1].table Logs_period1
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "memo",
+          "ShortText"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        1,
+        "2015-02-03 12:49:00",
+        1422935340.0
+      ],
+      [
+        2,
+        "2015-02-03 23:59:59",
+        1422975599.0
+      ],
+      [
+        1,
+        "2015-02-04 00:00:00",
+        1422975600.0
+      ],
+      [
+        2,
+        "2015-02-04 13:49:00",
+        1423025340.0
+      ],
+      [
+        3,
+        "2015-02-04 13:50:00",
+        1423025400.0
+      ],
+      [
+        1,
+        "2015-02-05 13:49:00",
+        1423111740.0
+      ],
+      [
+        2,
+        "2015-02-05 13:50:00",
+        1423111800.0
+      ],
+      [
+        3,
+        "2015-02-05 13:51:00",
+        1423111860.0
+      ],
+      [
+        4,
+        "2015-02-05 13:52:00",
+        1423111920.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/label/non_numeric.test
+++ b/test/command/suite/sharding/logical_select/shard/label/non_numeric.test
@@ -1,0 +1,75 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+table_create Times_period1 TABLE_PAT_KEY Time
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+
+table_create Logs_period2 TABLE_NO_KEY
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+table_create Times_period2 TABLE_PAT_KEY Time
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+
+table_create Logs_period3 TABLE_NO_KEY
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+table_create Times_period3 TABLE_PAT_KEY Time
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+
+logical_select \
+  --shard_key timestamp \
+  --shard[period3].table Logs_period3 \
+  --shard[period2].table Logs_period2 \
+  --shard[period1].table Logs_period1

--- a/test/command/suite/sharding/logical_select/shard/label/numeric.expected
+++ b/test/command/suite/sharding/logical_select/shard/label/numeric.expected
@@ -1,0 +1,154 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period1 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period2 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period2 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period3 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period3 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+[[0,0.0,0.0],true]
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+[[0,0.0,0.0],4]
+logical_select   --shard_key timestamp   --shard[3].table Logs_period3   --shard[2].table Logs_period2   --shard[1].table Logs_period1
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "memo",
+          "ShortText"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        1,
+        "2015-02-03 12:49:00",
+        1422935340.0
+      ],
+      [
+        2,
+        "2015-02-03 23:59:59",
+        1422975599.0
+      ],
+      [
+        1,
+        "2015-02-04 00:00:00",
+        1422975600.0
+      ],
+      [
+        2,
+        "2015-02-04 13:49:00",
+        1423025340.0
+      ],
+      [
+        3,
+        "2015-02-04 13:50:00",
+        1423025400.0
+      ],
+      [
+        1,
+        "2015-02-05 13:49:00",
+        1423111740.0
+      ],
+      [
+        2,
+        "2015-02-05 13:50:00",
+        1423111800.0
+      ],
+      [
+        3,
+        "2015-02-05 13:51:00",
+        1423111860.0
+      ],
+      [
+        4,
+        "2015-02-05 13:52:00",
+        1423111920.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/label/numeric.test
+++ b/test/command/suite/sharding/logical_select/shard/label/numeric.test
@@ -1,0 +1,75 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+table_create Times_period1 TABLE_PAT_KEY Time
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+
+table_create Logs_period2 TABLE_NO_KEY
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+table_create Times_period2 TABLE_PAT_KEY Time
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+
+table_create Logs_period3 TABLE_NO_KEY
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+table_create Times_period3 TABLE_PAT_KEY Time
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+
+logical_select \
+  --shard_key timestamp \
+  --shard[3].table Logs_period3 \
+  --shard[2].table Logs_period2 \
+  --shard[1].table Logs_period1

--- a/test/command/suite/sharding/logical_select/shard/range.expected
+++ b/test/command/suite/sharding/logical_select/shard/range.expected
@@ -1,0 +1,124 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period1 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period2 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period2 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period3 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period3 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+[[0,0.0,0.0],true]
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+[[0,0.0,0.0],4]
+logical_select   --shard_key timestamp   --shard[20150203].table Logs_period1   --shard[20150204].table Logs_period2   --shard[20150205].table Logs_period3   --min "2015-02-04 13:50:00"   --min_border "include"   --max "2015-02-05 13:50:00"   --max_border "include"
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        3
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "memo",
+          "ShortText"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        3,
+        "2015-02-04 13:50:00",
+        1423025400.0
+      ],
+      [
+        1,
+        "2015-02-05 13:49:00",
+        1423111740.0
+      ],
+      [
+        2,
+        "2015-02-05 13:50:00",
+        1423111800.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/range.test
+++ b/test/command/suite/sharding/logical_select/shard/range.test
@@ -1,0 +1,79 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+table_create Times_period1 TABLE_PAT_KEY Time
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+
+table_create Logs_period2 TABLE_NO_KEY
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+table_create Times_period2 TABLE_PAT_KEY Time
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+
+table_create Logs_period3 TABLE_NO_KEY
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+table_create Times_period3 TABLE_PAT_KEY Time
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+
+logical_select \
+  --shard_key timestamp \
+  --shard[20150203].table Logs_period1 \
+  --shard[20150204].table Logs_period2 \
+  --shard[20150205].table Logs_period3 \
+  --min "2015-02-04 13:50:00" \
+  --min_border "include" \
+  --max "2015-02-05 13:50:00" \
+  --max_border "include"

--- a/test/command/suite/sharding/logical_select/shard/subset.expected
+++ b/test/command/suite/sharding/logical_select/shard/subset.expected
@@ -1,0 +1,139 @@
+plugin_register sharding
+[[0,0.0,0.0],true]
+table_create Logs_period1 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period1 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period2 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period2 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+[[0,0.0,0.0],true]
+table_create Logs_period3 TABLE_NO_KEY
+[[0,0.0,0.0],true]
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+[[0,0.0,0.0],true]
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+table_create Times_period3 TABLE_PAT_KEY Time
+[[0,0.0,0.0],true]
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+[[0,0.0,0.0],true]
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+[[0,0.0,0.0],2]
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+[[0,0.0,0.0],3]
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+[[0,0.0,0.0],4]
+logical_select   --shard_key timestamp   --shard[20150203].table Logs_period1   --shard[20150205].table Logs_period3
+[
+  [
+    0,
+    0.0,
+    0.0
+  ],
+  [
+    [
+      [
+        6
+      ],
+      [
+        [
+          "_id",
+          "UInt32"
+        ],
+        [
+          "memo",
+          "ShortText"
+        ],
+        [
+          "timestamp",
+          "Time"
+        ]
+      ],
+      [
+        1,
+        "2015-02-03 12:49:00",
+        1422935340.0
+      ],
+      [
+        2,
+        "2015-02-03 23:59:59",
+        1422975599.0
+      ],
+      [
+        1,
+        "2015-02-05 13:49:00",
+        1423111740.0
+      ],
+      [
+        2,
+        "2015-02-05 13:50:00",
+        1423111800.0
+      ],
+      [
+        3,
+        "2015-02-05 13:51:00",
+        1423111860.0
+      ],
+      [
+        4,
+        "2015-02-05 13:52:00",
+        1423111920.0
+      ]
+    ]
+  ]
+]

--- a/test/command/suite/sharding/logical_select/shard/subset.test
+++ b/test/command/suite/sharding/logical_select/shard/subset.test
@@ -1,0 +1,74 @@
+#@on-error omit
+plugin_register sharding
+#@on-error default
+
+table_create Logs_period1 TABLE_NO_KEY
+column_create Logs_period1 timestamp COLUMN_SCALAR Time
+column_create Logs_period1 memo COLUMN_SCALAR ShortText
+table_create Times_period1 TABLE_PAT_KEY Time
+column_create Times_period1 timestamp_index COLUMN_INDEX Logs_period1 timestamp
+
+table_create Logs_period2 TABLE_NO_KEY
+column_create Logs_period2 timestamp COLUMN_SCALAR Time
+column_create Logs_period2 memo COLUMN_SCALAR ShortText
+table_create Times_period2 TABLE_PAT_KEY Time
+column_create Times_period2 timestamp_index COLUMN_INDEX Logs_period2 timestamp
+
+table_create Logs_period3 TABLE_NO_KEY
+column_create Logs_period3 timestamp COLUMN_SCALAR Time
+column_create Logs_period3 memo COLUMN_SCALAR ShortText
+table_create Times_period3 TABLE_PAT_KEY Time
+column_create Times_period3 timestamp_index COLUMN_INDEX Logs_period3 timestamp
+
+load --table Logs_period1
+[
+{
+  "timestamp": "2015-02-03 12:49:00",
+  "memo":      "2015-02-03 12:49:00"
+},
+{
+  "timestamp": "2015-02-03 23:59:59",
+  "memo":      "2015-02-03 23:59:59"
+}
+]
+
+load --table Logs_period2
+[
+{
+  "timestamp": "2015-02-04 00:00:00",
+  "memo":      "2015-02-04 00:00:00"
+},
+{
+  "timestamp": "2015-02-04 13:49:00",
+  "memo":      "2015-02-04 13:49:00"
+},
+{
+  "timestamp": "2015-02-04 13:50:00",
+  "memo":      "2015-02-04 13:50:00"
+}
+]
+
+load --table Logs_period3
+[
+{
+  "timestamp": "2015-02-05 13:49:00",
+  "memo":      "2015-02-05 13:49:00"
+},
+{
+  "timestamp": "2015-02-05 13:50:00",
+  "memo":      "2015-02-05 13:50:00"
+},
+{
+  "timestamp": "2015-02-05 13:51:00",
+  "memo":      "2015-02-05 13:51:00"
+},
+{
+  "timestamp": "2015-02-05 13:52:00",
+  "memo":      "2015-02-05 13:52:00"
+}
+]
+
+logical_select \
+  --shard_key timestamp \
+  --shard[20150203].table Logs_period1 \
+  --shard[20150205].table Logs_period3


### PR DESCRIPTION
`logical_select` finds actual tables by "{logical_table}_{yyyymm}" naming rule.
You can't use `logical_select` for actual tables that don't follow the naming rule.

This adds `--shard[LABEL].table`. You can specify actual tables explicitly by it:

```
logical_select \
  --shard_key timestamp \
  --shard[1].table Logs_a \
  --shard[2].table Logs_b
```