### PR TITLE
test task_executor: wait the first task in duplicated_id

### DIFF
--- a/test/command/suite/ruby/eval/task_executor/duplicated_id.expected
+++ b/test/command/suite/ruby/eval/task_executor/duplicated_id.expected
@@ -1,4 +1,4 @@
 plugin_register ruby/eval
 [[0,0.0,0.0],true]
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {1}; executor.execute(0, '[test]') {2}"
+ruby_eval "executor = Groonga::TaskExecutor.new; begin; executor.execute(0, '[test]') {1}; executor.execute(0, '[test]') {2}; ensure; executor.wait_all; end"
 [[0,0.0,0.0],{"exception":{"message":"[test][execute] ID is already used: 0"}}]

--- a/test/command/suite/ruby/eval/task_executor/duplicated_id.test
+++ b/test/command/suite/ruby/eval/task_executor/duplicated_id.test
@@ -2,4 +2,6 @@
 plugin_register ruby/eval
 #@on-error default
 
-ruby_eval "executor = Groonga::TaskExecutor.new; executor.execute(0, '[test]') {1}; executor.execute(0, '[test]') {2}"
+# The first task must be waited. Otherwise, the task may be running
+# on a worker thread while this process is exiting.
+ruby_eval "executor = Groonga::TaskExecutor.new; begin; executor.execute(0, '[test]') {1}; executor.execute(0, '[test]') {2}; ensure; executor.wait_all; end"


### PR DESCRIPTION
The first task was submitted successfully. It may be running on a worker thread while this process is exiting when it's not waited. grn_unset_variable() called by plugin finalization in grn_db_close() touches all contexts including a child context that is being initialized by the worker thread. It crashed sometimes.

Caller must call `Groonga::TaskExecutor#wait_all` when it starts any task.