### PR TITLE
Detect MSG_NOSIGNAL by C preprocessor

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -63,7 +63,6 @@
 #cmakedefine USE_FUTEX
 #cmakedefine USE_KQUEUE
 #cmakedefine USE_MSG_MORE
-#cmakedefine USE_MSG_NOSIGNAL
 #cmakedefine USE_POLL
 #cmakedefine USE_SELECT
 

--- a/configure.ac
+++ b/configure.ac
@@ -552,25 +552,6 @@ int main(int argc, char **argv)
       AC_MSG_RESULT(no)
     ])
 
-# check MSG_NOSIGNAL defined
-AC_MSG_CHECKING([whether MSG_NOSIGNAL defined])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-#include <sys/types.h>
-#include <sys/socket.h>
-
-int main(int argc, char **argv)
-{
-  return MSG_NOSIGNAL;
-}
-    ])],
-    [
-      AC_MSG_RESULT(yes)
-      AC_DEFINE(USE_MSG_NOSIGNAL, [1], [use MSG_NOSIGNAL])
-    ],
-    [
-      AC_MSG_RESULT(no)
-    ])
-
 # MinGW
 if test "$os_win32" = "yes"; then
   WINDOWS_LDFLAGS="-mwindows"

--- a/lib/com.c
+++ b/lib/com.c
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2009-2018  Brazil
-  Copyright (C) 2018-2022  Sutou Kouhei <kou@clear-code.com>
+  Copyright (C) 2018-2026  Sutou Kouhei <kou@clear-code.com>
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -31,9 +31,6 @@
 #  endif /* HAVE_SYS_SOCKET_H */
 #  include <netinet/in.h>
 #  include <netinet/tcp.h>
-#  ifdef HAVE_SIGNAL_H
-#    include <signal.h>
-#  endif /* HAVE_SIGNAL_H */
 #  include <sys/uio.h>
 #endif /* WIN32 */
 
@@ -59,12 +56,9 @@
 #  define MSG_MORE 0
 #endif /* USE_MSG_MORE */
 
-#ifndef USE_MSG_NOSIGNAL
-#  ifdef MSG_NOSIGNAL
-#    undef MSG_NOSIGNAL
-#  endif
+#ifndef MSG_NOSIGNAL
 #  define MSG_NOSIGNAL 0
-#endif /* USE_MSG_NOSIGNAL */
+#endif
 /******* grn_com_queue ********/
 
 grn_rc
@@ -265,14 +259,7 @@ grn_com_init(void)
     grn_ctx *ctx = &grn_gctx;
     SOERR("WSAStartup");
   }
-#else /* WIN32 */
-#  ifndef USE_MSG_NOSIGNAL
-  if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
-    grn_ctx *ctx = &grn_gctx;
-    SERR("signal");
-  }
-#  endif /* USE_MSG_NOSIGNAL */
-#endif   /* WIN32 */
+#endif /* WIN32 */
   return grn_gctx.rc;
 }
 

--- a/src/groonga.c
+++ b/src/groonga.c
@@ -59,18 +59,16 @@
 
 #if !defined(WIN32) && defined(HAVE_SIGNAL_H)
 #  define ENABLE_LOG_REOPEN_BY_SIGNAL
+#  define ENABLE_IGNORE_SIGPIPE
 #endif
 
-#ifdef ENABLE_LOG_REOPEN_BY_SIGNAL
+#if defined(ENABLE_LOG_REOPEN_BY_SIGNAL) || defined(ENABLE_IGNORE_SIGPIPE)
 #  include <signal.h>
 #endif
 
-#ifndef USE_MSG_NOSIGNAL
-#  ifdef MSG_NOSIGNAL
-#    undef MSG_NOSIGNAL
-#  endif
+#ifndef MSG_NOSIGNAL
 #  define MSG_NOSIGNAL 0
-#endif /* USE_MSG_NOSIGNAL */
+#endif
 
 #ifndef STDIN_FILENO
 #  define STDIN_FILENO 0
@@ -4798,6 +4796,16 @@ main(int argc, char **argv)
     }
     grn_set_default_n_workers(value);
   }
+
+#ifdef ENABLE_IGNORE_SIGPIPE
+  /* Writing to a pipe or a socket whose reader is closed such as
+   * stdout of this command raises SIGPIPE. If it's not ignored, this
+   * process is killed without closing the database. */
+  if (signal(SIGPIPE, SIG_IGN) == SIG_ERR) {
+    fprintf(stderr, "failed to ignore SIGPIPE: %s\n", strerror(errno));
+    return EXIT_FAILURE;
+  }
+#endif
 
   grn_gctx.errbuf[0] = '\0';
   if (grn_init()) {


### PR DESCRIPTION
MSG_NOSIGNAL is a macro in sys/socket.h. So we can detect it by #ifdef. We don't need the configure check for it. The CMake build never defined USE_MSG_NOSIGNAL. So MSG_NOSIGNAL wasn't used with CMake build even if it's available.

signal(SIGPIPE, SIG_IGN) is used only when MSG_NOSIGNAL and signal.h are available. WASI doesn't have both of them.

signal(SIGPIPE, SIG_IGN) is moved from grn_com_init() to the groonga command. It was needed not only for sockets but also for pipes such as stdout of the groonga command. If it's not ignored, the groonga command is killed by SIGPIPE without closing the database when the reader of the pipe is closed.

This is a behavior change for programs that embed libgroonga: grn_init() doesn't ignore SIGPIPE anymore. Socket sends in libgroonga are protected by MSG_NOSIGNAL but writes to pipes aren't. Programs that write to pipes must handle SIGPIPE by themselves. 