### PR TITLE
doc grn_expr_syntax_escape(): don't use backslash in inline code

### DIFF
--- a/include/groonga/expr.h
+++ b/include/groonga/expr.h
@@ -149,11 +149,11 @@ grn_expr_get_keywords(grn_ctx *ctx, grn_obj *expr, grn_obj *keywords);
  * \param query_size The byte size of \p query. A value of -1 indicates that
  *                   the query is null-terminated.
  * \param target_characters A null-terminated string containing the characters
- *                          to be escaped. For example, `"+-><~*()\"\\:"` is
- *                          used for query syntax.
+ *                          to be escaped. For example, `+-><~*()":` and
+ *                          backslash are used for query syntax.
  * \param escape_character The character to use for escaping characters found
- *                         in \p target_characters. For example, `"\\"`
- *                         (backslash) is used.
+ *                         in \p target_characters. For example, backslash is
+ *                         used for query syntax.
  * \param escaped_query The buffer where the escaped query is stored.
  *
  * \return \ref GRN_SUCCESS on success, the appropriate \ref grn_rc on error.


### PR DESCRIPTION
Doxygen 1.15.0 or later reports the following warning:

    include/groonga/expr.h:143: warning: The following parameter of grn_expr_syntax_escape(...) is not documented:
      parameter 'escape_character'

Doxygen 1.15.0 or later doesn't close an inline code that has `\"` when there is another inline code that has `\\` in the next `\param` and `EXTRACT_ALL` is `YES`. It's a regression by the fix for https://github.com/doxygen/doxygen/issues/8788 . Doxygen 1.14.0 doesn't report it.