### PR TITLE
sharding logical_select: process drilldowns in parallel

### DIFF
--- a/dockerfiles/alpine.dockerfile
+++ b/dockerfiles/alpine.dockerfile
@@ -58,7 +58,7 @@ RUN \
 RUN \
   gem install \
     bundler \
-    "grntest:>=1.8.6" \
+    "grntest:>=1.8.8" \
     groonga-client \
     pkg-config \
     rake

--- a/lib/mrb/mrb_task_executor.cpp
+++ b/lib/mrb/mrb_task_executor.cpp
@@ -148,9 +148,19 @@ namespace {
     return mrb_int_value(mrb, data->executor->get_n_workers());
   }
 
+  /* Groonga::TaskExecutor#parallel?(n_tasks=nil)
+   *
+   * Returns whether tasks are run in parallel. If n_tasks is given,
+   * this returns false when n_tasks is 1 or less because there is
+   * nothing to parallelize. */
   mrb_value
   task_executor_is_parallel(mrb_state *mrb, mrb_value self)
   {
+    mrb_int n_tasks;
+    auto n_args = mrb_get_args(mrb, "|i", &n_tasks);
+    if (n_args > 0 && n_tasks <= 1) {
+      return mrb_false_value();
+    }
     auto data = task_executor_data(mrb, self);
     return mrb_bool_value(data->executor->is_parallel());
   }
@@ -220,6 +230,16 @@ namespace {
     return mrb_obj_as_string(mrb, *static_cast<mrb_value *>(user_data));
   }
 
+  /* exception.class.rc.to_i */
+  mrb_value
+  groonga_error_rc_body(mrb_state *mrb, void *user_data)
+  {
+    auto exception = *static_cast<mrb_value *>(user_data);
+    auto exception_class = mrb_obj_value(mrb_obj_class(mrb, exception));
+    auto rc = mrb_funcall(mrb, exception_class, "rc", 0);
+    return mrb_funcall(mrb, rc, "to_i", 0);
+  }
+
   /* Move the error of the child context to the task. It's reported
    * to the caller's context by report_task_errors() after all tasks
    * are finished.
@@ -285,18 +305,37 @@ namespace {
     auto exception = mrb_protect_error(mrb, run_task_body, task, &error);
     if (error) {
       if (ctx->rc == GRN_SUCCESS) {
+        /* This is the same rule as Groonga::Command#run_internal: The
+         * rc of a Groonga::GroongaError is the rc of its class. Other
+         * exceptions are command errors. */
+        auto rc = GRN_COMMAND_ERROR;
+        auto groonga_error_class =
+          mrb_class_get_under(mrb, ctx->impl->mrb.module, "GroongaError");
+        if (mrb_obj_is_kind_of(mrb, exception, groonga_error_class)) {
+          mrb_bool rc_error = FALSE;
+          auto rc_value = mrb_protect_error(mrb,
+                                            groonga_error_rc_body,
+                                            &exception,
+                                            &rc_error);
+          /* rc may be GRN_SUCCESS when the class doesn't have rc.
+           * The error must not be lost. */
+          if (!rc_error && mrb_integer_p(rc_value) &&
+              mrb_integer(rc_value) != GRN_SUCCESS) {
+            rc = static_cast<grn_rc>(mrb_integer(rc_value));
+          }
+        }
         auto class_name = mrb_obj_classname(mrb, exception);
         mrb_bool message_error = FALSE;
         auto message =
           mrb_protect_error(mrb, to_s_body, &exception, &message_error);
         if (message_error || mrb_type(message) != MRB_TT_STRING) {
-          ERR(GRN_UNKNOWN_ERROR,
+          ERR(rc,
               "%s[%llu] %s",
               task->tag.c_str(),
               static_cast<unsigned long long>(task->id),
               class_name);
         } else {
-          ERR(GRN_UNKNOWN_ERROR,
+          ERR(rc,
               "%s[%llu] %s: %.*s",
               task->tag.c_str(),
               static_cast<unsigned long long>(task->id),
@@ -551,7 +590,7 @@ grn_mrb_task_executor_init(grn_ctx *ctx)
                     klass,
                     "parallel?",
                     task_executor_is_parallel,
-                    MRB_ARGS_NONE());
+                    MRB_ARGS_OPT(1));
   mrb_define_method(mrb,
                     klass,
                     "execute",

--- a/plugins/sharding/drilldown_executor.rb
+++ b/plugins/sharding/drilldown_executor.rb
@@ -53,7 +53,8 @@ module Groonga
         @temporary_tables << result_set
         query_logger.log(:size,
                          ":",
-                         "#{@query_log_prefix}(#{result_set.size})")
+                         "#{@query_log_prefix}(#{result_set.size}): " +
+                         @keys.join(","))
         if @dynamic_columns
           options = {query_log_prefix: "#{@query_log_prefix}."}
           @dynamic_columns.apply_initial([[result_set]], options)
@@ -62,6 +63,7 @@ module Groonga
 
         expression = Expression.create(result_set)
         @expressions << expression
+        expression.query_log_tag_prefix = "#{@query_log_prefix}."
         expression.parse(@filter)
         filtered_result_set = result_set.select(expression)
         @temporary_tables << filtered_result_set
@@ -89,7 +91,9 @@ module Groonga
             begin
               table.group(@keys, group_result)
             ensure
-              calc_target.close if calc_target
+              # A persistent column must not be closed. It's shared
+              # with other contexts.
+              calc_target.close if calc_target.is_a?(Accessor)
               group_result.calc_target = nil
             end
           end

--- a/plugins/sharding/logical_select.rb
+++ b/plugins/sharding/logical_select.rb
@@ -429,11 +429,15 @@ module Groonga
         attr_reader :calc_target_name
         attr_reader :calc_types
         attr_reader :filter
+        attr_reader :tag
+        attr_reader :query_log_prefix
         attr_reader :results
         attr_reader :temporary_tables
         attr_reader :expressions
         def initialize(input)
           @input = input
+          @tag = "[logical_select][drilldown]"
+          @query_log_prefix = "drilldown"
           @keys = parse_keys(@input[:drilldown])
           @offset = (@input[:drilldown_offset] || 0).to_i
           @limit = (@input[:drilldown_limit] || 10).to_i
@@ -468,6 +472,11 @@ module Groonga
 
         def n_results
           @results.size
+        end
+
+        # Plain drilldown doesn't support dynamic columns.
+        def dynamic_columns_arguments
+          nil
         end
       end
 
@@ -549,27 +558,34 @@ module Groonga
         attr_reader :calc_types
         attr_reader :filter
         attr_reader :table
+        attr_reader :tag
+        attr_reader :query_log_prefix
         attr_reader :dynamic_columns
+        # Raw arguments of this drilldown. They are used to
+        # reconstruct dynamic columns in a child context.
+        attr_reader :dynamic_columns_arguments
         attr_accessor :result_set
         attr_accessor :condition
         attr_reader :temporary_tables
         attr_reader :expressions
-        def initialize(label, parameters)
+        def initialize(label, arguments)
           @label = label
-          @keys = parse_keys(parameters["keys"])
-          @offset = (parameters["offset"] || 0).to_i
-          @limit = (parameters["limit"] || 10).to_i
-          @sort_keys = parse_keys(parameters["sort_keys"] ||
-                                  parameters["sortby"])
-          @output_columns = parameters["output_columns"]
+          @tag = "[logical_select][drilldowns][#{@label}]"
+          @query_log_prefix = "drilldowns[#{@label}]"
+          @keys = parse_keys(arguments["keys"])
+          @offset = (arguments["offset"] || 0).to_i
+          @limit = (arguments["limit"] || 10).to_i
+          @sort_keys = parse_keys(arguments["sort_keys"] ||
+                                  arguments["sortby"])
+          @output_columns = arguments["output_columns"]
           @output_columns ||= "_key, _nsubrecs"
-          @calc_target_name = parameters["calc_target"]
-          @calc_types = parse_calc_types(parameters["calc_types"])
-          @filter = parameters["filter"]
-          @table = parameters["table"]
+          @calc_target_name = arguments["calc_target"]
+          @calc_types = parse_calc_types(arguments["calc_types"])
+          @filter = arguments["filter"]
+          @table = arguments["table"]
 
-          tag = "[logical_select][drilldowns][#{@label}]"
-          @dynamic_columns = DynamicColumns.parse(tag, parameters)
+          @dynamic_columns_arguments = arguments
+          @dynamic_columns = DynamicColumns.parse(@tag, arguments)
 
           @result_set = nil
           @condition = nil
@@ -679,16 +695,17 @@ module Groonga
         # Selects records in each shard. Shards are processed in
         # parallel when the task executor is parallel.
         def execute_shards
-          # A child context isn't used when there is only one shard
-          # because there is nothing to parallelize.
           task_executor = TaskExecutor.new
-          if !task_executor.parallel? or @context.shard_targets.size == 1
+          if task_executor.parallel?(@context.shard_targets.size)
+            execute_shards_in_parallel(task_executor)
+          else
             @context.shard_targets.each do |shard_executor, _|
               shard_executor.execute
             end
-            return
           end
+        end
 
+        def execute_shards_in_parallel(task_executor)
           input = @context.input
           range = {
             min: input[:min],
@@ -699,8 +716,8 @@ module Groonga
           @context.shard_targets.each_with_index do |(shard_executor, target_table), i|
             shard = shard_executor.shard
             # The block is evaluated at the top level of a child
-            # context. It must not refer any local variable outside
-            # the block and must use full names for constants.
+            # context. It must not refer nor assign any local variable
+            # outside the block and must use full names for constants.
             task_executor.execute(i,
                                   "[logical_select][#{shard.table_name}]",
                                   shard.table_name,
@@ -778,25 +795,77 @@ module Groonga
           target_tables = @context.results.collect do |result|
             result[:result_set]
           end
-          drilldown.keys.each do |key|
-            executor = DrilldownExecutor.new(target_tables,
-                                             [key],
-                                             calc_types: drilldown.calc_types,
-                                             calc_target_name: drilldown.calc_target_name,
-                                             filter: drilldown.filter,
-                                             query_log_prefix: "drilldown")
-            result_set, condition = run_drilldown_executor(executor, drilldown)
-            drilldown.results << {
-              result_set: result_set,
-              condition: condition,
-            }
+          task_executor = TaskExecutor.new
+          if task_executor.parallel?(drilldown.keys.size)
+            target_table_ids = target_tables.collect(&:id)
+            drilldown.keys.each_with_index do |key, i|
+              execute_drilldown_task(task_executor,
+                                     i,
+                                     drilldown,
+                                     target_table_ids,
+                                     [key])
+            end
+            wait_drilldown_tasks(task_executor) do |results|
+              drilldown.keys.each_index do |i|
+                result_set, condition =
+                  add_drilldown_result(drilldown, results.delete(i))
+                drilldown.results << {
+                  result_set: result_set,
+                  condition: condition,
+                }
+              end
+            end
+          else
+            drilldown.keys.each do |key|
+              executor = DrilldownExecutor.new(target_tables,
+                                               [key],
+                                               calc_types: drilldown.calc_types,
+                                               calc_target_name: drilldown.calc_target_name,
+                                               filter: drilldown.filter,
+                                               query_log_prefix: drilldown.query_log_prefix)
+              result_set, condition = run_drilldown_executor(executor, drilldown)
+              drilldown.results << {
+                result_set: result_set,
+                condition: condition,
+              }
+            end
           end
         end
 
         def execute_labeled_drilldowns
           drilldowns = @context.labeled_drilldowns
-          drilldowns.tsort_each do |drilldown|
-            execute_labeled_drilldown(drilldowns, drilldown)
+          # A drilldown that depends on another drilldown by `table`
+          # is processed after the depended drilldown is finished.
+          task_executor = TaskExecutor.new
+          remaining_drilldowns = drilldowns.tsort
+          until remaining_drilldowns.empty?
+            ready_drilldowns = remaining_drilldowns.select do |drilldown|
+              drilldown.table.nil? or drilldowns[drilldown.table].result_set
+            end
+            if task_executor.parallel?(ready_drilldowns.size)
+              ready_drilldowns.each_with_index do |drilldown, i|
+                target_tables = labeled_drilldown_target_tables(drilldowns,
+                                                                drilldown)
+                execute_drilldown_task(task_executor,
+                                       i,
+                                       drilldown,
+                                       target_tables.collect(&:id),
+                                       drilldown.keys)
+              end
+              wait_drilldown_tasks(task_executor) do |results|
+                ready_drilldowns.each_with_index do |drilldown, i|
+                  result_set, condition =
+                    add_drilldown_result(drilldown, results.delete(i))
+                  drilldown.result_set = result_set
+                  drilldown.condition = condition
+                end
+              end
+            else
+              ready_drilldowns.each do |drilldown|
+                execute_labeled_drilldown(drilldowns, drilldown)
+              end
+            end
+            remaining_drilldowns -= ready_drilldowns
           end
         end
 
@@ -810,7 +879,7 @@ module Groonga
                                   calc_target_name: drilldown.calc_target_name,
                                   filter: drilldown.filter,
                                   dynamic_columns: drilldown.dynamic_columns,
-                                  query_log_prefix: "drilldowns[#{drilldown.label}]")
+                                  query_log_prefix: drilldown.query_log_prefix)
           result_set, condition = run_drilldown_executor(executor, drilldown)
           drilldown.result_set = result_set
           drilldown.condition = condition
@@ -835,6 +904,112 @@ module Groonga
             drilldown.temporary_tables.concat(executor.temporary_tables)
             drilldown.expressions.concat(executor.expressions)
           end
+        end
+
+        # Runs DrilldownExecutor for the drilldown in a child
+        # context. See execute_shards_in_parallel for restrictions of
+        # the block.
+        def execute_drilldown_task(task_executor,
+                                   id,
+                                   drilldown,
+                                   target_table_ids,
+                                   keys)
+          task_executor.execute(id,
+                                drilldown.tag,
+                                target_table_ids,
+                                keys,
+                                drilldown.calc_types,
+                                drilldown.calc_target_name,
+                                drilldown.filter,
+                                drilldown.dynamic_columns_arguments,
+                                drilldown.query_log_prefix,
+                                drilldown.tag) do |target_table_ids,
+                                                   keys,
+                                                   calc_types,
+                                                   calc_target_name,
+                                                   filter,
+                                                   dynamic_columns_arguments,
+                                                   query_log_prefix,
+                                                   tag|
+            require "sharding/keys_parsable"
+            require "sharding/window"
+            require "sharding/dynamic_columns"
+            require "sharding/drilldown_executor"
+            context = Groonga::Context.instance
+            target_tables = target_table_ids.collect do |table_id|
+              context[table_id]
+            end
+            dynamic_columns = nil
+            if dynamic_columns_arguments
+              dynamic_columns =
+                Groonga::Sharding::DynamicColumns.parse(tag,
+                                                        dynamic_columns_arguments)
+            end
+            executor =
+              Groonga::Sharding::DrilldownExecutor.new(target_tables,
+                                                       keys,
+                                                       calc_types: calc_types,
+                                                       calc_target_name: calc_target_name,
+                                                       filter: filter,
+                                                       dynamic_columns: dynamic_columns,
+                                                       query_log_prefix: query_log_prefix)
+            begin
+              result_set, condition = executor.execute
+              temporary_table_ids = executor.temporary_tables.collect(&:id)
+              expression_ids = executor.expressions.collect(&:id)
+              # Temporary tables and expressions are closed by the
+              # parent context.
+              executor.temporary_tables.clear
+              executor.expressions.clear
+              [result_set.id, condition&.id, temporary_table_ids, expression_ids]
+            ensure
+              executor.expressions.each(&:close)
+              executor.temporary_tables.each(&:close)
+            end
+          end
+        end
+
+        # Waits all drilldown tasks and yields the results. The block
+        # must delete results that are added to drilldowns. Temporary
+        # objects of the remaining results are closed here.
+        def wait_drilldown_tasks(task_executor)
+          results = task_executor.results
+          begin
+            task_executor.wait_all
+            yield(results)
+          ensure
+            # Only Groonga::Context#[] and Groonga::Object#close are
+            # used here because the context may have an error and
+            # bindings that check it raise.
+            context = Context.instance
+            results.each_value do |result|
+              _, _, temporary_table_ids, expression_ids = result
+              expression_ids.each do |expression_id|
+                context[expression_id].close
+              end
+              temporary_table_ids.each do |table_id|
+                context[table_id].close
+              end
+            end
+            results.clear
+          end
+        end
+
+        # Adds the result of DrilldownExecutor run in a child
+        # context. Objects are passed by ID. See
+        # ShardExecutor#add_selected for details.
+        def add_drilldown_result(drilldown, result)
+          result_set_id, condition_id, temporary_table_ids, expression_ids =
+            result
+          context = Context.instance
+          temporary_table_ids.each do |table_id|
+            drilldown.temporary_tables << context[table_id]
+          end
+          expression_ids.each do |expression_id|
+            drilldown.expressions << context[expression_id]
+          end
+          condition = condition_id ? context[condition_id] : nil
+          [context[result_set_id], condition]
         end
       end
 

--- a/test/command/suite/ruby/eval/task_executor/not_convertible_result.expected
+++ b/test/command/suite/ruby/eval/task_executor/not_convertible_result.expected
@@ -4,7 +4,7 @@ ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {
 [
   [
     [
-      -1,
+      -74,
       0.0,
       0.0
     ],
@@ -12,7 +12,7 @@ ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {
   ],
   {
     "exception": {
-      "message": "unknown error: <[test][0] ArgumentError: can't return Object from the block>(-1)"
+      "message": "command error: <[test][0] ArgumentError: can't return Object from the block>(-74)"
     }
   }
 ]

--- a/test/command/suite/ruby/eval/task_executor/parallel/parallel_n_tasks.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/parallel_n_tasks.expected
@@ -1,0 +1,4 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [executor.parallel?, executor.parallel?(0), executor.parallel?(1), executor.parallel?(2)].inspect"
+[[0,0.0,0.0],{"value":"[true, false, false, true]"}]

--- a/test/command/suite/ruby/eval/task_executor/parallel/parallel_n_tasks.test
+++ b/test/command/suite/ruby/eval/task_executor/parallel/parallel_n_tasks.test
@@ -1,0 +1,7 @@
+#@require-apache-arrow
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+# There is nothing to parallelize when the number of tasks is 1 or less.
+ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; [executor.parallel?, executor.parallel?(0), executor.parallel?(1), executor.parallel?(2)].inspect"

--- a/test/command/suite/ruby/eval/task_executor/parallel/raise.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/raise.expected
@@ -4,7 +4,7 @@ ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| exec
 [
   [
     [
-      -1,
+      -74,
       0.0,
       0.0
     ],
@@ -12,7 +12,7 @@ ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 8.times {|i| exec
   ],
   {
     "exception": {
-      "message": "unknown error: <[test][3] RuntimeError: error in task 3>(-1)"
+      "message": "command error: <[test][3] RuntimeError: error in task 3>(-74)"
     }
   }
 ]

--- a/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.expected
+++ b/test/command/suite/ruby/eval/task_executor/parallel/results_on_error.expected
@@ -8,7 +8,7 @@ ruby_eval --n_workers 4 "executor = Groonga::TaskExecutor.new; 4.times {|i| exec
     0.0
   ],
   {
-    "value": "[\"Groonga::UnknownError\", {0 => 0, 1 => 10, 3 => 30}]"
+    "value": "[\"Groonga::CommandError\", {0 => 0, 1 => 10, 3 => 30}]"
   }
 ]
 #|e| [test][2] RuntimeError: error in task 2

--- a/test/command/suite/ruby/eval/task_executor/raise.expected
+++ b/test/command/suite/ruby/eval/task_executor/raise.expected
@@ -4,7 +4,7 @@ ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {
 [
   [
     [
-      -1,
+      -74,
       0.0,
       0.0
     ],
@@ -12,7 +12,7 @@ ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {
   ],
   {
     "exception": {
-      "message": "unknown error: <[test][0] RuntimeError: block error>(-1)"
+      "message": "command error: <[test][0] RuntimeError: block error>(-74)"
     }
   }
 ]

--- a/test/command/suite/ruby/eval/task_executor/raise_groonga_error.expected
+++ b/test/command/suite/ruby/eval/task_executor/raise_groonga_error.expected
@@ -1,0 +1,19 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {raise Groonga::InvalidArgument, 'block error'}; executor.wait_all"
+[
+  [
+    [
+      -22,
+      0.0,
+      0.0
+    ],
+    "[test][0] Groonga::InvalidArgument: block error"
+  ],
+  {
+    "exception": {
+      "message": "invalid argument: <[test][0] Groonga::InvalidArgument: block error>(-22)"
+    }
+  }
+]
+#|e| [test][0] Groonga::InvalidArgument: block error

--- a/test/command/suite/ruby/eval/task_executor/raise_groonga_error.test
+++ b/test/command/suite/ruby/eval/task_executor/raise_groonga_error.test
@@ -1,0 +1,6 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+# The rc of a Groonga::GroongaError raised in a task is used.
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {raise Groonga::InvalidArgument, 'block error'}; executor.wait_all"

--- a/test/command/suite/ruby/eval/task_executor/raise_groonga_error_without_rc.expected
+++ b/test/command/suite/ruby/eval/task_executor/raise_groonga_error_without_rc.expected
@@ -1,0 +1,19 @@
+plugin_register ruby/eval
+[[0,0.0,0.0],true]
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {Object.const_set(:TestError, Class.new(Groonga::GroongaError)); raise TestError, 'block error'}; executor.wait_all"
+[
+  [
+    [
+      -74,
+      0.0,
+      0.0
+    ],
+    "[test][0] TestError: block error"
+  ],
+  {
+    "exception": {
+      "message": "command error: <[test][0] TestError: block error>(-74)"
+    }
+  }
+]
+#|e| [test][0] TestError: block error

--- a/test/command/suite/ruby/eval/task_executor/raise_groonga_error_without_rc.test
+++ b/test/command/suite/ruby/eval/task_executor/raise_groonga_error_without_rc.test
@@ -1,0 +1,7 @@
+#@on-error omit
+plugin_register ruby/eval
+#@on-error default
+
+# A Groonga::GroongaError subclass without rc is reported as a command
+# error. The error must not be lost.
+ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {Object.const_set(:TestError, Class.new(Groonga::GroongaError)); raise TestError, 'block error'}; executor.wait_all"

--- a/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.expected
+++ b/test/command/suite/ruby/eval/task_executor/unqualified_constant_in_module.expected
@@ -4,7 +4,7 @@ ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executo
 [
   [
     [
-      -1,
+      -74,
       0.0,
       0.0
     ],
@@ -12,7 +12,7 @@ ruby_eval "module Groonga::TableCursorFlags; def self.task_executor_test(executo
   ],
   {
     "exception": {
-      "message": "unknown error: <[test][0] NameError: uninitialized constant ASCENDING>(-1)"
+      "message": "command error: <[test][0] NameError: uninitialized constant ASCENDING>(-74)"
     }
   }
 ]

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.expected
@@ -158,12 +158,12 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[restart](3)
-#:000000000000000 filter(1): #<accessor _key(anonymous)> match "Restart"
+#:000000000000000 drilldowns[action](1): _key
+#:000000000000000 drilldowns[restart](3): action
+#:000000000000000 drilldowns[restart].filter(1): #<accessor _key(anonymous)> match "Restart"
 #:000000000000000 drilldowns[restart].filter(1)
-#:000000000000000 drilldowns[action](1)
-#:000000000000000 drilldowns[start](3)
-#:000000000000000 filter(2): #<accessor _key(anonymous)> match "Start"
+#:000000000000000 drilldowns[start](3): action
+#:000000000000000 drilldowns[start].filter(2): #<accessor _key(anonymous)> match "Start"
 #:000000000000000 drilldowns[start].filter(2)
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action](1)
@@ -252,13 +252,13 @@ logical_select Logs   --shard_key timestamp   --limit 0   --output_columns _id  
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[start](3)
-#:000000000000000 filter(2): #<accessor _key(anonymous)> match "Start"
-#:000000000000000 drilldowns[start].filter(2)
-#:000000000000000 drilldowns[action](2)
-#:000000000000000 drilldowns[restart](3)
-#:000000000000000 filter(1): #<accessor _key(anonymous)> match "Restart"
+#:000000000000000 drilldowns[action](2): _key
+#:000000000000000 drilldowns[restart](3): action
+#:000000000000000 drilldowns[restart].filter(1): #<accessor _key(anonymous)> match "Restart"
 #:000000000000000 drilldowns[restart].filter(1)
+#:000000000000000 drilldowns[start](3): action
+#:000000000000000 drilldowns[start].filter(2): #<accessor _key(anonymous)> match "Start"
+#:000000000000000 drilldowns[start].filter(2)
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action](2)
 #:000000000000000 output.drilldowns[restart](1)

--- a/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
+++ b/test/command/suite/sharding/logical_select/cache/drilldowns/table.test
@@ -77,7 +77,7 @@ load --table Logs_20150205
 #@sleep 1
 
 #@collect-query-log true
-#@sort-query-log-operations shard
+#@sort-query-log-operations shard drilldown
 logical_select Logs \
   --shard_key timestamp \
   --limit 0 \
@@ -107,5 +107,5 @@ logical_select Logs \
   --drilldowns[start].keys 'action' \
   --drilldowns[start].filter "_key @ 'Start'" \
   --drilldowns[start].output_columns _key
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/filtered/filter.test
@@ -42,5 +42,5 @@ logical_select Logs \
   --columns[filtered_id].value '_id' \
   --filter 'price < 910' \
   --output_columns _id,filtered_id,price
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.test
+++ b/test/command/suite/sharding/logical_select/columns/stage/initial/query_no_index.test
@@ -39,7 +39,7 @@ logical_select Logs \
   --match_columns item \
   --output_columns content \
   --query "Book"
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false
 #@remove-ignore-log-pattern /\A\[io\]/
 #@remove-important-log-levels info

--- a/test/command/suite/sharding/logical_select/drilldown/plain/calc_types/all.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/calc_types/all.expected
@@ -44,7 +44,7 @@ load --table Memos_20150710
  "created_at": "2015/07/10 04:00:00"}
 ]
 [[0,0.0,0.0],5]
-logical_select Memos   --shard_key created_at   --limit 0   --drilldown tag   --drilldown_calc_types 'MAX, MIN, SUM, AVG'   --drilldown_calc_target priority   --drilldown_output_columns _key,_max,_min,_sum,_avg
+logical_select Memos   --shard_key created_at   --limit 0   --drilldown tag,priority   --drilldown_calc_types 'MAX, MIN, SUM, AVG'   --drilldown_calc_target priority   --drilldown_output_columns _key,_max,_min,_sum,_avg
 [
   [
     0,
@@ -125,6 +125,96 @@ logical_select Memos   --shard_key created_at   --limit 0   --drilldown tag   --
         -9,
         -6,
         -2.0
+      ]
+    ],
+    [
+      [
+        9
+      ],
+      [
+        [
+          "_key",
+          "Int64"
+        ],
+        [
+          "_max",
+          "Int64"
+        ],
+        [
+          "_min",
+          "Int64"
+        ],
+        [
+          "_sum",
+          "Int64"
+        ],
+        [
+          "_avg",
+          "Float"
+        ]
+      ],
+      [
+        10,
+        10,
+        10,
+        10,
+        10.0
+      ],
+      [
+        20,
+        20,
+        20,
+        20,
+        20.0
+      ],
+      [
+        60,
+        60,
+        60,
+        60,
+        60.0
+      ],
+      [
+        61,
+        61,
+        61,
+        61,
+        61.0
+      ],
+      [
+        24,
+        24,
+        24,
+        24,
+        24.0
+      ],
+      [
+        8,
+        8,
+        8,
+        8,
+        8.0
+      ],
+      [
+        3,
+        3,
+        3,
+        3,
+        3.0
+      ],
+      [
+        -9,
+        -9,
+        -9,
+        -9,
+        -9.0
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0.0
       ]
     ]
   ]

--- a/test/command/suite/sharding/logical_select/drilldown/plain/calc_types/all.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/calc_types/all.test
@@ -43,7 +43,7 @@ load --table Memos_20150710
 logical_select Memos \
   --shard_key created_at \
   --limit 0 \
-  --drilldown tag \
+  --drilldown tag,priority \
   --drilldown_calc_types 'MAX, MIN, SUM, AVG' \
   --drilldown_calc_target priority \
   --drilldown_output_columns _key,_max,_min,_sum,_avg

--- a/test/command/suite/sharding/logical_select/drilldown/plain/filter/key.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/filter/key.expected
@@ -81,7 +81,7 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_filter '_key == "Restart"'
+logical_select Logs timestamp   --limit 0   --drilldown action,memo   --drilldown_filter '_key == "Restart"'
 [
   [
     0,
@@ -129,6 +129,21 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_fil
       [
         "Restart",
         6
+      ]
+    ],
+    [
+      [
+        0
+      ],
+      [
+        [
+          "_key",
+          "ShortText"
+        ],
+        [
+          "_nsubrecs",
+          "Int32"
+        ]
       ]
     ]
   ]

--- a/test/command/suite/sharding/logical_select/drilldown/plain/filter/key.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/filter/key.test
@@ -76,5 +76,5 @@ load --table Logs_20150205
 
 logical_select Logs timestamp \
   --limit 0 \
-  --drilldown action \
+  --drilldown action,memo \
   --drilldown_filter '_key == "Restart"'

--- a/test/command/suite/sharding/logical_select/drilldown/plain/keys/multiple.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/keys/multiple.expected
@@ -6,6 +6,8 @@ column_create Logs_20150203 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Logs_20150204 TABLE_NO_KEY
@@ -13,6 +15,8 @@ table_create Logs_20150204 TABLE_NO_KEY
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
@@ -22,6 +26,8 @@ column_create Logs_20150205 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Logs_20150203
@@ -29,11 +35,13 @@ load --table Logs_20150203
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
@@ -43,16 +51,19 @@ load --table Logs_20150204
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
@@ -62,26 +73,30 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action,action,action
+logical_select Logs timestamp   --limit 0   --drilldown action,date
 [
   [
     0,
@@ -100,6 +115,10 @@ logical_select Logs timestamp   --limit 0   --drilldown action,action,action
         ],
         [
           "action",
+          "ShortText"
+        ],
+        [
+          "date",
           "ShortText"
         ],
         [
@@ -154,44 +173,28 @@ logical_select Logs timestamp   --limit 0   --drilldown action,action,action
         ]
       ],
       [
-        "Start",
+        "2015-02-03",
         2
       ],
       [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ],
-    [
-      [
+        "2015-02-04",
         3
       ],
       [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Start",
-        2
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
+        "2015-02-05",
+        4
       ]
     ]
   ]
 ]
+#>logical_select --drilldown "action,date" --limit "0" --logical_table "Logs" --shard_key "timestamp"
+#:000000000000000 select(2)[Logs_20150203]
+#:000000000000000 select(3)[Logs_20150204]
+#:000000000000000 select(4)[Logs_20150205]
+#:000000000000000 drilldown(3): action
+#:000000000000000 drilldown(3): date
+#:000000000000000 output(0)
+#:000000000000000 output.drilldown(3)
+#:000000000000000 output.drilldown(3)
+#:000000000000000 send(0)
+#<000000000000000 rc=0

--- a/test/command/suite/sharding/logical_select/drilldown/plain/keys/multiple.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/keys/multiple.test
@@ -5,16 +5,19 @@ plugin_register sharding
 table_create Logs_20150203 TABLE_NO_KEY
 column_create Logs_20150203 timestamp COLUMN_SCALAR Time
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
 
 table_create Logs_20150204 TABLE_NO_KEY
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
 
 table_create Logs_20150205 TABLE_NO_KEY
 column_create Logs_20150205 timestamp COLUMN_SCALAR Time
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
 
 load --table Logs_20150203
@@ -22,11 +25,13 @@ load --table Logs_20150203
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
@@ -36,16 +41,19 @@ load --table Logs_20150204
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
@@ -55,25 +63,33 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
 
+#@collect-query-log true
+#@sort-query-log-operations shard drilldown
 logical_select Logs timestamp \
   --limit 0 \
-  --drilldown action,action,action
+  --drilldown action,date
+#@sort-query-log-operations
+#@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.expected
@@ -141,7 +141,7 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_lim
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3)
+#:000000000000000 drilldown(3): action
 #:000000000000000 output(0)
 #:000000000000000 output.drilldown(2)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/negative.test
@@ -80,5 +80,5 @@ logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_limit -2
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.expected
@@ -137,7 +137,7 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_lim
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3)
+#:000000000000000 drilldown(3): action
 #:000000000000000 output(0)
 #:000000000000000 output.drilldown(1)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/limit/positive.test
@@ -80,5 +80,5 @@ logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_limit 1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.expected
@@ -137,7 +137,7 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_off
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3)
+#:000000000000000 drilldown(3): action
 #:000000000000000 output(0)
 #:000000000000000 output.drilldown(1)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/offset/negative.test
@@ -80,5 +80,5 @@ logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_offset -1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/offset/positive.test
@@ -80,5 +80,5 @@ logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_offset 1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.expected
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.expected
@@ -145,7 +145,7 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_sor
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3)
+#:000000000000000 drilldown(3): action
 #:000000000000000 output(0)
 #:000000000000000 drilldown.sort(3): -_nsubrecs,_key
 #:000000000000000 output.drilldown(3)

--- a/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.test
+++ b/test/command/suite/sharding/logical_select/drilldown/plain/sort_keys/multiple.test
@@ -80,5 +80,5 @@ logical_select Logs timestamp \
   --limit 0 \
   --drilldown action \
   --drilldown_sort_keys -_nsubrecs,_key
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.expected
@@ -54,7 +54,7 @@ load --table Memos_20150710
  "created_at": "2015/07/10 07:00:00"}
 ]
 [[0,0.0,0.0],8]
-logical_select Memos   --shard_key created_at   --limit 0   --drilldowns[tag].keys tag,user   --drilldowns[tag].calc_types 'AVG, MAX, MIN, SUM'   --drilldowns[tag].calc_target priority   --drilldowns[tag].output_columns _value.tag,_value.user,_max,_min,_sum,_avg
+logical_select Memos   --shard_key created_at   --limit 0   --drilldowns[tag].keys tag,user   --drilldowns[tag].calc_types 'AVG, MAX, MIN, SUM'   --drilldowns[tag].calc_target priority   --drilldowns[tag].output_columns _value.tag,_value.user,_max,_min,_sum,_avg   --drilldowns[user].keys user   --drilldowns[user].calc_types 'AVG, MAX, MIN, SUM'   --drilldowns[user].calc_target priority   --drilldowns[user].output_columns _key,_max,_min,_sum,_avg
 [
   [
     0,
@@ -156,15 +156,72 @@ logical_select Memos   --shard_key created_at   --limit 0   --drilldowns[tag].ke
           -6,
           -2.0
         ]
+      ],
+      "user": [
+        [
+          4
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_max",
+            "Int64"
+          ],
+          [
+            "_min",
+            "Int64"
+          ],
+          [
+            "_sum",
+            "Int64"
+          ],
+          [
+            "_avg",
+            "Float"
+          ]
+        ],
+        [
+          "user1",
+          60,
+          10,
+          90,
+          30.0
+        ],
+        [
+          "user2",
+          61,
+          8,
+          93,
+          31.0
+        ],
+        [
+          "user3",
+          7,
+          -4,
+          6,
+          2.0
+        ],
+        [
+          "user4",
+          -1,
+          -3,
+          -6,
+          -2.0
+        ]
       ]
     }
   ]
 ]
-#>logical_select --drilldowns[tag].calc_target "priority" --drilldowns[tag].calc_types "AVG, MAX, MIN, SUM" --drilldowns[tag].keys "tag,user" --drilldowns[tag].output_columns "_value.tag,_value.user,_max,_min,_sum,_avg" --limit "0" --logical_table "Memos" --shard_key "created_at"
+#>logical_select --drilldowns[tag].calc_target "priority" --drilldowns[tag].calc_types "AVG, MAX, MIN, SUM" --drilldowns[tag].keys "tag,user" --drilldowns[tag].output_columns "_value.tag,_value.user,_max,_min,_sum,_avg" --drilldowns[user].calc_target "priority" --drilldowns[user].calc_types "AVG, MAX, MIN, SUM" --drilldowns[user].keys "user" --drilldowns[user].output_columns "_key,_max,_min,_sum,_avg" --limit "0" --logical_table "Memos" --shard_key "created_at"
 #:000000000000000 select(4)[Memos_20150709]
 #:000000000000000 select(8)[Memos_20150710]
-#:000000000000000 drilldowns[tag](4)
+#:000000000000000 drilldowns[tag](4): tag,user
+#:000000000000000 drilldowns[user](4): user
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[tag](4)
+#:000000000000000 output.drilldowns[user](4)
 #:000000000000000 send(0)
 #<000000000000000 rc=0

--- a/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/calc_types/multiple/all.test
@@ -49,13 +49,17 @@ load --table Memos_20150710
 ]
 
 #@collect-query-log true
-#@sort-query-log-operations shard
+#@sort-query-log-operations shard drilldown
 logical_select Memos \
   --shard_key created_at \
   --limit 0 \
   --drilldowns[tag].keys tag,user \
   --drilldowns[tag].calc_types 'AVG, MAX, MIN, SUM' \
   --drilldowns[tag].calc_target priority \
-  --drilldowns[tag].output_columns _value.tag,_value.user,_max,_min,_sum,_avg
-#@sort-query-log-operations none
+  --drilldowns[tag].output_columns _value.tag,_value.user,_max,_min,_sum,_avg \
+  --drilldowns[user].keys user \
+  --drilldowns[user].calc_types 'AVG, MAX, MIN, SUM' \
+  --drilldowns[user].calc_target priority \
+  --drilldowns[user].output_columns _key,_max,_min,_sum,_avg
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.expected
@@ -50,7 +50,7 @@ load --table Logs_20170317
 {"timestamp": "2017/03/17 20:00:00", "items": ["Drink", "Note"]}
 ]
 [[0,0.0,0.0],2]
-logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0   --drilldowns[item].keys items   --drilldowns[item].sort_keys price   --drilldowns[item].output_columns _key,_nsubrecs,price,price_with_tax   --drilldowns[item].columns[price_with_tax].stage initial   --drilldowns[item].columns[price_with_tax].type UInt32   --drilldowns[item].columns[price_with_tax].flags COLUMN_SCALAR   --drilldowns[item].columns[price_with_tax].value 'price * 1.08'   --drilldowns[real_price].table item   --drilldowns[real_price].keys price_with_tax
+logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0   --drilldowns[item].keys items   --drilldowns[item].sort_keys price   --drilldowns[item].output_columns _key,_nsubrecs,price,price_with_tax   --drilldowns[item].columns[price_with_tax].stage initial   --drilldowns[item].columns[price_with_tax].type UInt32   --drilldowns[item].columns[price_with_tax].flags COLUMN_SCALAR   --drilldowns[item].columns[price_with_tax].value 'price * 1.08'   --drilldowns[real_price].table item   --drilldowns[real_price].keys price_with_tax   --drilldowns[unit_price].keys items.price   --drilldowns[unit_price].output_columns _key,_nsubrecs
 [
   [
     0,
@@ -155,20 +155,49 @@ logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0  
           324,
           1
         ]
+      ],
+      "unit_price": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "UInt32"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          1000,
+          6
+        ],
+        [
+          500,
+          8
+        ],
+        [
+          300,
+          3
+        ]
       ]
     }
   ]
 ]
-#>logical_select --drilldowns[item].columns[price_with_tax].flags "COLUMN_SCALAR" --drilldowns[item].columns[price_with_tax].stage "initial" --drilldowns[item].columns[price_with_tax].type "UInt32" --drilldowns[item].columns[price_with_tax].value "price * 1.08" --drilldowns[item].keys "items" --drilldowns[item].output_columns "_key,_nsubrecs,price,price_with_tax" --drilldowns[item].sort_keys "price" --drilldowns[real_price].keys "price_with_tax" --drilldowns[real_price].table "item" --limit "0" --logical_table "Logs" --output_columns "_id" --shard_key "timestamp"
+#>logical_select --drilldowns[item].columns[price_with_tax].flags "COLUMN_SCALAR" --drilldowns[item].columns[price_with_tax].stage "initial" --drilldowns[item].columns[price_with_tax].type "UInt32" --drilldowns[item].columns[price_with_tax].value "price * 1.08" --drilldowns[item].keys "items" --drilldowns[item].output_columns "_key,_nsubrecs,price,price_with_tax" --drilldowns[item].sort_keys "price" --drilldowns[real_price].keys "price_with_tax" --drilldowns[real_price].table "item" --drilldowns[unit_price].keys "items.price" --drilldowns[unit_price].output_columns "_key,_nsubrecs" --limit "0" --logical_table "Logs" --output_columns "_id" --shard_key "timestamp"
 #:000000000000000 select(2)[Logs_20170315]
 #:000000000000000 select(2)[Logs_20170316]
 #:000000000000000 select(2)[Logs_20170317]
-#:000000000000000 drilldowns[item](6)
+#:000000000000000 drilldowns[item](6): items
 #:000000000000000 drilldowns[item].columns[price_with_tax](6)
-#:000000000000000 drilldowns[real_price](3)
+#:000000000000000 drilldowns[real_price](3): price_with_tax
+#:000000000000000 drilldowns[unit_price](3): items.price
 #:000000000000000 output(0)
 #:000000000000000 drilldowns[item].sort(6): price
 #:000000000000000 output.drilldowns[item](6)
 #:000000000000000 output.drilldowns[real_price](3)
+#:000000000000000 output.drilldowns[unit_price](3)
 #:000000000000000 send(0)
 #<000000000000000 rc=0

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/stage/initial/drilldown.test
@@ -46,7 +46,7 @@ load --table Logs_20170317
 ]
 
 #@collect-query-log true
-#@sort-query-log-operations shard
+#@sort-query-log-operations shard drilldown
 logical_select Logs \
   --shard_key timestamp \
   --output_columns _id \
@@ -59,6 +59,8 @@ logical_select Logs \
   --drilldowns[item].columns[price_with_tax].flags COLUMN_SCALAR \
   --drilldowns[item].columns[price_with_tax].value 'price * 1.08' \
   --drilldowns[real_price].table item \
-  --drilldowns[real_price].keys price_with_tax
-#@sort-query-log-operations none
+  --drilldowns[real_price].keys price_with_tax \
+  --drilldowns[unit_price].keys items.price \
+  --drilldowns[unit_price].output_columns _key,_nsubrecs
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.expected
@@ -126,7 +126,7 @@ logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0  
 #:000000000000000 select(2)[Logs_20170315]
 #:000000000000000 select(2)[Logs_20170316]
 #:000000000000000 select(2)[Logs_20170317]
-#:000000000000000 drilldowns[item](6)
+#:000000000000000 drilldowns[item](6): item
 #:000000000000000 drilldowns[item].columns[sun](6)
 #:000000000000000 output(0)
 #:000000000000000 drilldowns[item].sort(6): sun

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/ascending.test
@@ -59,5 +59,5 @@ logical_select Logs \
   --drilldowns[item].columns[sun].window.sort_keys price \
   --drilldowns[item].sort_keys 'sun' \
   --drilldowns[item].output_columns 'sun, _key, price'
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/group_keys.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/group_keys.expected
@@ -52,7 +52,7 @@ load --table Logs_20170317
 {"timestamp": "2017/03/17 20:00:00", "item": "item4"}
 ]
 [[0,0.0,0.0],2]
-logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0   --drilldowns[item].keys item   --drilldowns[item].columns[sum].stage initial   --drilldowns[item].columns[sum].type UInt32   --drilldowns[item].columns[sum].flags COLUMN_SCALAR   --drilldowns[item].columns[sum].value 'window_sum(price)'   --drilldowns[item].columns[sum].window.group_keys price   --drilldowns[item].columns[sum].window.sort_keys _key   --drilldowns[item].output_columns 'sum, _key, price, type'
+logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0   --drilldowns[item].keys item   --drilldowns[item].columns[sum].stage initial   --drilldowns[item].columns[sum].type UInt32   --drilldowns[item].columns[sum].flags COLUMN_SCALAR   --drilldowns[item].columns[sum].value 'window_sum(price)'   --drilldowns[item].columns[sum].window.group_keys price   --drilldowns[item].columns[sum].window.sort_keys _key   --drilldowns[item].output_columns 'sum, _key, price, type'   --drilldowns[item_by_type].keys item   --drilldowns[item_by_type].columns[sum].stage initial   --drilldowns[item_by_type].columns[sum].type UInt32   --drilldowns[item_by_type].columns[sum].flags COLUMN_SCALAR   --drilldowns[item_by_type].columns[sum].value 'window_sum(price)'   --drilldowns[item_by_type].columns[sum].window.group_keys type   --drilldowns[item_by_type].columns[sum].window.sort_keys _key   --drilldowns[item_by_type].output_columns 'sum, _key, price, type'
 [
   [
     0,
@@ -73,6 +73,53 @@ logical_select Logs   --shard_key timestamp   --output_columns _id   --limit 0  
     ],
     {
       "item": [
+        [
+          4
+        ],
+        [
+          [
+            "sum",
+            "UInt32"
+          ],
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "price",
+            "UInt32"
+          ],
+          [
+            "type",
+            "ShortText"
+          ]
+        ],
+        [
+          100,
+          "item1",
+          100,
+          "C"
+        ],
+        [
+          200,
+          "item2",
+          200,
+          "A"
+        ],
+        [
+          400,
+          "item3",
+          200,
+          "A"
+        ],
+        [
+          300,
+          "item4",
+          300,
+          "B"
+        ]
+      ],
+      "item_by_type": [
         [
           4
         ],

--- a/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/group_keys.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/columns/window_function/window_sum/group_keys.test
@@ -57,4 +57,12 @@ logical_select Logs \
   --drilldowns[item].columns[sum].value 'window_sum(price)' \
   --drilldowns[item].columns[sum].window.group_keys price \
   --drilldowns[item].columns[sum].window.sort_keys _key \
-  --drilldowns[item].output_columns 'sum, _key, price, type'
+  --drilldowns[item].output_columns 'sum, _key, price, type' \
+  --drilldowns[item_by_type].keys item \
+  --drilldowns[item_by_type].columns[sum].stage initial \
+  --drilldowns[item_by_type].columns[sum].type UInt32 \
+  --drilldowns[item_by_type].columns[sum].flags COLUMN_SCALAR \
+  --drilldowns[item_by_type].columns[sum].value 'window_sum(price)' \
+  --drilldowns[item_by_type].columns[sum].window.group_keys type \
+  --drilldowns[item_by_type].columns[sum].window.sort_keys _key \
+  --drilldowns[item_by_type].output_columns 'sum, _key, price, type'

--- a/test/command/suite/sharding/logical_select/drilldowns/filter/invalid.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/filter/invalid.expected
@@ -6,6 +6,8 @@ column_create Logs_20150203 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Logs_20150204 TABLE_NO_KEY
@@ -13,6 +15,8 @@ table_create Logs_20150204 TABLE_NO_KEY
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
@@ -22,6 +26,8 @@ column_create Logs_20150205 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Logs_20150203
@@ -29,11 +35,13 @@ load --table Logs_20150203
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
@@ -43,16 +51,19 @@ load --table Logs_20150204
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
@@ -62,87 +73,39 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
+logical_select Logs timestamp   --limit 0   --drilldowns[action].keys action   --drilldowns[action].filter 'nonexistent == 1'   --drilldowns[date].keys date
 [
   [
-    0,
-    0.0,
-    0.0
-  ],
-  [
     [
-      [
-        9
-      ],
-      [
-        [
-          "_id",
-          "UInt32"
-        ],
-        [
-          "action",
-          "ShortText"
-        ],
-        [
-          "memo",
-          "ShortText"
-        ],
-        [
-          "timestamp",
-          "Time"
-        ]
-      ]
+      -63,
+      0.0,
+      0.0
     ],
-    [
-      [
-        3
-      ],
-      [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ]
+    "syntax error: <Syntax error: <nonexistent| |== 1>: [expr][parse] unknown identifier: <nonexistent>>(-63)"
   ]
 ]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 select(3)[Logs_20150204]
-#:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
-#:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
-#:000000000000000 send(0)
-#<000000000000000 rc=0
+#|e| [expr][parse] unknown identifier: <nonexistent>
+#|e| Syntax error: <nonexistent| |== 1>: [expr][parse] unknown identifier: <nonexistent>

--- a/test/command/suite/sharding/logical_select/drilldowns/filter/invalid.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/filter/invalid.test
@@ -1,148 +1,94 @@
+#@on-error omit
 plugin_register sharding
-[[0,0.0,0.0],true]
+#@on-error default
+
 table_create Logs_20150203 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150203 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150204 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150205 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150205 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 load --table Logs_20150203
 [
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
-[[0,0.0,0.0],2]
+
 load --table Logs_20150204
 [
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],3]
+
 load --table Logs_20150205
 [
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
-[
-  [
-    0,
-    0.0,
-    0.0
-  ],
-  [
-    [
-      [
-        9
-      ],
-      [
-        [
-          "_id",
-          "UInt32"
-        ],
-        [
-          "action",
-          "ShortText"
-        ],
-        [
-          "memo",
-          "ShortText"
-        ],
-        [
-          "timestamp",
-          "Time"
-        ]
-      ]
-    ],
-    [
-      [
-        3
-      ],
-      [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ]
-  ]
-]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 select(3)[Logs_20150204]
-#:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
-#:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
-#:000000000000000 send(0)
-#<000000000000000 rc=0
+
+# action and date are processed in parallel. action is failed.
+logical_select Logs timestamp \
+  --limit 0 \
+  --drilldowns[action].keys action \
+  --drilldowns[action].filter 'nonexistent == 1' \
+  --drilldowns[date].keys date

--- a/test/command/suite/sharding/logical_select/drilldowns/filter/key.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/filter/key.expected
@@ -81,7 +81,7 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldowns[action].keys action   --drilldowns[action].filter '_key == "Restart"'
+logical_select Logs timestamp   --limit 0   --drilldowns[action].keys action   --drilldowns[action].filter '_key == "Restart"'   --drilldowns[start].keys action   --drilldowns[start].filter '_key == "Start"'
 [
   [
     0,
@@ -131,18 +131,41 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action].keys action   -
           "Restart",
           6
         ]
+      ],
+      "start": [
+        [
+          1
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Start",
+          2
+        ]
       ]
     }
   ]
 ]
-#>logical_select --drilldowns[action].filter "_key == \"Restart\"" --drilldowns[action].keys "action" --limit "0" --logical_table "Logs" --shard_key "timestamp"
+#>logical_select --drilldowns[action].filter "_key == \"Restart\"" --drilldowns[action].keys "action" --drilldowns[start].filter "_key == \"Start\"" --drilldowns[start].keys "action" --limit "0" --logical_table "Logs" --shard_key "timestamp"
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[action](3)
-#:000000000000000 filter(1): #<accessor _key(anonymous)> equal "Restart"
+#:000000000000000 drilldowns[action](3): action
+#:000000000000000 drilldowns[action].filter(1): #<accessor _key(anonymous)> equal "Restart"
 #:000000000000000 drilldowns[action].filter(1)
+#:000000000000000 drilldowns[start](3): action
+#:000000000000000 drilldowns[start].filter(1): #<accessor _key(anonymous)> equal "Start"
+#:000000000000000 drilldowns[start].filter(1)
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action](1)
+#:000000000000000 output.drilldowns[start](1)
 #:000000000000000 send(0)
 #<000000000000000 rc=0

--- a/test/command/suite/sharding/logical_select/drilldowns/filter/key.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/filter/key.test
@@ -75,10 +75,12 @@ load --table Logs_20150205
 ]
 
 #@collect-query-log true
-#@sort-query-log-operations shard
+#@sort-query-log-operations shard drilldown
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action].keys action \
-  --drilldowns[action].filter '_key == "Restart"'
-#@sort-query-log-operations none
+  --drilldowns[action].filter '_key == "Restart"' \
+  --drilldowns[start].keys action \
+  --drilldowns[start].filter '_key == "Start"'
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/keys/multiple.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/keys/multiple.expected
@@ -96,7 +96,7 @@ load --table Logs_20150205
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys action,date   --drilldowns[action_date].output_columns _key[0],_key[1],_nsubrecs
+logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys action,date   --drilldowns[action_date].output_columns _key[0],_key[1],_nsubrecs   --drilldowns[date_action].keys date,action   --drilldowns[date_action].output_columns _key[0],_key[1],_nsubrecs
 [
   [
     0,
@@ -173,6 +173,50 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys actio
         [
           "Restart",
           "2015-02-05",
+          4
+        ]
+      ],
+      "date_action": [
+        [
+          5
+        ],
+        [
+          [
+            "_key[0]",
+            null
+          ],
+          [
+            "_key[1]",
+            null
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "2015-02-03",
+          "Start",
+          1
+        ],
+        [
+          "2015-02-03",
+          "Shutdown",
+          1
+        ],
+        [
+          "2015-02-04",
+          "Start",
+          1
+        ],
+        [
+          "2015-02-04",
+          "Restart",
+          2
+        ],
+        [
+          "2015-02-05",
+          "Restart",
           4
         ]
       ]

--- a/test/command/suite/sharding/logical_select/drilldowns/keys/multiple.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/keys/multiple.test
@@ -89,4 +89,6 @@ load --table Logs_20150205
 logical_select Logs timestamp \
   --limit 0 \
   --drilldowns[action_date].keys action,date \
-  --drilldowns[action_date].output_columns _key[0],_key[1],_nsubrecs
+  --drilldowns[action_date].output_columns _key[0],_key[1],_nsubrecs \
+  --drilldowns[date_action].keys date,action \
+  --drilldowns[date_action].output_columns _key[0],_key[1],_nsubrecs

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/negative.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/negative.expected
@@ -178,7 +178,7 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys actio
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[action_date](5)
+#:000000000000000 drilldowns[action_date](5): action,date
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action_date](4)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/negative.test
@@ -93,5 +93,5 @@ logical_select Logs timestamp \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].limit -2
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/positive.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/positive.expected
@@ -163,7 +163,7 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys actio
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[action_date](5)
+#:000000000000000 drilldowns[action_date](5): action,date
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action_date](1)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldowns/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/limit/positive.test
@@ -93,5 +93,5 @@ logical_select Logs timestamp \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].limit 1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/negative.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/negative.expected
@@ -163,7 +163,7 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys actio
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[action_date](5)
+#:000000000000000 drilldowns[action_date](5): action,date
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action_date](1)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/negative.test
@@ -93,5 +93,5 @@ logical_select Logs timestamp \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].offset -1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/positive.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/positive.expected
@@ -178,7 +178,7 @@ logical_select Logs timestamp   --limit 0   --drilldowns[action_date].keys actio
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldowns[action_date](5)
+#:000000000000000 drilldowns[action_date](5): action,date
 #:000000000000000 output(0)
 #:000000000000000 output.drilldowns[action_date](4)
 #:000000000000000 send(0)

--- a/test/command/suite/sharding/logical_select/drilldowns/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/offset/positive.test
@@ -93,5 +93,5 @@ logical_select Logs timestamp \
   --drilldowns[action_date].keys action,date \
   --drilldowns[action_date].output_columns _value.action,_value.date,_nsubrecs \
   --drilldowns[action_date].offset 1
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/drilldowns/sort_keys/multiple/one_shard.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/sort_keys/multiple/one_shard.expected
@@ -177,7 +177,7 @@ logical_select Logs timestamp   --min "2015-02-05 00:00:00"   --min_border "incl
 ]
 #>logical_select --drilldowns[action_date].keys "action,date" --drilldowns[action_date].output_columns "_value.action,_value.date,_nsubrecs" --drilldowns[action_date].sort_keys "-_nsubrecs,_value.date,_value.action" --limit "0" --logical_table "Logs" --max "2015-02-06 00:00:00" --max_border "exclude" --min "2015-02-05 00:00:00" --min_border "include" --shard_key "timestamp"
 #:000000000000000 select(5)[Logs_20150205]
-#:000000000000000 drilldowns[action_date](3)
+#:000000000000000 drilldowns[action_date](3): action,date
 #:000000000000000 output(0)
 #:000000000000000 drilldowns[action_date].sort(3): -_nsubrecs,_value.date,_value.action
 #:000000000000000 output.drilldowns[action_date](3)

--- a/test/command/suite/sharding/logical_select/drilldowns/table/independent.expected
+++ b/test/command/suite/sharding/logical_select/drilldowns/table/independent.expected
@@ -6,6 +6,8 @@ column_create Logs_20150203 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Logs_20150204 TABLE_NO_KEY
@@ -13,6 +15,8 @@ table_create Logs_20150204 TABLE_NO_KEY
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
@@ -22,6 +26,8 @@ column_create Logs_20150205 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Logs_20150203
@@ -29,11 +35,13 @@ load --table Logs_20150203
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
@@ -43,16 +51,19 @@ load --table Logs_20150204
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
@@ -62,26 +73,30 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
+logical_select Logs timestamp   --limit 0   --drilldowns[action].keys action   --drilldowns[action].output_columns _key,_nsubrecs   --drilldowns[count].table action   --drilldowns[count].keys _nsubrecs   --drilldowns[count].output_columns _key,_nsubrecs   --drilldowns[date].keys date   --drilldowns[date].output_columns _key,_nsubrecs
 [
   [
     0,
@@ -103,6 +118,10 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_off
           "ShortText"
         ],
         [
+          "date",
+          "ShortText"
+        ],
+        [
           "memo",
           "ShortText"
         ],
@@ -112,37 +131,101 @@ logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_off
         ]
       ]
     ],
-    [
-      [
-        3
-      ],
-      [
+    {
+      "action": [
         [
-          "_key",
-          "ShortText"
+          3
         ],
         [
-          "_nsubrecs",
-          "Int32"
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "Start",
+          2
+        ],
+        [
+          "Shutdown",
+          1
+        ],
+        [
+          "Restart",
+          6
         ]
       ],
-      [
-        "Shutdown",
-        1
+      "count": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "Int32"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          1,
+          1
+        ],
+        [
+          6,
+          1
+        ]
       ],
-      [
-        "Restart",
-        6
+      "date": [
+        [
+          3
+        ],
+        [
+          [
+            "_key",
+            "ShortText"
+          ],
+          [
+            "_nsubrecs",
+            "Int32"
+          ]
+        ],
+        [
+          "2015-02-03",
+          2
+        ],
+        [
+          "2015-02-04",
+          3
+        ],
+        [
+          "2015-02-05",
+          4
+        ]
       ]
-    ]
+    }
   ]
 ]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
+#>logical_select --drilldowns[action].keys "action" --drilldowns[action].output_columns "_key,_nsubrecs" --drilldowns[count].keys "_nsubrecs" --drilldowns[count].output_columns "_key,_nsubrecs" --drilldowns[count].table "action" --drilldowns[date].keys "date" --drilldowns[date].output_columns "_key,_nsubrecs" --limit "0" --logical_table "Logs" --shard_key "timestamp"
 #:000000000000000 select(2)[Logs_20150203]
 #:000000000000000 select(3)[Logs_20150204]
 #:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
+#:000000000000000 drilldowns[action](3): action
+#:000000000000000 drilldowns[count](3): _nsubrecs
+#:000000000000000 drilldowns[date](3): date
 #:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
+#:000000000000000 output.drilldowns[action](3)
+#:000000000000000 output.drilldowns[count](3)
+#:000000000000000 output.drilldowns[date](3)
 #:000000000000000 send(0)
 #<000000000000000 rc=0

--- a/test/command/suite/sharding/logical_select/drilldowns/table/independent.test
+++ b/test/command/suite/sharding/logical_select/drilldowns/table/independent.test
@@ -1,148 +1,103 @@
+#@on-error omit
 plugin_register sharding
-[[0,0.0,0.0],true]
+#@on-error default
+
 table_create Logs_20150203 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150203 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150204 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150205 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150205 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 load --table Logs_20150203
 [
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
-[[0,0.0,0.0],2]
+
 load --table Logs_20150204
 [
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],3]
+
 load --table Logs_20150205
 [
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
-[
-  [
-    0,
-    0.0,
-    0.0
-  ],
-  [
-    [
-      [
-        9
-      ],
-      [
-        [
-          "_id",
-          "UInt32"
-        ],
-        [
-          "action",
-          "ShortText"
-        ],
-        [
-          "memo",
-          "ShortText"
-        ],
-        [
-          "timestamp",
-          "Time"
-        ]
-      ]
-    ],
-    [
-      [
-        3
-      ],
-      [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ]
-  ]
-]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 select(3)[Logs_20150204]
-#:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
-#:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
-#:000000000000000 send(0)
-#<000000000000000 rc=0
+
+# action and date are independent. They are processed in parallel.
+# count depends on action. It's processed after action is finished.
+#@collect-query-log true
+#@sort-query-log-operations shard drilldown
+logical_select Logs timestamp \
+  --limit 0 \
+  --drilldowns[action].keys action \
+  --drilldowns[action].output_columns _key,_nsubrecs \
+  --drilldowns[count].table action \
+  --drilldowns[count].keys _nsubrecs \
+  --drilldowns[count].output_columns _key,_nsubrecs \
+  --drilldowns[date].keys date \
+  --drilldowns[date].output_columns _key,_nsubrecs
+#@sort-query-log-operations
+#@collect-query-log false

--- a/test/command/suite/sharding/logical_select/limit/negative.test
+++ b/test/command/suite/sharding/logical_select/limit/negative.test
@@ -72,5 +72,5 @@ load --table Logs_20150205
 #@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit -6
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/limit/positive.test
+++ b/test/command/suite/sharding/logical_select/limit/positive.test
@@ -72,5 +72,5 @@ load --table Logs_20150205
 #@sort-query-log-operations shard
 logical_select Logs timestamp \
   --limit 3
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/load_table/key.test
+++ b/test/command/suite/sharding/logical_select/load_table/key.test
@@ -42,7 +42,7 @@ logical_select \
   --load_columns "_key, original_id, timestamp_text" \
   --load_values "cast_loose(ShortText, timestamp, '') + ':' + _id, _id, timestamp" \
   --limit 0
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false
 
 select --table Logs

--- a/test/command/suite/sharding/logical_select/n_workers/drilldown/plain/error/invalid_key.expected
+++ b/test/command/suite/sharding/logical_select/n_workers/drilldown/plain/error/invalid_key.expected
@@ -6,6 +6,8 @@ column_create Logs_20150203 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 table_create Logs_20150204 TABLE_NO_KEY
@@ -13,6 +15,8 @@ table_create Logs_20150204 TABLE_NO_KEY
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
@@ -22,6 +26,8 @@ column_create Logs_20150205 timestamp COLUMN_SCALAR Time
 [[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
+[[0,0.0,0.0],true]
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
 [[0,0.0,0.0],true]
 load --table Logs_20150203
@@ -29,11 +35,13 @@ load --table Logs_20150203
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
@@ -43,16 +51,19 @@ load --table Logs_20150204
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
@@ -62,87 +73,38 @@ load --table Logs_20150205
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
 [[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
+logical_select --n_workers 4 Logs timestamp   --limit 0   --drilldown action,nonexistent
 [
   [
-    0,
-    0.0,
-    0.0
-  ],
-  [
     [
-      [
-        9
-      ],
-      [
-        [
-          "_id",
-          "UInt32"
-        ],
-        [
-          "action",
-          "ShortText"
-        ],
-        [
-          "memo",
-          "ShortText"
-        ],
-        [
-          "timestamp",
-          "Time"
-        ]
-      ]
+      -74,
+      0.0,
+      0.0
     ],
-    [
-      [
-        3
-      ],
-      [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ]
+    "command error: <[logical_select][drilldown][1] ArgumentError: unknown key: \"nonexistent\": Logs_20150203(2)>(-74)"
   ]
 ]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 select(3)[Logs_20150204]
-#:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
-#:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
-#:000000000000000 send(0)
-#<000000000000000 rc=0
+#|e| [logical_select][drilldown][1] ArgumentError: unknown key: "nonexistent": Logs_20150203(2)

--- a/test/command/suite/sharding/logical_select/n_workers/drilldown/plain/error/invalid_key.test
+++ b/test/command/suite/sharding/logical_select/n_workers/drilldown/plain/error/invalid_key.test
@@ -1,148 +1,94 @@
+#@require-apache-arrow
+#@on-error omit
 plugin_register sharding
-[[0,0.0,0.0],true]
+#@on-error default
+
 table_create Logs_20150203 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150203 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150203 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150203 date COLUMN_SCALAR ShortText
 column_create Logs_20150203 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150204 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150204 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150204 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150204 date COLUMN_SCALAR ShortText
 column_create Logs_20150204 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 table_create Logs_20150205 TABLE_NO_KEY
-[[0,0.0,0.0],true]
 column_create Logs_20150205 timestamp COLUMN_SCALAR Time
-[[0,0.0,0.0],true]
 column_create Logs_20150205 memo COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+column_create Logs_20150205 date COLUMN_SCALAR ShortText
 column_create Logs_20150205 action COLUMN_SCALAR ShortText
-[[0,0.0,0.0],true]
+
 load --table Logs_20150203
 [
 {
   "timestamp": "2015-02-03 12:49:00",
   "memo":      "2015-02-03 12:49:00",
+  "date":      "2015-02-03",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-03 23:59:59",
   "memo":      "2015-02-03 23:59:59",
+  "date":      "2015-02-03",
   "action":    "Shutdown"
 }
 ]
-[[0,0.0,0.0],2]
+
 load --table Logs_20150204
 [
 {
   "timestamp": "2015-02-04 00:00:00",
   "memo":      "2015-02-04 00:00:00",
+  "date":      "2015-02-04",
   "action":    "Start"
 },
 {
   "timestamp": "2015-02-04 13:49:00",
   "memo":      "2015-02-04 13:49:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-04 13:50:00",
   "memo":      "2015-02-04 13:50:00",
+  "date":      "2015-02-04",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],3]
+
 load --table Logs_20150205
 [
 {
   "timestamp": "2015-02-05 13:49:00",
   "memo":      "2015-02-05 13:49:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:50:00",
   "memo":      "2015-02-05 13:50:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:51:00",
   "memo":      "2015-02-05 13:51:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 },
 {
   "timestamp": "2015-02-05 13:52:00",
   "memo":      "2015-02-05 13:52:00",
+  "date":      "2015-02-05",
   "action":    "Restart"
 }
 ]
-[[0,0.0,0.0],4]
-logical_select Logs timestamp   --limit 0   --drilldown action   --drilldown_offset 1
-[
-  [
-    0,
-    0.0,
-    0.0
-  ],
-  [
-    [
-      [
-        9
-      ],
-      [
-        [
-          "_id",
-          "UInt32"
-        ],
-        [
-          "action",
-          "ShortText"
-        ],
-        [
-          "memo",
-          "ShortText"
-        ],
-        [
-          "timestamp",
-          "Time"
-        ]
-      ]
-    ],
-    [
-      [
-        3
-      ],
-      [
-        [
-          "_key",
-          "ShortText"
-        ],
-        [
-          "_nsubrecs",
-          "Int32"
-        ]
-      ],
-      [
-        "Shutdown",
-        1
-      ],
-      [
-        "Restart",
-        6
-      ]
-    ]
-  ]
-]
-#>logical_select --drilldown "action" --drilldown_offset "1" --limit "0" --logical_table "Logs" --shard_key "timestamp"
-#:000000000000000 select(2)[Logs_20150203]
-#:000000000000000 select(3)[Logs_20150204]
-#:000000000000000 select(4)[Logs_20150205]
-#:000000000000000 drilldown(3): action
-#:000000000000000 output(0)
-#:000000000000000 output.drilldown(2)
-#:000000000000000 send(0)
-#<000000000000000 rc=0
+
+# action and nonexistent are processed in parallel. nonexistent is
+# failed.
+logical_select --n_workers 4 Logs timestamp \
+  --limit 0 \
+  --drilldown action,nonexistent

--- a/test/command/suite/sharding/logical_select/offset/negative.test
+++ b/test/command/suite/sharding/logical_select/offset/negative.test
@@ -72,5 +72,5 @@ load --table Logs_20150205
 #@sort-query-log-operations shard
 logical_select Logs timestamp \
   --offset -5
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/offset/positive.test
+++ b/test/command/suite/sharding/logical_select/offset/positive.test
@@ -72,5 +72,5 @@ load --table Logs_20150205
 #@sort-query-log-operations shard
 logical_select Logs timestamp \
   --offset 3
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/offset/with_limit.test
+++ b/test/command/suite/sharding/logical_select/offset/with_limit.test
@@ -73,5 +73,5 @@ load --table Logs_20150205
 logical_select Logs timestamp \
   --offset 3 \
   --limit 2
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false

--- a/test/command/suite/sharding/logical_select/sort_keys/shard_key/ascending.test
+++ b/test/command/suite/sharding/logical_select/sort_keys/shard_key/ascending.test
@@ -66,5 +66,5 @@ load --table Logs_20150205
 #@sort-query-log-operations shard
 logical_select Logs timestamp \
   --sort_keys timestamp
-#@sort-query-log-operations none
+#@sort-query-log-operations
 #@collect-query-log false


### PR DESCRIPTION
Plain drilldown keys and independent labeled drilldowns are processed in parallel with `Groonga::TaskExecutor` when `--n_workers` is 2 or more. A labeled drilldown that depends on another drilldown by `table` is processed after the depended drilldown is finished.

`Groonga::TaskExecutor` changes:

  * `parallel?(n_tasks=nil)` is added. It returns false when `n_tasks` is 1 or less because there is nothing to parallelize.
  * An exception raised in a task uses the rc of its class when it's a `Groonga::GroongaError`. Other exceptions are command errors. This is the same rule as `Groonga::Command#run_internal`. They were unknown errors.

Query log changes:

  * `drilldown(N)` and `drilldowns[LABEL](N)` show their keys like `drilldown(N): KEYS`.
  * The filter operation of a drilldown filter shows its prefix like `drilldowns[LABEL].filter(N): CONDITION`.

Fixed bug:

  * A persistent column specified by `calc_target` was closed after grouping. It's shared with other contexts. It caused a double free in parallel processing.

Tests use `#@sort-query-log-operations shard drilldown` because query log operations of parallel drilldowns aren't ordered. It requires grntest 1.8.7 or later.