### PR TITLE
Detect MSG_MORE by C preprocessor

### DIFF
--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -62,7 +62,6 @@
 #cmakedefine USE_EPOLL
 #cmakedefine USE_FUTEX
 #cmakedefine USE_KQUEUE
-#cmakedefine USE_MSG_MORE
 #cmakedefine USE_POLL
 #cmakedefine USE_SELECT
 

--- a/configure.ac
+++ b/configure.ac
@@ -533,25 +533,6 @@ if test "x$have_epoll" != "xyes"; then
   fi
 fi
 
-# check MSG_MORE defined
-AC_MSG_CHECKING([whether MSG_MORE defined])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-#include <sys/types.h>
-#include <sys/socket.h>
-
-int main(int argc, char **argv)
-{
-  return MSG_MORE;
-}
-    ])],
-    [
-      AC_MSG_RESULT(yes)
-      AC_DEFINE(USE_MSG_MORE, [1], [use MSG_MORE])
-    ],
-    [
-      AC_MSG_RESULT(no)
-    ])
-
 # MinGW
 if test "$os_win32" = "yes"; then
   WINDOWS_LDFLAGS="-mwindows"

--- a/lib/com.c
+++ b/lib/com.c
@@ -49,12 +49,9 @@
 #  endif /* IPPROTO_TCP */
 #endif   /* SOL_TCP */
 
-#ifndef USE_MSG_MORE
-#  ifdef MSG_MORE
-#    undef MSG_MORE
-#  endif
+#ifndef MSG_MORE
 #  define MSG_MORE 0
-#endif /* USE_MSG_MORE */
+#endif
 
 #ifndef MSG_NOSIGNAL
 #  define MSG_NOSIGNAL 0


### PR DESCRIPTION
MSG_MORE is a macro in sys/socket.h. So we can detect it by #ifdef. We don't need the configure check for it. The CMake build never defined USE_MSG_MORE. So MSG_MORE wasn't used with CMake build even if it's available. Now, GQTP uses MSG_MORE when it's available.